### PR TITLE
simplify .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,60 +1,21 @@
 *~
-.#*
-.git
-*#
 
-# os x stuff
-*Thumbs.db*
-*.DS_Store
+# Mac
+.DS_Store
 
-# Build artifacts
-build/
-target/
-out/
-mongo*.jar
+# Eclipse
+/.classpath
+/.project
+/.settings
+/bin/
 
-# Eclipse files
-.classpath
-.project
-.settings
+# Intellij IDEA
+/.idea/
+/*.ipr
+/*.iws
+/*.iml
+/out/
 
-# Intellij IDEA files
-*.ipr
-*.iws
-*.iml
-.idea
-
-workspace.xml
-atlassian-ide-plugin.xml
-
-# gradle
-.gradle/
-
-# code review
-codereview.rc
-
-# evergreen
-expansion.yml
-
-# local settings
-gradle.properties
-local.properties
-
-# jenv
-.java-version
-
-#sdkman
-.sdkmanrc
-
-# mongocryptd
-mongocryptd*.pid
-
-# shell scripts
-*.sh
-!.evergreen/*.sh
-
-# security-sensitive files
-*.gpg
-
-# bin build directories
-bin/
+# Gradle
+/.gradle/
+/build/


### PR DESCRIPTION
Our .gitignore was mainly copied from the counterpart of Java driver repo, but it contains many irrelevant stuff. Also, there are many common misuses as well.

By experimenting locally, there are simply two dimentions to consider:

- whether the entry is a file or directory; if the latter, append a `/` suffix
- whether the entry resides at the root folder or any location; if the former, simply  prepend a `/` prefix

Feel free to decline this PR if it is too frivolous (and I agree). 