### PR TITLE
introduce jmh gradle usage for local benchmarking purpose

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,6 +29,7 @@ plugins {
     alias(libs.plugins.spotless)
     alias(libs.plugins.errorprone)
     alias(libs.plugins.buildconfig)
+    alias(libs.plugins.jmh)
 }
 
 repositories { mavenCentral() }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,6 +17,7 @@ slf4j-api = "2.0.16"
 logback-classic = "1.5.16"
 mockito = "5.15.2"
 buildconfig = "5.5.1"
+jmh = "0.7.2"
 
 [libraries]
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit-jupiter" }
@@ -36,3 +37,4 @@ mockito-junit-jupiter = { module = "org.mockito:mockito-junit-jupiter", version.
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
 errorprone = { id = "net.ltgt.errorprone", version.ref = "errorprone" }
 buildconfig = { id = "com.github.gmazzo.buildconfig", version.ref = "buildconfig" }
+jmh = { id = "me.champeau.jmh", version.ref = "jmh" }

--- a/src/jmh/java/com/mongodb/hibernate/jdbc/MongoStatementBenchmark.java
+++ b/src/jmh/java/com/mongodb/hibernate/jdbc/MongoStatementBenchmark.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2025-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.hibernate.jdbc;
+
+import org.bson.BsonDocument;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.infra.Blackhole;
+
+@State(Scope.Benchmark)
+public class MongoStatementBenchmark {
+
+    private static final BsonDocument EXAMPLE_PROJECT_STAGE = BsonDocument.parse(
+            """
+            { f1: 1, f2: 1, f3: 1, f4: 1, f5: 1, f6: 1, f7: 1, f8: 1, f9: 1, f10: 1, f11: 1, f12: 1, _id: 0}\
+            """);
+
+    @Benchmark
+    public void getProjectStageFieldNames(Blackhole bh) {
+        var fieldNames = MongoStatement.getFieldNamesFromProjectStage(EXAMPLE_PROJECT_STAGE);
+        bh.consume(fieldNames);
+    }
+}


### PR DESCRIPTION
We have encountered the need to objectively compare implementation alternatives in terms of perf by local benchmarking. JMH is such handy tool. An example benchmark is included.

The current implementation in main is based on stream usage, and its local (on my laptop) is as follows:

```
Benchmark                                           Mode  Cnt        Score        Error  Units
MongoStatementBenchmark.getProjectStageFieldNames  thrpt   25  7436777.432 ± 237277.758  ops/s
```

When I changed it to non-stream alternative, JMH helps provided that the throughput almost doubles:

```
Benchmark                                           Mode  Cnt         Score        Error  Units
MongoStatementBenchmark.getProjectStageFieldNames  thrpt   25  14637872.456 ± 879754.679  ops/s
```

However, changing the `MongoStatementBenchmark.getProjectStageFieldNames()` is out of the scope of this PR for it has other more issues which are more important than the speed doubling. A followup PR might be created to solve the business logic issue later.

There might be issue on IDE integration but that is out of the scope of this PR as well.