### PR TITLE
add @DynamicInsert testing case in BasicCrudIntegrationTests

### DIFF
--- a/src/integrationTest/java/com/mongodb/hibernate/JakartaPersistenceBootstrappingIntegrationTests.java
+++ b/src/integrationTest/java/com/mongodb/hibernate/JakartaPersistenceBootstrappingIntegrationTests.java
@@ -43,7 +43,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 class JakartaPersistenceBootstrappingIntegrationTests {
 
     @InjectMongoCollection("items")
-    private static MongoCollection<BsonDocument> collection;
+    private static MongoCollection<BsonDocument> mongoCollection;
 
     @Test
     void smoke(EntityManagerFactoryScope scope) {
@@ -52,7 +52,7 @@ class JakartaPersistenceBootstrappingIntegrationTests {
             item.id = 1;
             em.persist(item);
         });
-        assertThat(collection.find()).containsExactly(BsonDocument.parse("{_id: 1}"));
+        assertThat(mongoCollection.find()).containsExactly(BsonDocument.parse("{_id: 1}"));
     }
 
     @Entity


### PR DESCRIPTION
a tech debt when we have tested `@DynamicUpdate` in the basic update translation PR; also created a new `crud` package to avoid dumping everything into root package. There could be many more integrtation testing classes under `crud` feature in the future.