### PR TITLE
simplify testing code by use of @AutoClose annotation from JUnit 5

### DIFF
--- a/src/integrationTest/java/com/mongodb/hibernate/JakartaPersistenceBootstrappingIntegrationTests.java
+++ b/src/integrationTest/java/com/mongodb/hibernate/JakartaPersistenceBootstrappingIntegrationTests.java
@@ -28,14 +28,19 @@ import jakarta.persistence.EntityManagerFactory;
 import jakarta.persistence.Id;
 import jakarta.persistence.Persistence;
 import jakarta.persistence.Table;
-import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class JakartaPersistenceBootstrappingIntegrationTests {
-    private static EntityManagerFactory entityManagerFactory;
+
     private static MongoConfiguration config;
+
+    @AutoClose
+    private static EntityManagerFactory entityManagerFactory;
+
+    @AutoClose
     private static MongoClient mongoClient;
 
     @BeforeAll
@@ -48,13 +53,6 @@ class JakartaPersistenceBootstrappingIntegrationTests {
     @BeforeEach
     void beforeEach() {
         mongoClient.getDatabase(config.databaseName()).drop();
-    }
-
-    @AfterAll
-    @SuppressWarnings("try")
-    static void afterAll() {
-        try (var closed1 = entityManagerFactory;
-                var closed2 = mongoClient) {}
     }
 
     @Test

--- a/src/integrationTest/java/com/mongodb/hibernate/SessionIntegrationTests.java
+++ b/src/integrationTest/java/com/mongodb/hibernate/SessionIntegrationTests.java
@@ -21,16 +21,17 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.cfg.Configuration;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class SessionIntegrationTests {
 
+    @AutoClose
     private static SessionFactory sessionFactory;
 
+    @AutoClose
     private Session session;
 
     @BeforeAll
@@ -38,23 +39,9 @@ class SessionIntegrationTests {
         sessionFactory = new Configuration().buildSessionFactory();
     }
 
-    @AfterAll
-    static void afterAll() {
-        if (sessionFactory != null) {
-            sessionFactory.close();
-        }
-    }
-
     @BeforeEach
     void beforeEach() {
         session = sessionFactory.openSession();
-    }
-
-    @AfterEach
-    void afterEach() {
-        if (session != null) {
-            session.close();
-        }
     }
 
     @Test

--- a/src/integrationTest/java/com/mongodb/hibernate/jdbc/MongoPreparedStatementIntegrationTests.java
+++ b/src/integrationTest/java/com/mongodb/hibernate/jdbc/MongoPreparedStatementIntegrationTests.java
@@ -28,8 +28,7 @@ import org.bson.BsonDocument;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.cfg.Configuration;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -38,8 +37,10 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 class MongoPreparedStatementIntegrationTests {
 
+    @AutoClose
     private static SessionFactory sessionFactory;
 
+    @AutoClose
     private Session session;
 
     @BeforeAll
@@ -47,23 +48,9 @@ class MongoPreparedStatementIntegrationTests {
         sessionFactory = new Configuration().buildSessionFactory();
     }
 
-    @AfterAll
-    static void afterAll() {
-        if (sessionFactory != null) {
-            sessionFactory.close();
-        }
-    }
-
     @BeforeEach
     void beforeEach() {
         session = sessionFactory.openSession();
-    }
-
-    @AfterEach
-    void afterEach() {
-        if (session != null) {
-            session.close();
-        }
     }
 
     @Nested

--- a/src/integrationTest/java/com/mongodb/hibernate/jdbc/MongoStatementIntegrationTests.java
+++ b/src/integrationTest/java/com/mongodb/hibernate/jdbc/MongoStatementIntegrationTests.java
@@ -25,8 +25,7 @@ import org.bson.BsonDocument;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.cfg.Configuration;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -35,8 +34,10 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 class MongoStatementIntegrationTests {
 
+    @AutoClose
     private static SessionFactory sessionFactory;
 
+    @AutoClose
     private Session session;
 
     @BeforeAll
@@ -44,23 +45,9 @@ class MongoStatementIntegrationTests {
         sessionFactory = new Configuration().buildSessionFactory();
     }
 
-    @AfterAll
-    static void afterAll() {
-        if (sessionFactory != null) {
-            sessionFactory.close();
-        }
-    }
-
     @BeforeEach
     void beforeEach() {
         session = sessionFactory.openSession();
-    }
-
-    @AfterEach
-    void afterEach() {
-        if (session != null) {
-            session.close();
-        }
     }
 
     @Nested

--- a/src/test/java/com/mongodb/hibernate/jdbc/MongoConnectionProviderTests.java
+++ b/src/test/java/com/mongodb/hibernate/jdbc/MongoConnectionProviderTests.java
@@ -29,7 +29,7 @@ import com.mongodb.hibernate.internal.cfg.MongoConfiguration;
 import com.mongodb.hibernate.internal.service.StandardServiceRegistryScopedState;
 import java.sql.SQLException;
 import org.hibernate.service.spi.ServiceRegistryImplementor;
-import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -42,18 +42,12 @@ class MongoConnectionProviderTests {
     @Mock(mockMaker = MockMakers.PROXY)
     private ServiceRegistryImplementor serviceRegistry;
 
+    @AutoClose("stop")
     private MongoConnectionProvider connectionProvider;
 
     @BeforeEach
     void beforeEach() {
         connectionProvider = createMongoConnectionProvider();
-    }
-
-    @AfterEach
-    void afterEach() {
-        if (connectionProvider != null) {
-            connectionProvider.stop();
-        }
     }
 
     @Test

--- a/src/test/java/com/mongodb/hibernate/jdbc/MongoPreparedStatementTests.java
+++ b/src/test/java/com/mongodb/hibernate/jdbc/MongoPreparedStatementTests.java
@@ -41,7 +41,7 @@ import java.util.Map;
 import java.util.stream.Stream;
 import org.bson.BsonDocument;
 import org.bson.Document;
-import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -230,16 +230,12 @@ class MongoPreparedStatementTests {
     @Nested
     class ParameterIndexCheckingTests {
 
+        @AutoClose
         private MongoPreparedStatement preparedStatement;
 
         @BeforeEach
         void beforeEach() throws SQLSyntaxErrorException {
             preparedStatement = createMongoPreparedStatement(EXAMPLE_MQL);
-        }
-
-        @AfterEach
-        void afterEach() {
-            preparedStatement.close();
         }
 
         @ParameterizedTest(name = "SQLException is thrown when \"{0}\" is called with parameter index being too low")


### PR DESCRIPTION
seems an improvement to avoid tedious and error-prone closing code logic. Applies to both static and non-static fields. I tested locally by setting breakpoint in debug mode and found it is working as expected.