### PR TITLE
use Hibernate's short-name mechanism to avoid exposing implementation classes

### DIFF
--- a/src/integrationTest/resources/hibernate.properties
+++ b/src/integrationTest/resources/hibernate.properties
@@ -1,3 +1,3 @@
 jakarta.persistence.jdbc.url=mongodb://localhost/mongo-hibernate-test?directConnection=false
-hibernate.dialect=com.mongodb.hibernate.dialect.MongoDialect
-hibernate.connection.provider_class=com.mongodb.hibernate.jdbc.MongoConnectionProvider
+hibernate.dialect=mongodb
+hibernate.connection.provider_class=mongodb-connection-provider

--- a/src/main/java/com/mongodb/hibernate/dialect/MongoStragetyContributor.java
+++ b/src/main/java/com/mongodb/hibernate/dialect/MongoStragetyContributor.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2025-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.hibernate.dialect;
+
+import static com.mongodb.hibernate.internal.MongoAssertions.assertNotNull;
+
+import com.mongodb.hibernate.jdbc.MongoConnectionProvider;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.boot.registry.selector.spi.StrategySelector;
+import org.hibernate.dialect.Dialect;
+import org.hibernate.engine.jdbc.connections.spi.ConnectionProvider;
+import org.hibernate.service.spi.ServiceContributor;
+
+public class MongoStragetyContributor implements ServiceContributor {
+    @Override
+    public void contribute(StandardServiceRegistryBuilder serviceRegistryBuilder) {
+        var selector = assertNotNull(
+                serviceRegistryBuilder.getBootstrapServiceRegistry().getService(StrategySelector.class));
+        selector.registerStrategyImplementor(Dialect.class, "mongodb", MongoDialect.class);
+        selector.registerStrategyImplementor(
+                ConnectionProvider.class, "mongodb-connection-provider", MongoConnectionProvider.class);
+    }
+}

--- a/src/main/resources/META-INF/services/org.hibernate.service.spi.ServiceContributor
+++ b/src/main/resources/META-INF/services/org.hibernate.service.spi.ServiceContributor
@@ -1,0 +1,1 @@
+com.mongodb.hibernate.dialect.MongoStragetyContributor

--- a/src/test/resources/hibernate.properties
+++ b/src/test/resources/hibernate.properties
@@ -1,4 +1,4 @@
 jakarta.persistence.jdbc.url=mongodb://localhost/mongo-hibernate-test?directConnection=false
-hibernate.dialect=com.mongodb.hibernate.dialect.MongoDialect
-hibernate.connection.provider_class=com.mongodb.hibernate.jdbc.MongoConnectionProvider
+hibernate.dialect=mongodb
+hibernate.connection.provider_class=mongodb-connection-provider
 hibernate.boot.allow_jdbc_metadata_access=false


### PR DESCRIPTION
Hibernate has a `Stragety` mechanism (a little misleading for it refers to 'short-name' service, instead of Stragety Pattern) as examplified in `Hibernate Integration Guide`(https://docs.jboss.org/hibernate/orm/6.6/integrationguide/html_single/Hibernate_Integration_Guide.html) . As the doc explains:

> Think of this as the short naming service. Historically to configure Hibernate users would often need to give fully-qualified name references to internal Hibernate classes. Of course, this has caused lots of problems as we refactor internal code and move these classes around into different package structures. Enter the concept of short-naming, using a well defined and well known short name for the strategy/implementation class.

It might be a good feature to our product with similar concern. The customization is based on the common ServiceLoader mechanism Hibernate mainly depends on (as an example stragety registration implementation in the doc).

This PR is not urgent (but given all other PRs were blocked by the first MQL translation PR (https://github.com/mongodb/mongo-hibernate/pull/27) due to integration testing verfication requirement), I created this DRAFT PR for you to consider. 