### PR TITLE
minor improvements to gradle usage

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,6 +23,7 @@ import org.gradle.api.tasks.testing.logging.TestLogEvent
 version = "1.0.0-SNAPSHOT"
 
 plugins {
+    eclipse
     idea
     `java-library`
     alias(libs.plugins.spotless)
@@ -170,23 +171,20 @@ buildConfig {
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // Dependencies
 
-dependencies {
-    testImplementation(libs.junit.jupiter)
-    testImplementation(libs.assertj)
-    testImplementation(libs.logback.classic)
-    testImplementation(libs.mockito.junit.jupiter)
-    testRuntimeOnly(libs.junit.platform.launcher)
+listOf(libs.junit.jupiter, libs.assertj, libs.logback.classic).forEach {
+    dependencies {
+        testImplementation(it)
+        integrationTestImplementation(it)
+    }
+}
 
-    integrationTestImplementation(libs.junit.jupiter)
-    integrationTestImplementation(libs.assertj)
-    integrationTestImplementation(libs.logback.classic)
+dependencies {
+    testImplementation(libs.mockito.junit.jupiter)
 
     @Suppress("UnstableApiUsage")
     integrationTestImplementation(libs.hibernate.testing) {
         exclude(group = "org.apache.logging.log4j", module = "log4j-core")
     }
-
-    integrationTestRuntimeOnly(libs.junit.platform.launcher)
 
     api(libs.jspecify)
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -171,20 +171,20 @@ buildConfig {
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // Dependencies
 
-listOf(libs.junit.jupiter, libs.assertj, libs.logback.classic).forEach {
-    dependencies {
+dependencies {
+    listOf(libs.junit.jupiter, libs.assertj, libs.logback.classic).forEach {
         testImplementation(it)
         integrationTestImplementation(it)
     }
-}
 
-dependencies {
     testImplementation(libs.mockito.junit.jupiter)
+    testRuntimeOnly(libs.junit.platform.launcher)
 
     @Suppress("UnstableApiUsage")
     integrationTestImplementation(libs.hibernate.testing) {
         exclude(group = "org.apache.logging.log4j", module = "log4j-core")
     }
+    integrationTestRuntimeOnly(libs.junit.platform.launcher)
 
     api(libs.jspecify)
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,7 +20,6 @@ buildconfig = "5.5.1"
 
 [libraries]
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit-jupiter" }
-junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher" }
 assertj = { module = "org.assertj:assertj-core", version.ref = "assertj" }
 nullaway = { module = "com.uber.nullaway:nullaway", version.ref = "nullaway" }
 jspecify = { module = "org.jspecify:jspecify", version.ref = "jspecify" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,6 +20,7 @@ buildconfig = "5.5.1"
 
 [libraries]
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit-jupiter" }
+junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher" }
 assertj = { module = "org.assertj:assertj-core", version.ref = "assertj" }
 nullaway = { module = "com.uber.nullaway:nullaway", version.ref = "nullaway" }
 jspecify = { module = "org.jspecify:jspecify", version.ref = "jspecify" }


### PR DESCRIPTION
- add `eclipse` plugin usage (if `idea` has been used)
- remove unnecessary junit launcher dependency (`junit-jupiter` is a bom dependency which will include it transitively)
- eliminate dependencies duplication across `test` and `integrationTest` tasks