### PR TITLE
Remove `MongoStatement.getMongoDatabase`

### DIFF
--- a/src/integrationTest/java/com/mongodb/hibernate/jdbc/MongoPreparedStatementIntegrationTests.java
+++ b/src/integrationTest/java/com/mongodb/hibernate/jdbc/MongoPreparedStatementIntegrationTests.java
@@ -200,9 +200,9 @@ class MongoPreparedStatementIntegrationTests {
                             connection.commit();
                         }
                     }
-                    var realDocuments =
+                    var actualDocuments =
                             mongoCollection.find().sort(Sorts.ascending("_id")).into(new ArrayList<>());
-                    assertEquals(expectedDocuments, realDocuments);
+                    assertEquals(expectedDocuments, actualDocuments);
                 }
             });
         }

--- a/src/integrationTest/java/com/mongodb/hibernate/jdbc/MongoStatementIntegrationTests.java
+++ b/src/integrationTest/java/com/mongodb/hibernate/jdbc/MongoStatementIntegrationTests.java
@@ -242,9 +242,9 @@ class MongoStatementIntegrationTests {
                             connection.commit();
                         }
                     }
-                    var realDocuments =
+                    var actualDocuments =
                             mongoCollection.find().sort(Sorts.ascending("_id")).into(new ArrayList<>());
-                    assertEquals(expectedDocuments, realDocuments);
+                    assertEquals(expectedDocuments, actualDocuments);
                 }
             });
         }

--- a/src/integrationTest/java/com/mongodb/hibernate/jdbc/MongoStatementIntegrationTests.java
+++ b/src/integrationTest/java/com/mongodb/hibernate/jdbc/MongoStatementIntegrationTests.java
@@ -18,7 +18,11 @@ package com.mongodb.hibernate.jdbc;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+import com.mongodb.client.MongoCollection;
 import com.mongodb.client.model.Sorts;
+import com.mongodb.hibernate.internal.cfg.MongoConfigurationBuilder;
 import java.util.ArrayList;
 import java.util.List;
 import org.bson.BsonDocument;
@@ -38,11 +42,19 @@ class MongoStatementIntegrationTests {
     private static SessionFactory sessionFactory;
 
     @AutoClose
+    private static MongoClient mongoClient;
+
+    private static MongoCollection<BsonDocument> mongoCollection;
+
+    @AutoClose
     private Session session;
 
     @BeforeAll
     static void beforeAll() {
         sessionFactory = new Configuration().buildSessionFactory();
+        var config = new MongoConfigurationBuilder(sessionFactory.getProperties()).build();
+        mongoClient = MongoClients.create(config.mongoClientSettings());
+        mongoCollection = mongoClient.getDatabase(config.databaseName()).getCollection("books", BsonDocument.class);
     }
 
     @BeforeEach
@@ -230,11 +242,8 @@ class MongoStatementIntegrationTests {
                             connection.commit();
                         }
                     }
-                    var realDocuments = stmt.getMongoDatabase()
-                            .getCollection("books", BsonDocument.class)
-                            .find()
-                            .sort(Sorts.ascending("_id"))
-                            .into(new ArrayList<>());
+                    var realDocuments =
+                            mongoCollection.find().sort(Sorts.ascending("_id")).into(new ArrayList<>());
                     assertEquals(expectedDocuments, realDocuments);
                 }
             });

--- a/src/main/java/com/mongodb/hibernate/jdbc/MongoStatement.java
+++ b/src/main/java/com/mongodb/hibernate/jdbc/MongoStatement.java
@@ -16,13 +16,11 @@
 
 package com.mongodb.hibernate.jdbc;
 
-import static com.mongodb.hibernate.internal.VisibleForTesting.AccessModifier.PRIVATE;
 import static java.lang.String.format;
 
 import com.mongodb.client.ClientSession;
 import com.mongodb.client.MongoDatabase;
 import com.mongodb.hibernate.internal.FeatureNotSupportedException;
-import com.mongodb.hibernate.internal.VisibleForTesting;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -199,11 +197,6 @@ class MongoStatement implements StatementAdapter {
         if (closed) {
             throw new SQLException(format("%s has been closed", getClass().getSimpleName()));
         }
-    }
-
-    @VisibleForTesting(otherwise = PRIVATE)
-    MongoDatabase getMongoDatabase() {
-        return mongoDatabase;
     }
 
     static BsonDocument parse(String mql) throws SQLSyntaxErrorException {

--- a/src/test/java/com/mongodb/hibernate/internal/translate/AstVisitorValueHolderTests.java
+++ b/src/test/java/com/mongodb/hibernate/internal/translate/AstVisitorValueHolderTests.java
@@ -81,7 +81,7 @@ class AstVisitorValueHolderTests {
     }
 
     @Test
-    @DisplayName("Exception is thrown when holder is expecting a descriptor different from that of real data")
+    @DisplayName("Exception is thrown when holder is expecting a descriptor different from that of actual data")
     void testHolderExpectingDifferentDescriptor() {
 
         Runnable valueYielder =


### PR DESCRIPTION
Unfortunately, we can't get rid of `MongoConnectionProvider.getMongoClient`.