### PR TITLE
make use of `@InjectService` to simplify MongoConnectionProvider

### DIFF
--- a/src/main/java/com/mongodb/hibernate/jdbc/MongoConnectionProvider.java
+++ b/src/main/java/com/mongodb/hibernate/jdbc/MongoConnectionProvider.java
@@ -36,8 +36,7 @@ import java.sql.SQLException;
 import org.hibernate.HibernateException;
 import org.hibernate.engine.jdbc.connections.spi.ConnectionProvider;
 import org.hibernate.service.UnknownUnwrapTypeException;
-import org.hibernate.service.spi.ServiceRegistryAwareService;
-import org.hibernate.service.spi.ServiceRegistryImplementor;
+import org.hibernate.service.spi.InjectService;
 import org.hibernate.service.spi.Stoppable;
 import org.jspecify.annotations.Nullable;
 
@@ -53,7 +52,7 @@ import org.jspecify.annotations.Nullable;
  * configuration property, and {@linkplain MongoConnectionProvider#getConnection() provides} {@link Connection}s with
  * {@linkplain Connection#getAutoCommit() auto-commit} enabled.
  */
-public final class MongoConnectionProvider implements ConnectionProvider, Stoppable, ServiceRegistryAwareService {
+public final class MongoConnectionProvider implements ConnectionProvider, Stoppable {
     @Serial
     private static final long serialVersionUID = 1L;
 
@@ -101,10 +100,9 @@ public final class MongoConnectionProvider implements ConnectionProvider, Stoppa
         }
     }
 
-    @Override
-    public void injectServices(ServiceRegistryImplementor serviceRegistry) {
-        var standardServiceRegistryScopedState =
-                serviceRegistry.requireService(StandardServiceRegistryScopedState.class);
+    @InjectService
+    public void injectStandardServiceRegistryScopedState(
+            StandardServiceRegistryScopedState standardServiceRegistryScopedState) {
         this.standardServiceRegistryScopedState = standardServiceRegistryScopedState;
         var mongoClientSettings =
                 standardServiceRegistryScopedState.getConfiguration().mongoClientSettings();

--- a/src/test/java/com/mongodb/hibernate/jdbc/MongoConnectionProviderTests.java
+++ b/src/test/java/com/mongodb/hibernate/jdbc/MongoConnectionProviderTests.java
@@ -18,8 +18,6 @@ package com.mongodb.hibernate.jdbc;
 
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doReturn;
 
 import com.mongodb.ConnectionString;
 import com.mongodb.MongoClientSettings;
@@ -28,19 +26,14 @@ import com.mongodb.hibernate.BuildConfig;
 import com.mongodb.hibernate.internal.cfg.MongoConfiguration;
 import com.mongodb.hibernate.internal.service.StandardServiceRegistryScopedState;
 import java.sql.SQLException;
-import org.hibernate.service.spi.ServiceRegistryImplementor;
 import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.MockMakers;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class MongoConnectionProviderTests {
-    @Mock(mockMaker = MockMakers.PROXY)
-    private ServiceRegistryImplementor serviceRegistry;
 
     @AutoClose("stop")
     private MongoConnectionProvider connectionProvider;
@@ -73,11 +66,8 @@ class MongoConnectionProviderTests {
                         .build(),
                 "db");
         var standardServiceRegistryScopedState = new StandardServiceRegistryScopedState(mongoConfiguration);
-        doReturn(standardServiceRegistryScopedState)
-                .when(serviceRegistry)
-                .requireService(eq(StandardServiceRegistryScopedState.class));
         var result = new MongoConnectionProvider();
-        result.injectServices(serviceRegistry);
+        result.injectStandardServiceRegistryScopedState(standardServiceRegistryScopedState);
         return result;
     }
 }


### PR DESCRIPTION
as per Hibernate integration doc, there are two ways to inject service (https://docs.jboss.org/hibernate/orm/6.6/integrationguide/html_single/Hibernate_Integration_Guide.html#services-dependencies). Previously we use the second way, but seems the first `@InjectService` is simpler.

Unit testing case is also simplified and we can get rid of that weird mock.