### PR TITLE
minor improvements

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -82,7 +82,7 @@ spotless {
         // due to the bug: https://github.com/diffplug/spotless/issues/532
         licenseHeaderFile("spotless.license.java") // contains '$YEAR' placeholder
 
-        targetExclude("{${layout.buildDirectory}}/generated/sources/buildConfig/**/*.java")
+        targetExclude("${layout.buildDirectory.get().asFile.name}/generated/sources/buildConfig/**/*.java")
 
         val formatter = MultilineFormatter()
         addStep(

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,8 +16,8 @@
 
 import com.diffplug.spotless.FormatterFunc
 import com.diffplug.spotless.FormatterStep
-import net.ltgt.gradle.errorprone.errorprone
 import java.io.Serializable
+import net.ltgt.gradle.errorprone.errorprone
 
 version = "1.0.0-SNAPSHOT"
 
@@ -28,19 +28,11 @@ plugins {
     alias(libs.plugins.buildconfig)
 }
 
-repositories {
-    mavenCentral()
-}
+repositories { mavenCentral() }
 
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(17)
-    }
-}
+java { toolchain { languageVersion = JavaLanguageVersion.of(17) } }
 
-tasks.named<Test>("test") {
-    useJUnitPlatform()
-}
+tasks.named<Test>("test") { useJUnitPlatform() }
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // Integration Tests
@@ -52,27 +44,24 @@ sourceSets {
     }
 }
 
-val integrationTestImplementation by configurations.getting {
-    extendsFrom(configurations.implementation.get())
-}
+val integrationTestImplementation by configurations.getting { extendsFrom(configurations.implementation.get()) }
 val integrationTestRuntimeOnly: Configuration by configurations.getting
 
 configurations["integrationTestRuntimeOnly"].extendsFrom(configurations.runtimeOnly.get())
 
-val integrationTest = task<Test>("integrationTest") {
-    description = "Runs integration tests."
-    group = "verification"
+val integrationTest =
+    task<Test>("integrationTest") {
+        description = "Runs integration tests requiring external MongoDB deployment"
+        group = "verification"
 
-    testClassesDirs = sourceSets["integrationTest"].output.classesDirs
-    classpath = sourceSets["integrationTest"].runtimeClasspath
-    shouldRunAfter("test")
+        testClassesDirs = sourceSets["integrationTest"].output.classesDirs
+        classpath = sourceSets["integrationTest"].runtimeClasspath
+        shouldRunAfter("test")
 
-    useJUnitPlatform()
+        useJUnitPlatform()
 
-    testLogging {
-        events("passed")
+        testLogging { events("passed") }
     }
-}
 
 tasks.check { dependsOn(integrationTest) }
 
@@ -93,20 +82,26 @@ spotless {
         // due to the bug: https://github.com/diffplug/spotless/issues/532
         licenseHeaderFile("spotless.license.java") // contains '$YEAR' placeholder
 
-        targetExclude("**/generated/**/*.java")
+        targetExclude("{${layout.buildDirectory}}/generated/sources/buildConfig/**/*.java")
 
         val formatter = MultilineFormatter()
-        addStep(FormatterStep.create(
-            "multilineFormatter",
-            object : Serializable {},
-            { _: Any? -> FormatterFunc { input: String -> formatter.format(input) } }
-        ))
+        addStep(
+            FormatterStep.create(
+                "multilineFormatter",
+                object : Serializable {},
+                { _: Any? -> FormatterFunc { input: String -> formatter.format(input) } }))
+    }
+
+    kotlinGradle {
+        ktfmt(libs.versions.ktfmt.get()).configure {
+            it.setMaxWidth(120)
+            it.setBlockIndent(4)
+            it.setContinuationIndent(4)
+        }
     }
 }
 
-/**
- * Format multiline strings to match the initial """ indentation level
- */
+/** Format multiline strings to match the initial """ indentation level */
 class MultilineFormatter : Serializable {
     fun format(content: String): String {
         val tripleQuote = "\"\"\""
@@ -130,13 +125,13 @@ class MultilineFormatter : Serializable {
                 multilineStringLines.add(multilineStringLine)
                 if (multilineStringLine.contains(tripleQuote)) break
             }
-            val minIndent = multilineStringLines.filter { it.isNotBlank() }
-                .map { l -> l.indexOfFirst { ch -> !ch.isWhitespace() }.takeIf { it >= 0 } ?: line.length }
-                .minOrNull() ?: 0
+            val minIndent =
+                multilineStringLines
+                    .filter { it.isNotBlank() }
+                    .map { l -> l.indexOfFirst { ch -> !ch.isWhitespace() }.takeIf { it >= 0 } ?: line.length }
+                    .minOrNull() ?: 0
             multilineStringLines.forEach { blockLine ->
-                result.append(" ".repeat(baseIndent))
-                    .append(blockLine.drop(minIndent))
-                    .append("\n")
+                result.append(" ".repeat(baseIndent)).append(blockLine.drop(minIndent)).append("\n")
             }
         }
         return result.toString()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -82,7 +82,7 @@ spotless {
         // due to the bug: https://github.com/diffplug/spotless/issues/532
         licenseHeaderFile("spotless.license.java") // contains '$YEAR' placeholder
 
-        targetExclude("${layout.buildDirectory.get().asFile.name}/generated/sources/buildConfig/**/*.java")
+        targetExclude("${layout.buildDirectory.get().asFile.name}/generated/**/*.java")
 
         val formatter = MultilineFormatter()
         addStep(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,6 +5,7 @@
 junit-jupiter = "5.11.4"
 spotless = "7.0.2"
 palantir = "2.50.0"
+ktfmt = "0.54"
 errorprone = "4.1.0"
 google-errorprone-core = "2.36.0"
 nullaway = "0.12.3"

--- a/src/integrationTest/java/com/mongodb/hibernate/jdbc/MongoPreparedStatementIntegrationTests.java
+++ b/src/integrationTest/java/com/mongodb/hibernate/jdbc/MongoPreparedStatementIntegrationTests.java
@@ -18,10 +18,10 @@ package com.mongodb.hibernate.jdbc;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import com.mongodb.client.model.Sorts;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
 import java.util.function.Function;
 import org.bson.BsonDocument;
@@ -202,8 +202,7 @@ class MongoPreparedStatementIntegrationTests {
                             connection.commit();
                         }
                     }
-                    var realDocuments = pstmt
-                            .getMongoDatabase()
+                    var realDocuments = pstmt.getMongoDatabase()
                             .getCollection("books", BsonDocument.class)
                             .find()
                             .sort(Sorts.ascending("_id"))

--- a/src/integrationTest/java/com/mongodb/hibernate/jdbc/MongoPreparedStatementIntegrationTests.java
+++ b/src/integrationTest/java/com/mongodb/hibernate/jdbc/MongoPreparedStatementIntegrationTests.java
@@ -206,10 +206,8 @@ class MongoPreparedStatementIntegrationTests {
                             .getMongoDatabase()
                             .getCollection("books", BsonDocument.class)
                             .find()
-                            .into(new ArrayList<>())
-                            .stream()
-                            .sorted(Comparator.comparing(doc -> doc.getInt32("_id")))
-                            .toList();
+                            .sort(Sorts.ascending("_id"))
+                            .into(new ArrayList<>());
                     assertEquals(expectedDocuments, realDocuments);
                 }
             });

--- a/src/integrationTest/java/com/mongodb/hibernate/jdbc/MongoStatementIntegrationTests.java
+++ b/src/integrationTest/java/com/mongodb/hibernate/jdbc/MongoStatementIntegrationTests.java
@@ -249,10 +249,8 @@ class MongoStatementIntegrationTests {
                             .getMongoDatabase()
                             .getCollection("books", BsonDocument.class)
                             .find()
-                            .into(new ArrayList<>())
-                            .stream()
-                            .sorted(Comparator.comparing(doc -> doc.getInt32("_id")))
-                            .toList();
+                            .sort(Sorts.ascending("_id"))
+                            .into(new ArrayList<>());
                     assertEquals(expectedDocuments, realDocuments);
                 }
             });

--- a/src/integrationTest/java/com/mongodb/hibernate/jdbc/MongoStatementIntegrationTests.java
+++ b/src/integrationTest/java/com/mongodb/hibernate/jdbc/MongoStatementIntegrationTests.java
@@ -18,8 +18,9 @@ package com.mongodb.hibernate.jdbc;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.util.HashSet;
-import java.util.Set;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
 import org.bson.BsonDocument;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
@@ -109,7 +110,7 @@ class MongoStatementIntegrationTests {
         @ParameterizedTest
         @ValueSource(booleans = {true, false})
         void testInsert(boolean autoCommit) {
-            var expectedDocs = Set.of(
+            var expectedDocs = List.of(
                     BsonDocument.parse(
                             """
                             {
@@ -158,7 +159,7 @@ class MongoStatementIntegrationTests {
                             }
                         ]
                     }""";
-            var expectedDocs = Set.of(
+            var expectedDocs = List.of(
                     BsonDocument.parse(
                             """
                             {
@@ -204,7 +205,7 @@ class MongoStatementIntegrationTests {
                             }
                         ]
                     }""";
-            var expectedDocs = Set.of(
+            var expectedDocs = List.of(
                     BsonDocument.parse(
                             """
                             {
@@ -233,7 +234,7 @@ class MongoStatementIntegrationTests {
         }
 
         private void assertExecuteUpdate(
-                String mql, boolean autoCommit, int expectedRowCount, Set<? extends BsonDocument> expectedDocuments) {
+                String mql, boolean autoCommit, int expectedRowCount, List<? extends BsonDocument> expectedDocuments) {
             session.doWork(connection -> {
                 connection.setAutoCommit(autoCommit);
                 try (var stmt = (MongoStatement) connection.createStatement()) {
@@ -244,10 +245,14 @@ class MongoStatementIntegrationTests {
                             connection.commit();
                         }
                     }
-                    var realDocuments = stmt.getMongoDatabase()
+                    var realDocuments = stmt
+                            .getMongoDatabase()
                             .getCollection("books", BsonDocument.class)
                             .find()
-                            .into(new HashSet<>());
+                            .into(new ArrayList<>())
+                            .stream()
+                            .sorted(Comparator.comparing(doc -> doc.getInt32("_id")))
+                            .toList();
                     assertEquals(expectedDocuments, realDocuments);
                 }
             });

--- a/src/integrationTest/java/com/mongodb/hibernate/jdbc/MongoStatementIntegrationTests.java
+++ b/src/integrationTest/java/com/mongodb/hibernate/jdbc/MongoStatementIntegrationTests.java
@@ -18,8 +18,8 @@ package com.mongodb.hibernate.jdbc;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import com.mongodb.client.model.Sorts;
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
 import org.bson.BsonDocument;
 import org.hibernate.Session;
@@ -245,8 +245,7 @@ class MongoStatementIntegrationTests {
                             connection.commit();
                         }
                     }
-                    var realDocuments = stmt
-                            .getMongoDatabase()
+                    var realDocuments = stmt.getMongoDatabase()
                             .getCollection("books", BsonDocument.class)
                             .find()
                             .sort(Sorts.ascending("_id"))


### PR DESCRIPTION
1. thanks to Ross's sharing today, `ktfmt` plugin is used in Spotless to make the `build.gradle.kts` looks spotless
2. improve the document collection comparison in the two integration testing cases based on `List<BsonDocument>` rather than `Set<BsonDocument>` so the diff is decipherable once testing fails.