### PR TITLE
Name integration tests consistently

### DIFF
--- a/src/integrationTest/java/com/mongodb/hibernate/BasicInsertionIntegrationTests.java
+++ b/src/integrationTest/java/com/mongodb/hibernate/BasicInsertionIntegrationTests.java
@@ -40,8 +40,12 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 @SessionFactory(exportSchema = false)
-@DomainModel(annotatedClasses = {BasicInsertionTests.Book.class, BasicInsertionTests.BookWithEmbeddedField.class})
-class BasicInsertionTests {
+@DomainModel(
+        annotatedClasses = {
+            BasicInsertionIntegrationTests.Book.class,
+            BasicInsertionIntegrationTests.BookWithEmbeddedField.class
+        })
+class BasicInsertionIntegrationTests {
 
     @BeforeEach
     void setUp() {

--- a/src/integrationTest/java/com/mongodb/hibernate/SessionFactoryIntegrationTests.java
+++ b/src/integrationTest/java/com/mongodb/hibernate/SessionFactoryIntegrationTests.java
@@ -29,7 +29,7 @@ import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.service.spi.ServiceException;
 import org.junit.jupiter.api.Test;
 
-class SessionFactoryTests {
+class SessionFactoryIntegrationTests {
 
     @Test
     void testSuccess() {

--- a/src/integrationTest/java/com/mongodb/hibernate/SessionIntegrationTests.java
+++ b/src/integrationTest/java/com/mongodb/hibernate/SessionIntegrationTests.java
@@ -27,7 +27,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-class SessionTests {
+class SessionIntegrationTests {
 
     private static SessionFactory sessionFactory;
 

--- a/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/AstLiteralValue.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/AstLiteralValue.java
@@ -28,7 +28,7 @@ public record AstLiteralValue(BsonValue literalValue) implements AstValue {
             EncoderContext.builder().build();
 
     @Override
-    public void render(final BsonWriter writer) {
+    public void render(BsonWriter writer) {
         BSON_VALUE_CODEC.encode(writer, literalValue, DEFAULT_CONTEXT);
     }
 }


### PR DESCRIPTION
Some of them have suffix `IntegrationTests`, while others have just `Tests`. Let's make that naming consistent.