### PR TITLE
Start using `TODO-<Jira ticket ID>` tags

### DIFF
--- a/src/main/java/com/mongodb/hibernate/internal/NotYetImplementedException.java
+++ b/src/main/java/com/mongodb/hibernate/internal/NotYetImplementedException.java
@@ -25,8 +25,16 @@ import java.io.Serial;
  * <p>Ultimately all of its references should be eliminated sooner or later, and then this class is supposed to be
  * deleted prior to product release.
  *
- * <p>It is recommended to provide some message to explain when it will be implemented (e.g. JIRA ticket id is a good
- * idea), but that is optional.
+ * <p>It is recommended to provide a {@code TODO-<Jira ticket ID> ...} message, in which case one must mention in the
+ * ticket description that resolving the {@code TODO-<Jira ticket ID>} notes is in scope of the ticket. Examples:
+ *
+ * <pre>{@code
+ * throw new NotYetImplementedException("TODO-HIBERNATE-13 https://jira.mongodb.org/browse/HIBERNATE-13")
+ * }</pre>
+ *
+ * <pre>{@code
+ * throw new NotYetImplementedException("TODO-HIBERNATE-13")
+ * }</pre>
  *
  * <p>This class is not part of the public API and may be removed or changed at any time.
  */

--- a/src/main/java/com/mongodb/hibernate/jdbc/MongoConnection.java
+++ b/src/main/java/com/mongodb/hibernate/jdbc/MongoConnection.java
@@ -46,7 +46,7 @@ final class MongoConnection implements ConnectionAdapter {
 
     private final Logger logger = LoggerFactory.getLogger(MongoConnection.class);
 
-    // temporary hard-coded database prior to the db config tech design finalizing
+    // TODO-HIBERNATE-38 temporary hard-coded database prior to the db config tech design finalizing
     public static final String DATABASE = "mongo-hibernate-test";
 
     private final MongoClient mongoClient;
@@ -156,8 +156,7 @@ final class MongoConnection implements ConnectionAdapter {
     public PreparedStatement prepareStatement(String mql, int resultSetType, int resultSetConcurrency)
             throws SQLException {
         checkClosed();
-        throw new NotYetImplementedException(
-                "To be implemented in scope of https://jira.mongodb.org/browse/HIBERNATE-21");
+        throw new NotYetImplementedException("TODO-HIBERNATE-21 https://jira.mongodb.org/browse/HIBERNATE-21");
     }
 
     // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/main/java/com/mongodb/hibernate/jdbc/MongoPreparedStatement.java
+++ b/src/main/java/com/mongodb/hibernate/jdbc/MongoPreparedStatement.java
@@ -181,21 +181,21 @@ final class MongoPreparedStatement extends MongoStatement implements PreparedSta
     public void setDate(int parameterIndex, Date x) throws SQLException {
         checkClosed();
         checkParameterIndex(parameterIndex);
-        throw new NotYetImplementedException("To implement in scope of https://jira.mongodb.org/browse/HIBERNATE-42");
+        throw new NotYetImplementedException("TODO-HIBERNATE-42 https://jira.mongodb.org/browse/HIBERNATE-42");
     }
 
     @Override
     public void setTime(int parameterIndex, Time x) throws SQLException {
         checkClosed();
         checkParameterIndex(parameterIndex);
-        throw new NotYetImplementedException("To implement in scope of https://jira.mongodb.org/browse/HIBERNATE-42");
+        throw new NotYetImplementedException("TODO-HIBERNATE-42 https://jira.mongodb.org/browse/HIBERNATE-42");
     }
 
     @Override
     public void setTimestamp(int parameterIndex, Timestamp x) throws SQLException {
         checkClosed();
         checkParameterIndex(parameterIndex);
-        throw new NotYetImplementedException("To implement in scope of https://jira.mongodb.org/browse/HIBERNATE-42");
+        throw new NotYetImplementedException("TODO-HIBERNATE-42 https://jira.mongodb.org/browse/HIBERNATE-42");
     }
 
     @Override
@@ -222,8 +222,7 @@ final class MongoPreparedStatement extends MongoStatement implements PreparedSta
     @Override
     public void addBatch() throws SQLException {
         checkClosed();
-        throw new NotYetImplementedException(
-                "To be implemented in scope of https://jira.mongodb.org/browse/HIBERNATE-35");
+        throw new NotYetImplementedException("TODO-HIBERNATE-35 https://jira.mongodb.org/browse/HIBERNATE-35");
     }
 
     @Override
@@ -237,21 +236,21 @@ final class MongoPreparedStatement extends MongoStatement implements PreparedSta
     public void setDate(int parameterIndex, Date x, Calendar cal) throws SQLException {
         checkClosed();
         checkParameterIndex(parameterIndex);
-        throw new NotYetImplementedException("To implement in scope of https://jira.mongodb.org/browse/HIBERNATE-42");
+        throw new NotYetImplementedException("TODO-HIBERNATE-42 https://jira.mongodb.org/browse/HIBERNATE-42");
     }
 
     @Override
     public void setTime(int parameterIndex, Time x, Calendar cal) throws SQLException {
         checkClosed();
         checkParameterIndex(parameterIndex);
-        throw new NotYetImplementedException("To implement in scope of https://jira.mongodb.org/browse/HIBERNATE-42");
+        throw new NotYetImplementedException("TODO-HIBERNATE-42 https://jira.mongodb.org/browse/HIBERNATE-42");
     }
 
     @Override
     public void setTimestamp(int parameterIndex, Timestamp x, Calendar cal) throws SQLException {
         checkClosed();
         checkParameterIndex(parameterIndex);
-        throw new NotYetImplementedException("To implement in scope of https://jira.mongodb.org/browse/HIBERNATE-42");
+        throw new NotYetImplementedException("TODO-HIBERNATE-42 https://jira.mongodb.org/browse/HIBERNATE-42");
     }
 
     @Override

--- a/src/main/java/com/mongodb/hibernate/jdbc/MongoStatement.java
+++ b/src/main/java/com/mongodb/hibernate/jdbc/MongoStatement.java
@@ -56,8 +56,7 @@ class MongoStatement implements StatementAdapter {
     @Override
     public ResultSet executeQuery(String mql) throws SQLException {
         checkClosed();
-        throw new NotYetImplementedException(
-                "To be implemented in scope of https://jira.mongodb.org/browse/HIBERNATE-21");
+        throw new NotYetImplementedException("TODO-HIBERNATE-21 https://jira.mongodb.org/browse/HIBERNATE-21");
     }
 
     @Override
@@ -89,29 +88,25 @@ class MongoStatement implements StatementAdapter {
     @Override
     public int getMaxRows() throws SQLException {
         checkClosed();
-        throw new NotYetImplementedException(
-                "To be implemented in scope of https://jira.mongodb.org/browse/HIBERNATE-21");
+        throw new NotYetImplementedException("TODO-HIBERNATE-21 https://jira.mongodb.org/browse/HIBERNATE-21");
     }
 
     @Override
     public void setMaxRows(int max) throws SQLException {
         checkClosed();
-        throw new NotYetImplementedException(
-                "To be implemented in scope of https://jira.mongodb.org/browse/HIBERNATE-21");
+        throw new NotYetImplementedException("TODO-HIBERNATE-21 https://jira.mongodb.org/browse/HIBERNATE-21");
     }
 
     @Override
     public int getQueryTimeout() throws SQLException {
         checkClosed();
-        throw new NotYetImplementedException(
-                "To be implemented in scope of https://jira.mongodb.org/browse/HIBERNATE-21");
+        throw new NotYetImplementedException("TODO-HIBERNATE-21 https://jira.mongodb.org/browse/HIBERNATE-21");
     }
 
     @Override
     public void setQueryTimeout(int seconds) throws SQLException {
         checkClosed();
-        throw new NotYetImplementedException(
-                "To be implemented in scope of https://jira.mongodb.org/browse/HIBERNATE-21");
+        throw new NotYetImplementedException("TODO-HIBERNATE-21 https://jira.mongodb.org/browse/HIBERNATE-21");
     }
 
     @Override
@@ -161,36 +156,31 @@ class MongoStatement implements StatementAdapter {
     @Override
     public void setFetchSize(int rows) throws SQLException {
         checkClosed();
-        throw new NotYetImplementedException(
-                "To be implemented in scope of https://jira.mongodb.org/browse/HIBERNATE-21");
+        throw new NotYetImplementedException("TODO-HIBERNATE-21 https://jira.mongodb.org/browse/HIBERNATE-21");
     }
 
     @Override
     public int getFetchSize() throws SQLException {
         checkClosed();
-        throw new NotYetImplementedException(
-                "To be implemented in scope of https://jira.mongodb.org/browse/HIBERNATE-21");
+        throw new NotYetImplementedException("TODO-HIBERNATE-21 https://jira.mongodb.org/browse/HIBERNATE-21");
     }
 
     @Override
     public void addBatch(String mql) throws SQLException {
         checkClosed();
-        throw new NotYetImplementedException(
-                "To be implemented in scope of https://jira.mongodb.org/browse/HIBERNATE-35");
+        throw new NotYetImplementedException("TODO-HIBERNATE-35 https://jira.mongodb.org/browse/HIBERNATE-35");
     }
 
     @Override
     public void clearBatch() throws SQLException {
         checkClosed();
-        throw new NotYetImplementedException(
-                "To be implemented in scope of https://jira.mongodb.org/browse/HIBERNATE-35");
+        throw new NotYetImplementedException("TODO-HIBERNATE-35 https://jira.mongodb.org/browse/HIBERNATE-35");
     }
 
     @Override
     public int[] executeBatch() throws SQLException {
         checkClosed();
-        throw new NotYetImplementedException(
-                "To be implemented in scope of https://jira.mongodb.org/browse/HIBERNATE-35");
+        throw new NotYetImplementedException("TODO-HIBERNATE-35 https://jira.mongodb.org/browse/HIBERNATE-35");
     }
 
     @Override


### PR DESCRIPTION
These tags, by virtue of the design of their name, reference the corresponding Jira ticket, and allow that ticket to refer back to them, because each tag is as unique as a Jira ticket ID. They also allow searching for all the `TODO` source code notes, without taking into account the specific Jira ticket.

I updated the descriptions of the tickets mentioned in the `TODO-<Jira ticket ID>` tags:

- https://jira.mongodb.org/browse/HIBERNATE-21
- https://jira.mongodb.org/browse/HIBERNATE-35
- https://jira.mongodb.org/browse/HIBERNATE-38
- https://jira.mongodb.org/browse/HIBERNATE-42

With a line as follows:

> Addressing the source code notes tagged with `TODO-<Jira ticket ID>` is in scope of this ticket.