### PR TITLE
improve MongoStatement#executeUpdate()

### DIFF
--- a/src/main/java/com/mongodb/hibernate/jdbc/MongoStatement.java
+++ b/src/main/java/com/mongodb/hibernate/jdbc/MongoStatement.java
@@ -16,16 +16,33 @@
 
 package com.mongodb.hibernate.jdbc;
 
+import static com.mongodb.hibernate.internal.MongoAssertions.assertNotNull;
+import static com.mongodb.hibernate.internal.MongoAssertions.assertTrue;
 import static java.lang.String.format;
+import static java.util.Collections.singletonList;
 
+import com.mongodb.MongoExecutionTimeoutException;
+import com.mongodb.MongoSocketReadTimeoutException;
+import com.mongodb.MongoSocketWriteTimeoutException;
+import com.mongodb.MongoTimeoutException;
+import com.mongodb.bulk.BulkWriteResult;
 import com.mongodb.client.ClientSession;
 import com.mongodb.client.MongoDatabase;
+import com.mongodb.client.model.DeleteManyModel;
+import com.mongodb.client.model.DeleteOneModel;
+import com.mongodb.client.model.InsertOneModel;
+import com.mongodb.client.model.UpdateManyModel;
+import com.mongodb.client.model.UpdateOneModel;
+import com.mongodb.client.model.WriteModel;
 import com.mongodb.hibernate.internal.FeatureNotSupportedException;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.SQLSyntaxErrorException;
+import java.sql.SQLTimeoutException;
 import java.sql.SQLWarning;
+import java.util.ArrayList;
+import java.util.List;
 import org.bson.BsonDocument;
 import org.jspecify.annotations.Nullable;
 
@@ -57,11 +74,74 @@ class MongoStatement implements StatementAdapter {
     }
 
     int executeUpdateCommand(BsonDocument command) throws SQLException {
+        var bulkWriteResult = executeBulkWrite(singletonList(command));
+        return switch (command.getFirstKey()) {
+            case "insert" -> bulkWriteResult.getInsertedCount();
+            case "update" -> bulkWriteResult.getModifiedCount();
+            case "delete" -> bulkWriteResult.getDeletedCount();
+            default -> throw new FeatureNotSupportedException("Unsupported command: " + command.getFirstKey());
+        };
+    }
+
+    BulkWriteResult executeBulkWrite(List<? extends BsonDocument> commandBatch) throws SQLException {
         startTransactionIfNeeded();
+
         try {
-            return mongoDatabase.runCommand(clientSession, command).getInteger("n");
-        } catch (Exception e) {
-            throw new SQLException("Failed to execute update command", e);
+            var writeModels = new ArrayList<WriteModel<BsonDocument>>(commandBatch.size());
+
+            var commandName = assertNotNull(commandBatch.get(0).getFirstKey());
+            var collectionName =
+                    assertNotNull(commandBatch.get(0).getString(commandName).getValue());
+
+            for (var command : commandBatch) {
+
+                assertTrue(commandName.equals(command.getFirstKey()));
+                assertTrue(collectionName.equals(command.getString(commandName).getValue()));
+
+                switch (commandName) {
+                    case "insert":
+                        var documents = command.getArray("documents");
+                        for (var document : documents) {
+                            writeModels.add(new InsertOneModel<>((BsonDocument) document));
+                        }
+                        break;
+                    case "update":
+                        var updates = command.getArray("updates").getValues();
+                        for (var update : updates) {
+                            var updateDocument = (BsonDocument) update;
+                            WriteModel<BsonDocument> updateModel =
+                                    !updateDocument.getBoolean("multi").getValue()
+                                            ? new UpdateOneModel<>(
+                                                    updateDocument.getDocument("q"), updateDocument.getDocument("u"))
+                                            : new UpdateManyModel<>(
+                                                    updateDocument.getDocument("q"), updateDocument.getDocument("u"));
+                            writeModels.add(updateModel);
+                        }
+                        break;
+                    case "delete":
+                        var deletes = command.getArray("deletes");
+                        for (var delete : deletes) {
+                            var deleteDocument = (BsonDocument) delete;
+                            writeModels.add(
+                                    deleteDocument.getNumber("limit").intValue() == 1
+                                            ? new DeleteOneModel<>(deleteDocument.getDocument("q"))
+                                            : new DeleteManyModel<>(deleteDocument.getDocument("q")));
+                        }
+                        break;
+                    default:
+                        throw new FeatureNotSupportedException();
+                }
+            }
+            return mongoDatabase
+                    .getCollection(collectionName, BsonDocument.class)
+                    .bulkWrite(clientSession, writeModels);
+        } catch (MongoSocketReadTimeoutException
+                | MongoSocketWriteTimeoutException
+                | MongoTimeoutException
+                | MongoExecutionTimeoutException e) {
+            throw new SQLTimeoutException(e.getMessage(), e);
+        } catch (RuntimeException e) {
+            throw new SQLException("Failed to execute update", e);
         }
     }
 


### PR DESCRIPTION
https://jira.mongodb.org/browse/HIBERNATE-40

to accommodate the future batch processing, bulk write API usage is chosen as the implementation plan as opposed to crud API.