### PR TITLE
basic insertion

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -139,5 +139,7 @@ dependencies {
     implementation(libs.hibernate.core)
     implementation(libs.mongo.java.driver.sync)
     implementation(libs.sl4j.api)
+    implementation(libs.guava)
+    implementation(libs.mockito.core)
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,12 +9,13 @@ errorprone = "4.1.0"
 google-errorprone-core = "2.36.0"
 nullaway = "0.12.2"
 jspecify = "1.0.0"
-hibernate-core = "6.6.4.Final"
+hibernate-core = "6.6.5.Final"
 mongo-java-driver-sync = "5.3.0"
 slf4j-api = "2.0.16"
 logback-classic = "1.5.15"
 mockito = "5.14.2"
 buildconfig = "5.5.1"
+guava = "33.4.0-jre"
 
 [libraries]
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit-jupiter" }
@@ -27,6 +28,8 @@ mongo-java-driver-sync = { module = "org.mongodb:mongodb-driver-sync", version.r
 sl4j-api = { module = "org.slf4j:slf4j-api", version.ref = "slf4j-api" }
 logback-classic = { module = "ch.qos.logback:logback-classic", version.ref = "logback-classic" }
 mockito-junit-jupiter = { module = "org.mockito:mockito-junit-jupiter", version.ref = "mockito" }
+mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockito" }
+guava = { module = "com.google.guava:guava", version.ref = "guava" }
 
 [plugins]
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }

--- a/src/integrationTest/java/com/mongodb/hibernate/BasicInsertionTests.java
+++ b/src/integrationTest/java/com/mongodb/hibernate/BasicInsertionTests.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2025-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.hibernate;
+
+import static org.hibernate.cfg.JdbcSettings.JAKARTA_JDBC_URL;
+
+import com.mongodb.ConnectionString;
+import com.mongodb.MongoClientSettings;
+import com.mongodb.client.MongoClients;
+import com.mongodb.client.MongoCollection;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Consumer;
+import org.bson.BsonDocument;
+import org.hibernate.SessionFactory;
+import org.hibernate.cfg.Configuration;
+import org.jspecify.annotations.NullUnmarked;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+@NullUnmarked
+class BasicInsertionTests {
+
+    private static SessionFactory sessionFactory;
+
+    @BeforeAll
+    static void beforeAll() {
+        sessionFactory = new Configuration().addAnnotatedClass(Book.class).buildSessionFactory();
+    }
+
+    @AfterAll
+    static void afterAll() {
+        if (sessionFactory != null) {
+            sessionFactory.close();
+        }
+    }
+
+    @BeforeEach
+    void setUp() {
+        onMongoCollection(MongoCollection::drop);
+    }
+
+    @Test
+    void testInsertion() {
+        sessionFactory.inTransaction(session -> {
+            var book = new Book();
+            book.id = 1;
+            book.title = "War and Peace";
+            book.author = "Leo Tolstoy";
+            book.publishYear = 1867;
+            session.persist(book);
+        });
+        var expectedDocuments = Set.of(
+                BsonDocument.parse(
+                        """
+                        {
+                            _id: 1,
+                            title: "War and Peace",
+                            author: "Leo Tolstoy",
+                            publishYear: 1867
+                        }"""));
+        Assertions.assertEquals(expectedDocuments, getCollectionDocuments());
+    }
+
+    private void onMongoCollection(Consumer<MongoCollection<BsonDocument>> collectionConsumer) {
+        var connectionString = new ConnectionString(new Configuration().getProperty(JAKARTA_JDBC_URL));
+        try (var mongoClient = MongoClients.create(MongoClientSettings.builder()
+                .applyConnectionString(connectionString)
+                .build())) {
+            var collection = mongoClient.getDatabase("mongo-hibernate-test").getCollection("books", BsonDocument.class);
+            ;
+            collectionConsumer.accept(collection);
+        }
+        ;
+    }
+
+    private Set<BsonDocument> getCollectionDocuments() {
+        var documents = new HashSet<BsonDocument>();
+        onMongoCollection(collection -> collection.find().into(documents));
+        return documents;
+    }
+
+    @Entity(name = "Book")
+    @Table(name = "books")
+    static class Book {
+        @Id
+        @Column(name = "_id")
+        int id;
+
+        String title;
+        String author;
+        int publishYear;
+    }
+}

--- a/src/main/java/com/mongodb/hibernate/dialect/MongoDialect.java
+++ b/src/main/java/com/mongodb/hibernate/dialect/MongoDialect.java
@@ -16,9 +16,12 @@
 
 package com.mongodb.hibernate.dialect;
 
+import com.mongodb.hibernate.translate.MongoTranslatorFactory;
 import org.hibernate.dialect.DatabaseVersion;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.jdbc.dialect.spi.DialectResolutionInfo;
+import org.hibernate.sql.ast.SqlAstTranslatorFactory;
+import org.hibernate.sql.ast.spi.ParameterMarkerStrategy;
 
 /**
  * A MongoDB {@link Dialect} for {@linkplain #getMinimumSupportedVersion() version 6.0 and above}.
@@ -48,5 +51,15 @@ public final class MongoDialect extends Dialect {
     @Override
     protected DatabaseVersion getMinimumSupportedVersion() {
         return MINIMUM_VERSION;
+    }
+
+    @Override
+    public SqlAstTranslatorFactory getSqlAstTranslatorFactory() {
+        return new MongoTranslatorFactory();
+    }
+
+    @Override
+    public ParameterMarkerStrategy getNativeParameterMarkerStrategy() {
+        return (i, jdbcType) -> "{$undefined: true}";
     }
 }

--- a/src/main/java/com/mongodb/hibernate/internal/MongoAssertions.java
+++ b/src/main/java/com/mongodb/hibernate/internal/MongoAssertions.java
@@ -53,4 +53,30 @@ public final class MongoAssertions {
     public static AssertionError fail(String msg) throws AssertionError {
         throw new AssertionError(assertNotNull(msg));
     }
+
+    /**
+     * Asserts that some value is {@code null}.
+     *
+     * @param value A value to check.
+     * @param <T> The type of {@code value}.
+     * @throws AssertionError If {@code value} is not {@code null}.
+     */
+    public static <T> void assertNull(@Nullable T value) throws AssertionError {
+        if (value != null) {
+            throw new AssertionError();
+        }
+    }
+
+    /**
+     * Throw AssertionError if the condition if false.
+     *
+     * @param name the name of the state that is being checked
+     * @param condition the condition about the parameter to check
+     * @throws AssertionError if the condition is false
+     */
+    public static void assertTrue(String name, boolean condition) {
+        if (!condition) {
+            throw new AssertionError("state should be: " + assertNotNull(name));
+        }
+    }
 }

--- a/src/main/java/com/mongodb/hibernate/translate/AstVisitorValueHolder.java
+++ b/src/main/java/com/mongodb/hibernate/translate/AstVisitorValueHolder.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2024-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.hibernate.translate;
+
+import static com.mongodb.hibernate.internal.MongoAssertions.assertNotNull;
+import static com.mongodb.hibernate.internal.MongoAssertions.assertNull;
+import static com.mongodb.hibernate.internal.MongoAssertions.assertTrue;
+import static java.lang.String.format;
+
+import com.google.common.reflect.TypeToken;
+import com.mongodb.hibernate.translate.mongoast.AstNode;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * A data exchange mechanism to overcome the limitation of various visitor methods in
+ * {@link org.hibernate.sql.ast.SqlAstWalker} don't return value; Returning values is required during MQL translation
+ * (e.g. returning intermediate MQL {@link AstNode}).
+ *
+ * <p>Contains both value and its type info (using Guava's {@link TypeToken} so Java generics info is retained at
+ * runtime), which will be used to ensure value provided has identical type with value consumer's expectation.
+ *
+ * <p>During one MQL translation process, one single object of this class should be created globally (or not within
+ * methods as temporary variable) so various {@code void} visitor methods of {@code SqlAstWalker} could access it as
+ * either producer calling {@link #setValue(TypeToken, Object)} method) or consumer calling {@link #getValue(TypeToken,
+ * Runnable)} method). Once the consumer grabs its expected value, it becomes the sole owner of the value with the
+ * holder being blank.
+ *
+ * @see org.hibernate.sql.ast.SqlAstWalker
+ * @see TypeToken
+ */
+final class AstVisitorValueHolder {
+
+    private TypeToken<?> valueType;
+    private @Nullable Object value;
+
+    private AstVisitorValueHolder(TypeToken<?> valueType) {
+        this.valueType = valueType;
+    }
+
+    public static AstVisitorValueHolder emptyHolder() {
+        return new AstVisitorValueHolder(new TypeToken<Void>() {});
+    }
+
+    /**
+     * Grabs the value (matching the expected type) then empties the holder and restored its previous state.
+     *
+     * <p>Note that during SQL AST tree traversal, it is common to call this method recursively, so one salient feature
+     * of this class is the capability to restore previous state.
+     *
+     * @param valueType expected type of the data to be grabbed.
+     * @param valueSetter the {@code Runnable} wrapper of a void AST visitor method which is supposed to invoke
+     *     {@link #setValue(TypeToken, Object)} internally with type identical to the {@code valueType}.
+     * @return the grabbed value set by {@code valueSetter}
+     * @param <T> generics type of the value returned
+     */
+    @SuppressWarnings("unchecked")
+    public <T> T getValue(TypeToken<T> valueType, Runnable valueSetter) {
+        var previousType = this.valueType;
+        assertNull(value);
+        this.valueType = valueType;
+        try {
+            valueSetter.run();
+            return (T) assertNotNull(value);
+        } finally {
+            this.valueType = previousType;
+            value = null;
+        }
+    }
+
+    /**
+     * Overloaded method to simplify usage by providing {@code Class} instead of {@link TypeToken}.
+     *
+     * @see #getValue(TypeToken, Runnable)
+     */
+    public <T> T getValue(Class<T> clazz, Runnable valueSetter) {
+        return getValue(TypeToken.of(clazz), valueSetter);
+    }
+
+    /**
+     * Sets the value matching type expectation.
+     *
+     * <p>To ensure smooth data exchange, the following preconditions need to be satisfied:
+     *
+     * <ul>
+     *   <li>the holder contains empty value
+     *   <li>the holder's data type matches the real data type
+     * </ul>
+     *
+     * @param valueType data type of the {@code value}; should match the expected type in holder.
+     * @param value data returned inside some {@code void} method.
+     * @param <T> generics type of the {@code value}
+     */
+    public <T> void setValue(TypeToken<T> valueType, T value) {
+        assertTrue(
+                format("provided type [%s] should match expected [%s]", valueType, this.valueType),
+                valueType.equals(this.valueType));
+        assertNull(this.value);
+        this.value = value;
+    }
+
+    /**
+     * Overloaded method to simplify usage by providing {@code Class} instead of {@link TypeToken}.
+     *
+     * @see #setValue(TypeToken, Object)
+     */
+    public <T> void setValue(Class<T> clazz, T value) {
+        setValue(TypeToken.of(clazz), value);
+    }
+}

--- a/src/main/java/com/mongodb/hibernate/translate/MongoTranslatorFactory.java
+++ b/src/main/java/com/mongodb/hibernate/translate/MongoTranslatorFactory.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2025-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.hibernate.translate;
+
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.sql.ast.SqlAstTranslator;
+import org.hibernate.sql.ast.SqlAstTranslatorFactory;
+import org.hibernate.sql.ast.tree.MutationStatement;
+import org.hibernate.sql.ast.tree.select.SelectStatement;
+import org.hibernate.sql.exec.spi.JdbcOperationQueryMutation;
+import org.hibernate.sql.exec.spi.JdbcOperationQuerySelect;
+import org.hibernate.sql.model.ast.TableMutation;
+import org.hibernate.sql.model.jdbc.JdbcMutationOperation;
+import org.mockito.Mockito;
+
+@SuppressWarnings("unchecked")
+public final class MongoTranslatorFactory implements SqlAstTranslatorFactory {
+    @Override
+    public SqlAstTranslator<JdbcOperationQuerySelect> buildSelectTranslator(
+            SessionFactoryImplementor sessionFactoryImplementor, SelectStatement selectStatement) {
+        return Mockito.mock(SqlAstTranslator.class);
+    }
+
+    @Override
+    public SqlAstTranslator<? extends JdbcOperationQueryMutation> buildMutationTranslator(
+            SessionFactoryImplementor sessionFactoryImplementor, MutationStatement mutationStatement) {
+        return Mockito.mock(SqlAstTranslator.class);
+    }
+
+    @Override
+    public <O extends JdbcMutationOperation> SqlAstTranslator<O> buildModelMutationTranslator(
+            TableMutation<O> tableMutation, SessionFactoryImplementor sessionFactoryImplementor) {
+        return new MqlTranslator<>(sessionFactoryImplementor, tableMutation);
+    }
+}

--- a/src/main/java/com/mongodb/hibernate/translate/MqlTranslator.java
+++ b/src/main/java/com/mongodb/hibernate/translate/MqlTranslator.java
@@ -1,0 +1,595 @@
+/*
+ * Copyright 2025-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.hibernate.translate;
+
+import com.mongodb.hibernate.internal.NotYetImplementedException;
+import com.mongodb.hibernate.translate.mongoast.AstElement;
+import com.mongodb.hibernate.translate.mongoast.AstNode;
+import com.mongodb.hibernate.translate.mongoast.AstPlaceholder;
+import com.mongodb.hibernate.translate.mongoast.AstValue;
+import com.mongodb.hibernate.translate.mongoast.command.AstInsertCommand;
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import org.bson.json.JsonWriter;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.internal.util.collections.Stack;
+import org.hibernate.persister.internal.SqlFragmentPredicate;
+import org.hibernate.query.spi.QueryOptions;
+import org.hibernate.query.sqm.tree.expression.Conversion;
+import org.hibernate.sql.ast.Clause;
+import org.hibernate.sql.ast.SqlAstNodeRenderingMode;
+import org.hibernate.sql.ast.SqlAstTranslator;
+import org.hibernate.sql.ast.spi.SqlSelection;
+import org.hibernate.sql.ast.tree.SqlAstNode;
+import org.hibernate.sql.ast.tree.Statement;
+import org.hibernate.sql.ast.tree.delete.DeleteStatement;
+import org.hibernate.sql.ast.tree.expression.AggregateColumnWriteExpression;
+import org.hibernate.sql.ast.tree.expression.Any;
+import org.hibernate.sql.ast.tree.expression.BinaryArithmeticExpression;
+import org.hibernate.sql.ast.tree.expression.CaseSearchedExpression;
+import org.hibernate.sql.ast.tree.expression.CaseSimpleExpression;
+import org.hibernate.sql.ast.tree.expression.CastTarget;
+import org.hibernate.sql.ast.tree.expression.Collation;
+import org.hibernate.sql.ast.tree.expression.ColumnReference;
+import org.hibernate.sql.ast.tree.expression.Distinct;
+import org.hibernate.sql.ast.tree.expression.Duration;
+import org.hibernate.sql.ast.tree.expression.DurationUnit;
+import org.hibernate.sql.ast.tree.expression.EmbeddableTypeLiteral;
+import org.hibernate.sql.ast.tree.expression.EntityTypeLiteral;
+import org.hibernate.sql.ast.tree.expression.Every;
+import org.hibernate.sql.ast.tree.expression.ExtractUnit;
+import org.hibernate.sql.ast.tree.expression.Format;
+import org.hibernate.sql.ast.tree.expression.JdbcLiteral;
+import org.hibernate.sql.ast.tree.expression.JdbcParameter;
+import org.hibernate.sql.ast.tree.expression.ModifiedSubQueryExpression;
+import org.hibernate.sql.ast.tree.expression.NestedColumnReference;
+import org.hibernate.sql.ast.tree.expression.Over;
+import org.hibernate.sql.ast.tree.expression.Overflow;
+import org.hibernate.sql.ast.tree.expression.QueryLiteral;
+import org.hibernate.sql.ast.tree.expression.SelfRenderingExpression;
+import org.hibernate.sql.ast.tree.expression.SqlSelectionExpression;
+import org.hibernate.sql.ast.tree.expression.SqlTuple;
+import org.hibernate.sql.ast.tree.expression.Star;
+import org.hibernate.sql.ast.tree.expression.Summarization;
+import org.hibernate.sql.ast.tree.expression.TrimSpecification;
+import org.hibernate.sql.ast.tree.expression.UnaryOperation;
+import org.hibernate.sql.ast.tree.expression.UnparsedNumericLiteral;
+import org.hibernate.sql.ast.tree.from.FromClause;
+import org.hibernate.sql.ast.tree.from.FunctionTableReference;
+import org.hibernate.sql.ast.tree.from.NamedTableReference;
+import org.hibernate.sql.ast.tree.from.QueryPartTableReference;
+import org.hibernate.sql.ast.tree.from.TableGroup;
+import org.hibernate.sql.ast.tree.from.TableGroupJoin;
+import org.hibernate.sql.ast.tree.from.TableReferenceJoin;
+import org.hibernate.sql.ast.tree.from.ValuesTableReference;
+import org.hibernate.sql.ast.tree.insert.InsertSelectStatement;
+import org.hibernate.sql.ast.tree.predicate.BetweenPredicate;
+import org.hibernate.sql.ast.tree.predicate.BooleanExpressionPredicate;
+import org.hibernate.sql.ast.tree.predicate.ComparisonPredicate;
+import org.hibernate.sql.ast.tree.predicate.ExistsPredicate;
+import org.hibernate.sql.ast.tree.predicate.FilterPredicate;
+import org.hibernate.sql.ast.tree.predicate.GroupedPredicate;
+import org.hibernate.sql.ast.tree.predicate.InArrayPredicate;
+import org.hibernate.sql.ast.tree.predicate.InListPredicate;
+import org.hibernate.sql.ast.tree.predicate.InSubQueryPredicate;
+import org.hibernate.sql.ast.tree.predicate.Junction;
+import org.hibernate.sql.ast.tree.predicate.LikePredicate;
+import org.hibernate.sql.ast.tree.predicate.NegatedPredicate;
+import org.hibernate.sql.ast.tree.predicate.NullnessPredicate;
+import org.hibernate.sql.ast.tree.predicate.SelfRenderingPredicate;
+import org.hibernate.sql.ast.tree.predicate.ThruthnessPredicate;
+import org.hibernate.sql.ast.tree.select.QueryGroup;
+import org.hibernate.sql.ast.tree.select.QueryPart;
+import org.hibernate.sql.ast.tree.select.QuerySpec;
+import org.hibernate.sql.ast.tree.select.SelectClause;
+import org.hibernate.sql.ast.tree.select.SelectStatement;
+import org.hibernate.sql.ast.tree.select.SortSpecification;
+import org.hibernate.sql.ast.tree.update.Assignment;
+import org.hibernate.sql.ast.tree.update.UpdateStatement;
+import org.hibernate.sql.exec.internal.JdbcParametersImpl;
+import org.hibernate.sql.exec.spi.JdbcOperation;
+import org.hibernate.sql.exec.spi.JdbcParameterBinder;
+import org.hibernate.sql.exec.spi.JdbcParameterBindings;
+import org.hibernate.sql.model.MutationOperation;
+import org.hibernate.sql.model.ast.ColumnWriteFragment;
+import org.hibernate.sql.model.ast.TableInsert;
+import org.hibernate.sql.model.ast.TableMutation;
+import org.hibernate.sql.model.internal.OptionalTableUpdate;
+import org.hibernate.sql.model.internal.TableDeleteCustomSql;
+import org.hibernate.sql.model.internal.TableDeleteStandard;
+import org.hibernate.sql.model.internal.TableInsertCustomSql;
+import org.hibernate.sql.model.internal.TableInsertStandard;
+import org.hibernate.sql.model.internal.TableUpdateCustomSql;
+import org.hibernate.sql.model.internal.TableUpdateStandard;
+import org.hibernate.sql.model.jdbc.JdbcMutationOperation;
+import org.mockito.Mockito;
+
+final class MqlTranslator<T extends JdbcOperation & MutationOperation> implements SqlAstTranslator<T> {
+
+    private final SessionFactoryImplementor sessionFactory;
+    private final Statement statement;
+
+    private final AstVisitorValueHolder astReturnValueHolder = AstVisitorValueHolder.emptyHolder();
+
+    private final List<JdbcParameterBinder> parameterBinders = new ArrayList<>();
+    private final JdbcParametersImpl jdbcParameters = new JdbcParametersImpl();
+
+    MqlTranslator(SessionFactoryImplementor sessionFactory, Statement statement) {
+        this.sessionFactory = sessionFactory;
+        this.statement = statement;
+    }
+
+    @Override
+    public SessionFactoryImplementor getSessionFactory() {
+        return sessionFactory;
+    }
+
+    @Override
+    public void render(SqlAstNode sqlAstNode, SqlAstNodeRenderingMode sqlAstNodeRenderingMode) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean supportsFilterClause() {
+        return true;
+    }
+
+    @Override
+    public QueryPart getCurrentQueryPart() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Stack<Clause> getCurrentClauseStack() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Set<String> getAffectedTableNames() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    @SuppressWarnings({"unchecked"})
+    public T translate(JdbcParameterBindings jdbcParameterBindings, QueryOptions queryOptions) {
+        if (statement instanceof TableMutation) {
+            TableMutation<T> tableMutation = (TableMutation<T>) statement;
+            if (tableMutation instanceof TableInsert) {
+                return translateTableMutation(tableMutation);
+            } else {
+                return (T) Mockito.mock(JdbcMutationOperation.class);
+            }
+        }
+        throw new NotYetImplementedException();
+    }
+
+    private T translateTableMutation(TableMutation<T> mutation) {
+        var rootAstNode = astReturnValueHolder.getValue(AstNode.class, () -> mutation.accept(this));
+        return mutation.createMutationOperation(translateMongoAst(rootAstNode), parameterBinders);
+    }
+
+    private String translateMongoAst(AstNode rootAstNode) {
+        var writer = new StringWriter();
+        rootAstNode.render(new JsonWriter(writer));
+        return writer.toString();
+    }
+
+    // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    // Table Mutation: insertion
+
+    @Override
+    public void visitStandardTableInsert(TableInsertStandard tableInsertStandard) {
+        var tableName = tableInsertStandard.getTableName();
+        var astElements = new ArrayList<AstElement>(tableInsertStandard.getNumberOfValueBindings());
+        tableInsertStandard.forEachValueBinding((columnPosition, columnValueBinding) -> {
+            var astValue = astReturnValueHolder.getValue(
+                    AstValue.class,
+                    () -> columnValueBinding.getValueExpression().accept(this));
+            var columnExpression = columnValueBinding.getColumnReference().getColumnExpression();
+            astElements.add(new AstElement(columnExpression, astValue));
+        });
+        astReturnValueHolder.setValue(AstNode.class, new AstInsertCommand(tableName, astElements));
+    }
+
+    @Override
+    public void visitColumnWriteFragment(ColumnWriteFragment columnWriteFragment) {
+        if (columnWriteFragment.getParameters().isEmpty()) {
+            throw new NotYetImplementedException("maybe belongs to scope of Formula feature");
+        }
+        if (columnWriteFragment.getParameters().size() > 1) {
+            throw new NotYetImplementedException("belongs to the scope of Array or STRUCT feature");
+        }
+        var jdbcParameter = columnWriteFragment.getParameters().iterator().next();
+        parameterBinders.add(jdbcParameter.getParameterBinder());
+        jdbcParameters.addParameter(jdbcParameter);
+        astReturnValueHolder.setValue(AstValue.class, AstPlaceholder.INSTANCE);
+    }
+
+    // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    @Override
+    public void visitSelectStatement(SelectStatement selectStatement) {
+        throw new NotYetImplementedException();
+    }
+
+    @Override
+    public void visitDeleteStatement(DeleteStatement deleteStatement) {
+        throw new NotYetImplementedException();
+    }
+
+    @Override
+    public void visitUpdateStatement(UpdateStatement updateStatement) {
+        throw new NotYetImplementedException();
+    }
+
+    @Override
+    public void visitInsertStatement(InsertSelectStatement insertSelectStatement) {
+        throw new NotYetImplementedException();
+    }
+
+    @Override
+    public void visitAssignment(Assignment assignment) {
+        throw new NotYetImplementedException();
+    }
+
+    @Override
+    public void visitQueryGroup(QueryGroup queryGroup) {
+        throw new NotYetImplementedException();
+    }
+
+    @Override
+    public void visitQuerySpec(QuerySpec querySpec) {
+        throw new NotYetImplementedException();
+    }
+
+    @Override
+    public void visitSortSpecification(SortSpecification sortSpecification) {
+        throw new NotYetImplementedException();
+    }
+
+    @Override
+    public void visitOffsetFetchClause(QueryPart queryPart) {
+        throw new NotYetImplementedException();
+    }
+
+    @Override
+    public void visitSelectClause(SelectClause selectClause) {
+        throw new NotYetImplementedException();
+    }
+
+    @Override
+    public void visitSqlSelection(SqlSelection sqlSelection) {
+        throw new NotYetImplementedException();
+    }
+
+    @Override
+    public void visitFromClause(FromClause fromClause) {
+        throw new NotYetImplementedException();
+    }
+
+    @Override
+    public void visitTableGroup(TableGroup tableGroup) {
+        throw new NotYetImplementedException();
+    }
+
+    @Override
+    public void visitTableGroupJoin(TableGroupJoin tableGroupJoin) {
+        throw new NotYetImplementedException();
+    }
+
+    @Override
+    public void visitNamedTableReference(NamedTableReference namedTableReference) {
+        throw new NotYetImplementedException();
+    }
+
+    @Override
+    public void visitValuesTableReference(ValuesTableReference valuesTableReference) {
+        throw new NotYetImplementedException();
+    }
+
+    @Override
+    public void visitQueryPartTableReference(QueryPartTableReference queryPartTableReference) {
+        throw new NotYetImplementedException();
+    }
+
+    @Override
+    public void visitFunctionTableReference(FunctionTableReference functionTableReference) {
+        throw new NotYetImplementedException();
+    }
+
+    @Override
+    public void visitTableReferenceJoin(TableReferenceJoin tableReferenceJoin) {
+        throw new NotYetImplementedException();
+    }
+
+    @Override
+    public void visitColumnReference(ColumnReference columnReference) {
+        throw new NotYetImplementedException();
+    }
+
+    @Override
+    public void visitNestedColumnReference(NestedColumnReference nestedColumnReference) {
+        throw new NotYetImplementedException();
+    }
+
+    @Override
+    public void visitAggregateColumnWriteExpression(AggregateColumnWriteExpression aggregateColumnWriteExpression) {
+        throw new NotYetImplementedException();
+    }
+
+    @Override
+    public void visitExtractUnit(ExtractUnit extractUnit) {
+        throw new NotYetImplementedException();
+    }
+
+    @Override
+    public void visitFormat(Format format) {
+        throw new NotYetImplementedException();
+    }
+
+    @Override
+    public void visitDistinct(Distinct distinct) {
+        throw new NotYetImplementedException();
+    }
+
+    @Override
+    public void visitOverflow(Overflow overflow) {
+        throw new NotYetImplementedException();
+    }
+
+    @Override
+    public void visitStar(Star star) {
+        throw new NotYetImplementedException();
+    }
+
+    @Override
+    public void visitTrimSpecification(TrimSpecification trimSpecification) {
+        throw new NotYetImplementedException();
+    }
+
+    @Override
+    public void visitCastTarget(CastTarget castTarget) {
+        throw new NotYetImplementedException();
+    }
+
+    @Override
+    public void visitBinaryArithmeticExpression(BinaryArithmeticExpression binaryArithmeticExpression) {
+        throw new NotYetImplementedException();
+    }
+
+    @Override
+    public void visitCaseSearchedExpression(CaseSearchedExpression caseSearchedExpression) {
+        throw new NotYetImplementedException();
+    }
+
+    @Override
+    public void visitCaseSimpleExpression(CaseSimpleExpression caseSimpleExpression) {
+        throw new NotYetImplementedException();
+    }
+
+    @Override
+    public void visitAny(Any any) {
+        throw new NotYetImplementedException();
+    }
+
+    @Override
+    public void visitEvery(Every every) {
+        throw new NotYetImplementedException();
+    }
+
+    @Override
+    public void visitSummarization(Summarization summarization) {
+        throw new NotYetImplementedException();
+    }
+
+    @Override
+    public void visitOver(Over<?> over) {
+        throw new NotYetImplementedException();
+    }
+
+    @Override
+    public void visitSelfRenderingExpression(SelfRenderingExpression selfRenderingExpression) {
+        throw new NotYetImplementedException();
+    }
+
+    @Override
+    public void visitSqlSelectionExpression(SqlSelectionExpression sqlSelectionExpression) {
+        throw new NotYetImplementedException();
+    }
+
+    @Override
+    public void visitEntityTypeLiteral(EntityTypeLiteral entityTypeLiteral) {
+        throw new NotYetImplementedException();
+    }
+
+    @Override
+    public void visitEmbeddableTypeLiteral(EmbeddableTypeLiteral embeddableTypeLiteral) {
+        throw new NotYetImplementedException();
+    }
+
+    @Override
+    public void visitTuple(SqlTuple sqlTuple) {
+        throw new NotYetImplementedException();
+    }
+
+    @Override
+    public void visitCollation(Collation collation) {
+        throw new NotYetImplementedException();
+    }
+
+    @Override
+    public void visitParameter(JdbcParameter jdbcParameter) {
+        throw new NotYetImplementedException();
+    }
+
+    @Override
+    public void visitJdbcLiteral(JdbcLiteral<?> jdbcLiteral) {
+        throw new NotYetImplementedException();
+    }
+
+    @Override
+    public void visitQueryLiteral(QueryLiteral<?> queryLiteral) {
+        throw new NotYetImplementedException();
+    }
+
+    @Override
+    public <N extends Number> void visitUnparsedNumericLiteral(UnparsedNumericLiteral<N> unparsedNumericLiteral) {
+        throw new NotYetImplementedException();
+    }
+
+    @Override
+    public void visitUnaryOperationExpression(UnaryOperation unaryOperation) {
+        throw new NotYetImplementedException();
+    }
+
+    @Override
+    public void visitModifiedSubQueryExpression(ModifiedSubQueryExpression modifiedSubQueryExpression) {
+        throw new NotYetImplementedException();
+    }
+
+    @Override
+    public void visitBooleanExpressionPredicate(BooleanExpressionPredicate booleanExpressionPredicate) {
+        throw new NotYetImplementedException();
+    }
+
+    @Override
+    public void visitBetweenPredicate(BetweenPredicate betweenPredicate) {
+        throw new NotYetImplementedException();
+    }
+
+    @Override
+    public void visitFilterPredicate(FilterPredicate filterPredicate) {
+        throw new NotYetImplementedException();
+    }
+
+    @Override
+    public void visitFilterFragmentPredicate(FilterPredicate.FilterFragmentPredicate filterFragmentPredicate) {
+        throw new NotYetImplementedException();
+    }
+
+    @Override
+    public void visitSqlFragmentPredicate(SqlFragmentPredicate sqlFragmentPredicate) {
+        throw new NotYetImplementedException();
+    }
+
+    @Override
+    public void visitGroupedPredicate(GroupedPredicate groupedPredicate) {
+        throw new NotYetImplementedException();
+    }
+
+    @Override
+    public void visitInListPredicate(InListPredicate inListPredicate) {
+        throw new NotYetImplementedException();
+    }
+
+    @Override
+    public void visitInSubQueryPredicate(InSubQueryPredicate inSubQueryPredicate) {
+        throw new NotYetImplementedException();
+    }
+
+    @Override
+    public void visitInArrayPredicate(InArrayPredicate inArrayPredicate) {
+        throw new NotYetImplementedException();
+    }
+
+    @Override
+    public void visitExistsPredicate(ExistsPredicate existsPredicate) {
+        throw new NotYetImplementedException();
+    }
+
+    @Override
+    public void visitJunction(Junction junction) {
+        throw new NotYetImplementedException();
+    }
+
+    @Override
+    public void visitLikePredicate(LikePredicate likePredicate) {
+        throw new NotYetImplementedException();
+    }
+
+    @Override
+    public void visitNegatedPredicate(NegatedPredicate negatedPredicate) {
+        throw new NotYetImplementedException();
+    }
+
+    @Override
+    public void visitNullnessPredicate(NullnessPredicate nullnessPredicate) {
+        throw new NotYetImplementedException();
+    }
+
+    @Override
+    public void visitThruthnessPredicate(ThruthnessPredicate thruthnessPredicate) {
+        throw new NotYetImplementedException();
+    }
+
+    @Override
+    public void visitRelationalPredicate(ComparisonPredicate comparisonPredicate) {
+        throw new NotYetImplementedException();
+    }
+
+    @Override
+    public void visitSelfRenderingPredicate(SelfRenderingPredicate selfRenderingPredicate) {
+        throw new NotYetImplementedException();
+    }
+
+    @Override
+    public void visitDurationUnit(DurationUnit durationUnit) {
+        throw new NotYetImplementedException();
+    }
+
+    @Override
+    public void visitDuration(Duration duration) {
+        throw new NotYetImplementedException();
+    }
+
+    @Override
+    public void visitConversion(Conversion conversion) {
+        throw new NotYetImplementedException();
+    }
+
+    @Override
+    public void visitCustomTableInsert(TableInsertCustomSql tableInsertCustomSql) {
+        throw new NotYetImplementedException();
+    }
+
+    @Override
+    public void visitStandardTableDelete(TableDeleteStandard tableDeleteStandard) {
+        throw new NotYetImplementedException();
+    }
+
+    @Override
+    public void visitCustomTableDelete(TableDeleteCustomSql tableDeleteCustomSql) {
+        throw new NotYetImplementedException();
+    }
+
+    @Override
+    public void visitStandardTableUpdate(TableUpdateStandard tableUpdateStandard) {
+        throw new NotYetImplementedException();
+    }
+
+    @Override
+    public void visitOptionalTableUpdate(OptionalTableUpdate optionalTableUpdate) {
+        throw new NotYetImplementedException();
+    }
+
+    @Override
+    public void visitCustomTableUpdate(TableUpdateCustomSql tableUpdateCustomSql) {
+        throw new NotYetImplementedException();
+    }
+}

--- a/src/main/java/com/mongodb/hibernate/translate/mongoast/AstElement.java
+++ b/src/main/java/com/mongodb/hibernate/translate/mongoast/AstElement.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2024-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.hibernate.translate.mongoast;
+
+import org.bson.BsonWriter;
+
+/**
+ * Represents some Bson field with name and value, which is usually rendered with other {@link AstElement}s to compose a
+ * {@link org.bson.BsonDocument}.
+ *
+ * @param name field name; not {@code null}
+ * @param value field value; not {@code null}
+ */
+public record AstElement(String name, AstValue value) implements AstNode {
+    @Override
+    public void render(BsonWriter writer) {
+        writer.writeName(name);
+        value.render(writer);
+    }
+}

--- a/src/main/java/com/mongodb/hibernate/translate/mongoast/AstLiteralValue.java
+++ b/src/main/java/com/mongodb/hibernate/translate/mongoast/AstLiteralValue.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2024-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.hibernate.translate.mongoast;
+
+import org.bson.BsonValue;
+import org.bson.BsonWriter;
+import org.bson.codecs.BsonValueCodec;
+import org.bson.codecs.EncoderContext;
+
+/**
+ * Represents a literal Bson value {@link AstNode} type, whose rendering is based on some {@link BsonValueCodec}.
+ *
+ * @param literalValue some {@link BsonValue} instance to be rendered; not {@code null}
+ * @see AstPlaceholder
+ */
+public record AstLiteralValue(BsonValue literalValue) implements AstValue {
+
+    private static final BsonValueCodec BSON_VALUE_CODEC = new BsonValueCodec();
+    private static final EncoderContext DEFAULT_CONTEXT =
+            EncoderContext.builder().build();
+
+    @Override
+    public void render(final BsonWriter writer) {
+        BSON_VALUE_CODEC.encode(writer, literalValue, DEFAULT_CONTEXT);
+    }
+}

--- a/src/main/java/com/mongodb/hibernate/translate/mongoast/AstNode.java
+++ b/src/main/java/com/mongodb/hibernate/translate/mongoast/AstNode.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2024-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.hibernate.translate.mongoast;
+
+import org.bson.BsonWriter;
+
+/**
+ * The ultimate ancestor interface representing any node in a Mongo AST tree model.
+ *
+ * <p>Its central concern is how to render the sub-tree rooted with it using a {@link BsonWriter} instance.
+ */
+@FunctionalInterface
+public interface AstNode {
+    /**
+     * Renders the AST sub-tree with {@code this} object as the root.
+     *
+     * @param writer provided {@code BsonWriter} instance; not {@code null}
+     */
+    void render(BsonWriter writer);
+}

--- a/src/main/java/com/mongodb/hibernate/translate/mongoast/AstPlaceholder.java
+++ b/src/main/java/com/mongodb/hibernate/translate/mongoast/AstPlaceholder.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2024-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.hibernate.translate.mongoast;
+
+import org.bson.BsonWriter;
+
+/**
+ * Represents an MQL parameter placeholder, whose values will be provided to {@link java.sql.PreparedStatement}'s
+ * various setter methods together with the their position indexes.
+ *
+ * <p>Note that MQL has no SQL parameter placeholder (JDBC uses {@code ?} as placeholder marker) counterpart; currently
+ * {@code {"$undefined": true}} is chosen
+ */
+public record AstPlaceholder() implements AstValue {
+
+    public static AstPlaceholder INSTANCE = new AstPlaceholder();
+
+    @Override
+    public void render(BsonWriter writer) {
+        writer.writeUndefined();
+    }
+}

--- a/src/main/java/com/mongodb/hibernate/translate/mongoast/AstValue.java
+++ b/src/main/java/com/mongodb/hibernate/translate/mongoast/AstValue.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2024-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.hibernate.translate.mongoast;
+
+/**
+ * Represents value type {@link AstNode}, e.g.
+ *
+ * <ul>
+ *   <li>{@link AstLiteralValue}: non-parameter literal value
+ *   <li>{@link AstPlaceholder}: parameter placeholder
+ * </ul>
+ */
+public interface AstValue extends AstNode {}

--- a/src/main/java/com/mongodb/hibernate/translate/mongoast/command/AstInsertCommand.java
+++ b/src/main/java/com/mongodb/hibernate/translate/mongoast/command/AstInsertCommand.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2024-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.hibernate.translate.mongoast.command;
+
+import com.mongodb.hibernate.translate.mongoast.AstElement;
+import com.mongodb.hibernate.translate.mongoast.AstNode;
+import java.util.List;
+import org.bson.BsonWriter;
+
+/**
+ * Represents some insert MQL command which aims to insert one single document composed of a collection of
+ * {@link AstElement}s.
+ *
+ * @param collection collection name; never {@code null}
+ * @param elements the fields of the inserted document; never {@code null}
+ */
+public record AstInsertCommand(String collection, List<? extends AstElement> elements) implements AstNode {
+    @Override
+    public void render(BsonWriter writer) {
+        writer.writeStartDocument();
+        writer.writeString("insert", collection);
+        writer.writeName("documents");
+        writer.writeStartArray();
+        writer.writeStartDocument();
+        elements.forEach(element -> element.render(writer));
+        writer.writeEndDocument();
+        writer.writeEndArray();
+        writer.writeEndDocument();
+    }
+}

--- a/src/main/java/com/mongodb/hibernate/translate/mongoast/command/package-info.java
+++ b/src/main/java/com/mongodb/hibernate/translate/mongoast/command/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2024-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package com.mongodb.hibernate.translate.mongoast.command;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/com/mongodb/hibernate/translate/mongoast/package-info.java
+++ b/src/main/java/com/mongodb/hibernate/translate/mongoast/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2024-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@NullMarked
+package com.mongodb.hibernate.translate.mongoast;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/com/mongodb/hibernate/translate/package-info.java
+++ b/src/main/java/com/mongodb/hibernate/translate/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2024-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package com.mongodb.hibernate.translate;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/test/java/com/mongodb/hibernate/translate/AstVisitorValueHolderTests.java
+++ b/src/test/java/com/mongodb/hibernate/translate/AstVisitorValueHolderTests.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2024-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.hibernate.translate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.google.common.reflect.TypeToken;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class AstVisitorValueHolderTests {
+
+    private AstVisitorValueHolder astVisitorValueHolder;
+
+    @BeforeEach
+    void setUp() {
+        astVisitorValueHolder = AstVisitorValueHolder.emptyHolder();
+    }
+
+    @Test
+    void testSimpleUsage() {
+        // given
+        TypeToken<Set<String>> typeToken = new TypeToken<>() {};
+
+        var valueSet = Set.of("name", "address", "postCode");
+        Runnable valueSetter = () -> astVisitorValueHolder.setValue(typeToken, valueSet);
+
+        // when
+        var valueGotten = astVisitorValueHolder.getValue(typeToken, valueSetter);
+
+        // then
+        assertEquals(valueSet, valueGotten);
+    }
+
+    @Test
+    void testRecursiveUsage() {
+        // given
+        var level1Type = new TypeToken<Long>() {};
+
+        Runnable level1Setter = () -> {
+            var level2Type = new TypeToken<String>() {};
+            Runnable level2Setter = () -> {
+                var level3Type = new TypeToken<List<String>>() {};
+                Runnable level3Setter = () -> astVisitorValueHolder.setValue(level3Type, List.of("name", "address"));
+                var level3Value = astVisitorValueHolder.getValue(level3Type, level3Setter);
+                astVisitorValueHolder.setValue(level2Type, "fields: " + String.join(",", level3Value));
+            };
+            var level2Value = astVisitorValueHolder.getValue(level2Type, level2Setter);
+            astVisitorValueHolder.setValue(level1Type, level2Value.length() + 20L);
+        };
+
+        // when
+        var resultLevel1 = astVisitorValueHolder.getValue(level1Type, level1Setter);
+
+        // then
+        assertEquals(40L, resultLevel1);
+    }
+
+    @Nested
+    class ValueSettingTests {
+
+        @Test
+        @DisplayName("Exception is thrown when holder is not empty when setting data")
+        void testHolderNotEmptyWhenSetting() {
+            // given
+            var type = new TypeToken<String>() {};
+            Runnable valueSetter = () -> {
+                astVisitorValueHolder.setValue(type, "first load");
+                astVisitorValueHolder.setValue(type, "second load");
+            };
+            // when && then
+            assertThrows(Error.class, () -> astVisitorValueHolder.getValue(type, valueSetter));
+        }
+
+        @Test
+        @DisplayName("Exception is thrown when holder is expecting a type different from that of real data")
+        void testHolderExpectingDifferentType() {
+            // given
+            Runnable valueSetter = () -> astVisitorValueHolder.setValue(new TypeToken<>() {}, List.of(1, 2, 3));
+
+            // when && then
+            assertThrows(
+                    Error.class, () -> astVisitorValueHolder.getValue(new TypeToken<List<String>>() {}, valueSetter));
+        }
+    }
+
+    @Nested
+    class ValueGettingTests {
+
+        @Test
+        @DisplayName("Exception is thrown when getting value from an empty holder")
+        void testHolderStillEmpty() {
+            // given
+            var type = new TypeToken<String>() {};
+
+            // when && then
+            assertThrows(Error.class, () -> astVisitorValueHolder.getValue(type, () -> {}));
+        }
+    }
+}


### PR DESCRIPTION
https://jira.mongodb.org/browse/HIBERNATE-14

The first CRUD component implementation PR (choosing insertion as the first step due to the data dependency for the other components requires insertion as pre-condition; though Java driver-based native insertion is also fine). After this PR is merged, the other `update`, `delete` and `load` PR could be implemented in parallel. This PR will lay down important infrastructure and would streamline the other three.

As in POC project, mongoast stuff (inspired by C# mongo driver's Linq: https://github.com/mongodb/mongo-csharp-driver/tree/main/src/MongoDB.Driver/Linq) was used as elegant translation result of SQL AST scanning. Only insertion related mongoast stuff was included and incrementally introducing more mongoast stuff will be an important part of the later CRUD PRs.

Hibernate relies on `SqlAstWalker` as the SQL AST scanning abstraction based on well-known visitor pattern. In origiinal SQL translation scenario, string concatenation seems to suffice so the visitor walker interface's all visitor methods don't return any value (using `void` as the return type); but given our internal mongoast generation implmenetation plan, it is natural to return value from the visitor methods. So a tricky data exchange mechanism was introduced (previously we called it `Attachment` though it is misnomer). Type safety is a core concern but I think what really matters is the type, including generics info (which would be erased by Java at runtime; but there is well-known solution to retain generics info like Guava's TypeToken: https://www.baeldung.com/guava-reflection). Another tricky part is the data exchange mechanism shares something with Stack in the sense that once its value is fetched, its previous state should be restored. The necessity could only be shown by code debugging when visiting SQL AST tree.
