### PR TITLE
Use non-existent host name in unit tests

### DIFF
--- a/src/test/java/com/mongodb/hibernate/jdbc/MongoConnectionProviderTests.java
+++ b/src/test/java/com/mongodb/hibernate/jdbc/MongoConnectionProviderTests.java
@@ -63,7 +63,7 @@ class MongoConnectionProviderTests {
 
             // given
 
-            var hostInConnectionString = customizerAppliesConnectionString ? "my-host" : "localhost";
+            var hostInConnectionString = "host";
             var connectionString = "mongodb://" + hostInConnectionString;
 
             var clusterListener = new TestClusterListener();
@@ -151,9 +151,7 @@ class MongoConnectionProviderTests {
     @Test
     void testMongoDriverInformationPopulated() {
         verifyMongoClient(
-                null,
-                "mongodb://localhost/db",
-                MongoConnectionProviderTests.this::verifyMongoDriverInformationPopulated);
+                null, "mongodb://host/db", MongoConnectionProviderTests.this::verifyMongoDriverInformationPopulated);
     }
 
     private void verifyMongoDriverInformationPopulated(MongoClient mongoClient) {

--- a/src/test/resources/hibernate.properties
+++ b/src/test/resources/hibernate.properties
@@ -1,4 +1,4 @@
-jakarta.persistence.jdbc.url=mongodb://localhost/mongo-hibernate-test?directConnection=false
+jakarta.persistence.jdbc.url=mongodb://host/mongo-hibernate-test?directConnection=false
 hibernate.dialect=com.mongodb.hibernate.dialect.MongoDialect
 hibernate.connection.provider_class=com.mongodb.hibernate.jdbc.MongoConnectionProvider
 hibernate.boot.allow_jdbc_metadata_access=false


### PR DESCRIPTION
This way we cannot accidentally write a unit test that needs a successful connection to a MongoDB deployment.