### PR TITLE
Add multiline string formatter

### DIFF
--- a/src/integrationTest/java/com/mongodb/hibernate/jdbc/MongoPreparedStatementIntegrationTests.java
+++ b/src/integrationTest/java/com/mongodb/hibernate/jdbc/MongoPreparedStatementIntegrationTests.java
@@ -74,12 +74,12 @@ class MongoPreparedStatementIntegrationTests {
                 conn.createStatement()
                         .executeUpdate(
                                 """
-                                    {
-                                        delete: "books",
-                                        deletes: [
-                                            { q: {}, limit: 0 }
-                                        ]
-                                    }""");
+                                {
+                                    delete: "books",
+                                    deletes: [
+                                        { q: {}, limit: 0 }
+                                    ]
+                                }""");
             });
         }
 
@@ -122,51 +122,51 @@ class MongoPreparedStatementIntegrationTests {
             var expectedDocs = Set.of(
                     BsonDocument.parse(
                             """
-                                {
-                                    _id: 1,
-                                    title: "War and Peace",
-                                    author: "Leo Tolstoy",
-                                    outOfStock: true,
-                                    tags: [ "classic", "tolstoy", "literature" ]
-                                }"""),
+                            {
+                                _id: 1,
+                                title: "War and Peace",
+                                author: "Leo Tolstoy",
+                                outOfStock: true,
+                                tags: [ "classic", "tolstoy", "literature" ]
+                            }"""),
                     BsonDocument.parse(
                             """
-                                {
-                                    _id: 2,
-                                    title: "Anna Karenina",
-                                    author: "Leo Tolstoy",
-                                    outOfStock: true,
-                                    tags: [ "classic", "tolstoy", "literature" ]
-                                }"""),
+                            {
+                                _id: 2,
+                                title: "Anna Karenina",
+                                author: "Leo Tolstoy",
+                                outOfStock: true,
+                                tags: [ "classic", "tolstoy", "literature" ]
+                            }"""),
                     BsonDocument.parse(
                             """
-                               {
-                                   _id: 3,
-                                   title: "Crime and Punishment",
-                                   author: "Fyodor Dostoevsky",
-                                   outOfStock: false,
-                                   tags: [ "classic", "Dostoevsky", "literature" ]
-                               }"""));
+                            {
+                                _id: 3,
+                                title: "Crime and Punishment",
+                                author: "Fyodor Dostoevsky",
+                                outOfStock: false,
+                                tags: [ "classic", "Dostoevsky", "literature" ]
+                            }"""));
             Function<Connection, MongoPreparedStatement> pstmtProvider = connection -> {
                 try {
                     var pstmt = (MongoPreparedStatement)
                             connection.prepareStatement(
                                     """
-                                        {
-                                            update: "books",
-                                            updates: [
-                                                {
-                                                    q: { author: { $undefined: true } },
-                                                    u: {
-                                                        $set: {
-                                                            outOfStock: { $undefined: true }
-                                                        },
-                                                        $push: { tags: { $undefined: true } }
+                                    {
+                                        update: "books",
+                                        updates: [
+                                            {
+                                                q: { author: { $undefined: true } },
+                                                u: {
+                                                    $set: {
+                                                        outOfStock: { $undefined: true }
                                                     },
-                                                    multi: true
-                                                }
-                                            ]
-                                        }""");
+                                                    $push: { tags: { $undefined: true } }
+                                                },
+                                                multi: true
+                                            }
+                                        ]
+                                    }""");
                     pstmt.setString(1, "Leo Tolstoy");
                     pstmt.setBoolean(2, true);
                     pstmt.setString(3, "literature");

--- a/src/integrationTest/java/com/mongodb/hibernate/jdbc/MongoStatementIntegrationTests.java
+++ b/src/integrationTest/java/com/mongodb/hibernate/jdbc/MongoStatementIntegrationTests.java
@@ -71,12 +71,12 @@ class MongoStatementIntegrationTests {
                 conn.createStatement()
                         .executeUpdate(
                                 """
-                                    {
-                                        delete: "books",
-                                        deletes: [
-                                            { q: {}, limit: 0 }
-                                        ]
-                                    }""");
+                                {
+                                    delete: "books",
+                                    deletes: [
+                                        { q: {}, limit: 0 }
+                                    ]
+                                }""");
             });
         }
 
@@ -112,28 +112,28 @@ class MongoStatementIntegrationTests {
             var expectedDocs = Set.of(
                     BsonDocument.parse(
                             """
-                                {
-                                    _id: 1,
-                                    title: "War and Peace",
-                                    author: "Leo Tolstoy",
-                                    outOfStock: false
-                                }"""),
+                            {
+                                _id: 1,
+                                title: "War and Peace",
+                                author: "Leo Tolstoy",
+                                outOfStock: false
+                            }"""),
                     BsonDocument.parse(
                             """
-                                {
-                                    _id: 2,
-                                    title: "Anna Karenina",
-                                    author: "Leo Tolstoy",
-                                    outOfStock: false
-                                }"""),
+                            {
+                                _id: 2,
+                                title: "Anna Karenina",
+                                author: "Leo Tolstoy",
+                                outOfStock: false
+                            }"""),
                     BsonDocument.parse(
                             """
-                               {
-                                   _id: 3,
-                                   title: "Crime and Punishment",
-                                   author: "Fyodor Dostoevsky",
-                                   outOfStock: false
-                               }"""));
+                            {
+                                _id: 3,
+                                title: "Crime and Punishment",
+                                author: "Fyodor Dostoevsky",
+                                outOfStock: false
+                            }"""));
             assertExecuteUpdate(INSERT_MQL, autoCommit, 3, expectedDocs);
         }
 
@@ -161,28 +161,28 @@ class MongoStatementIntegrationTests {
             var expectedDocs = Set.of(
                     BsonDocument.parse(
                             """
-                                {
-                                    _id: 1,
-                                    title: "War and Peace",
-                                    author: "Leo Tolstoy",
-                                    outOfStock: true
-                                }"""),
+                            {
+                                _id: 1,
+                                title: "War and Peace",
+                                author: "Leo Tolstoy",
+                                outOfStock: true
+                            }"""),
                     BsonDocument.parse(
                             """
-                                {
-                                    _id: 2,
-                                    title: "Anna Karenina",
-                                    author: "Leo Tolstoy",
-                                    outOfStock: true
-                                }"""),
+                            {
+                                _id: 2,
+                                title: "Anna Karenina",
+                                author: "Leo Tolstoy",
+                                outOfStock: true
+                            }"""),
                     BsonDocument.parse(
                             """
-                               {
-                                   _id: 3,
-                                   title: "Crime and Punishment",
-                                   author: "Fyodor Dostoevsky",
-                                   outOfStock: false
-                               }"""));
+                            {
+                                _id: 3,
+                                title: "Crime and Punishment",
+                                author: "Fyodor Dostoevsky",
+                                outOfStock: false
+                            }"""));
             assertExecuteUpdate(updateMql, autoCommit, 2, expectedDocs);
         }
 
@@ -207,20 +207,20 @@ class MongoStatementIntegrationTests {
             var expectedDocs = Set.of(
                     BsonDocument.parse(
                             """
-                                {
-                                    _id: 2,
-                                    title: "Anna Karenina",
-                                    author: "Leo Tolstoy",
-                                    outOfStock: false
-                                }"""),
+                            {
+                                _id: 2,
+                                title: "Anna Karenina",
+                                author: "Leo Tolstoy",
+                                outOfStock: false
+                            }"""),
                     BsonDocument.parse(
                             """
-                               {
-                                    _id: 3,
-                                    title: "Crime and Punishment",
-                                    author: "Fyodor Dostoevsky",
-                                    outOfStock: false
-                               }"""));
+                            {
+                                 _id: 3,
+                                 title: "Crime and Punishment",
+                                 author: "Fyodor Dostoevsky",
+                                 outOfStock: false
+                            }"""));
             assertExecuteUpdate(deleteMql, autoCommit, 1, expectedDocs);
         }
 

--- a/src/test/java/com/mongodb/hibernate/jdbc/MongoConnectionTests.java
+++ b/src/test/java/com/mongodb/hibernate/jdbc/MongoConnectionTests.java
@@ -118,25 +118,25 @@ class MongoConnectionTests {
         private static Stream<Arguments> getMongoConnectionMethodInvocationsImpactedByClosing() {
             var exampleQueryMql =
                     """
-                {
-                  find: "restaurants",
-                  filter: { rating: { $gte: 9 }, cuisine: "italian" },
-                  projection: { name: 1, rating: 1, address: 1 },
-                  sort: { name: 1 },
-                  limit: 5
-                }""";
+                    {
+                      find: "restaurants",
+                      filter: { rating: { $gte: 9 }, cuisine: "italian" },
+                      projection: { name: 1, rating: 1, address: 1 },
+                      sort: { name: 1 },
+                      limit: 5
+                    }""";
             var exampleUpdateMql =
                     """
-                {
-                  update: "members",
-                  updates: [
                     {
-                      q: {},
-                      u: { $inc: { points: 1 } },
-                      multi: true
-                    }
-                  ]
-                }""";
+                      update: "members",
+                      updates: [
+                        {
+                          q: {},
+                          u: { $inc: { points: 1 } },
+                          multi: true
+                        }
+                      ]
+                    }""";
             return Map.<String, ConnectionMethodInvocation>ofEntries(
                             Map.entry("setAutoCommit(boolean)", conn -> conn.setAutoCommit(false)),
                             Map.entry("getAutoCommit()", MongoConnection::getAutoCommit),

--- a/src/test/java/com/mongodb/hibernate/jdbc/MongoPreparedStatementTests.java
+++ b/src/test/java/com/mongodb/hibernate/jdbc/MongoPreparedStatementTests.java
@@ -77,21 +77,21 @@ class MongoPreparedStatementTests {
 
         private static final String EXAMPLE_MQL =
                 """
-                 {
-                    insert: "books",
-                    documents: [
-                        {
-                            title: { $undefined: true },
-                            author: { $undefined: true },
-                            publishYear: { $undefined: true },
-                            outOfStock: { $undefined: true },
-                            tags: [
-                                { $undefined: true }
-                            ]
-                        }
-                    ]
-                 }
-                 """;
+                {
+                   insert: "books",
+                   documents: [
+                       {
+                           title: { $undefined: true },
+                           author: { $undefined: true },
+                           publishYear: { $undefined: true },
+                           outOfStock: { $undefined: true },
+                           tags: [
+                               { $undefined: true }
+                           ]
+                       }
+                   ]
+                }
+                """;
 
         @Mock
         private MongoDatabase mongoDatabase;
@@ -123,21 +123,21 @@ class MongoPreparedStatementTests {
                 var command = commandCaptor.getValue();
                 var expectedDoc = BsonDocument.parse(
                         """
-                            {
-                                insert: "books",
-                                documents: [
-                                    {
-                                        title: "War and Peace",
-                                        author: "Leo Tolstoy",
-                                        publishYear: 1869,
-                                        outOfStock: false,
-                                        tags: [
-                                            "classic"
-                                        ]
-                                    }
-                                ]
-                            }
-                            """);
+                        {
+                            insert: "books",
+                            documents: [
+                                {
+                                    title: "War and Peace",
+                                    author: "Leo Tolstoy",
+                                    publishYear: 1869,
+                                    outOfStock: false,
+                                    tags: [
+                                        "classic"
+                                    ]
+                                }
+                            ]
+                        }
+                        """);
                 assertEquals(expectedDoc, command);
             }
         }
@@ -171,20 +171,20 @@ class MongoPreparedStatementTests {
             // given
             var mql =
                     """
-                     {
-                        insert: "books",
-                        documents: [
-                            {
-                                title: "War and Peace",
-                                author: "Leo Tolstoy",
-                                outOfStock: false,
-                                values: [
-                                    { $undefined: true }
-                                ]
-                            }
-                        ]
-                     }
-                     """;
+                    {
+                       insert: "books",
+                       documents: [
+                           {
+                               title: "War and Peace",
+                               author: "Leo Tolstoy",
+                               outOfStock: false,
+                               values: [
+                                   { $undefined: true }
+                               ]
+                           }
+                       ]
+                    }
+                    """;
 
             var preparedStatement = createMongoPreparedStatement(mql);
             preparedStatement.close();

--- a/src/test/java/com/mongodb/hibernate/jdbc/MongoStatementTests.java
+++ b/src/test/java/com/mongodb/hibernate/jdbc/MongoStatementTests.java
@@ -81,8 +81,8 @@ class MongoStatementTests {
             // given
             String invalidMql =
                     """
-                { insert: "books"'", documents: [ { title: "War and Peace" } ]
-                """;
+                    { insert: "books"'", documents: [ { title: "War and Peace" } ]
+                    """;
 
             // when && then
             assertThrows(SQLSyntaxErrorException.class, () -> mongoStatement.executeUpdate(invalidMql));
@@ -97,11 +97,11 @@ class MongoStatementTests {
             doThrow(dbAccessException).when(mongoDatabase).runCommand(same(clientSession), any(BsonDocument.class));
             String mql =
                     """
-                {
-                    delete: "orders",
-                    deletes: [ { q: { status: "D" }, limit: 1 }, { q: { outOfStock: true }, limit: 0 } ]
-                }
-                """;
+                    {
+                        delete: "orders",
+                        deletes: [ { q: { status: "D" }, limit: 1 }, { q: { outOfStock: true }, limit: 0 } ]
+                    }
+                    """;
 
             // when && then
             var sqlException = assertThrows(SQLException.class, () -> mongoStatement.executeUpdate(mql));
@@ -131,25 +131,25 @@ class MongoStatementTests {
         private static Stream<Arguments> getMongoStatementMethodInvocationsImpactedByClosing() {
             var exampleQueryMql =
                     """
-                {
-                  find: "restaurants",
-                  filter: { rating: { $gte: 9 }, cuisine: "italian" },
-                  projection: { name: 1, rating: 1, address: 1 },
-                  sort: { name: 1 },
-                  limit: 5
-                }""";
+                    {
+                      find: "restaurants",
+                      filter: { rating: { $gte: 9 }, cuisine: "italian" },
+                      projection: { name: 1, rating: 1, address: 1 },
+                      sort: { name: 1 },
+                      limit: 5
+                    }""";
             var exampleUpdateMql =
                     """
-                {
-                  update: "members",
-                  updates: [
                     {
-                      q: {},
-                      u: { $inc: { points: 1 } },
-                      multi: true
-                    }
-                  ]
-                }""";
+                      update: "members",
+                      updates: [
+                        {
+                          q: {},
+                          u: { $inc: { points: 1 } },
+                          multi: true
+                        }
+                      ]
+                    }""";
             return Map.<String, StatementMethodInvocation>ofEntries(
                             Map.entry("executeQuery(String)", stmt -> stmt.executeQuery(exampleQueryMql)),
                             Map.entry("executeUpdate(String)", stmt -> stmt.executeUpdate(exampleUpdateMql)),


### PR DESCRIPTION
The existing formatter does not catch multiline string indentation inconsistencies ([example](https://github.com/mongodb/mongo-hibernate/blob/cd5bdba521ac688af8a6a757f59d3cfd74cb07f8/src/integrationTest/java/com/mongodb/hibernate/jdbc/MongoStatementIntegrationTests.java#L79-L92)). These show up a fair bit in tests.