### PR TITLE
substitute `SQLFeatureNotSupportedException` for `FeatureNotSupportedException` in jdbc package

### DIFF
--- a/src/main/java/com/mongodb/hibernate/jdbc/MongoConnection.java
+++ b/src/main/java/com/mongodb/hibernate/jdbc/MongoConnection.java
@@ -23,7 +23,6 @@ import com.mongodb.client.ClientSession;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoDatabase;
 import com.mongodb.hibernate.internal.BuildConfig;
-import com.mongodb.hibernate.internal.FeatureNotSupportedException;
 import com.mongodb.hibernate.internal.cfg.MongoConfiguration;
 import java.sql.Array;
 import java.sql.DatabaseMetaData;
@@ -153,13 +152,13 @@ final class MongoConnection implements ConnectionAdapter {
     @Override
     public Array createArrayOf(String typeName, Object[] elements) throws SQLException {
         checkClosed();
-        throw new FeatureNotSupportedException();
+        throw new SQLFeatureNotSupportedException();
     }
 
     @Override
     public Struct createStruct(String typeName, Object[] attributes) throws SQLException {
         checkClosed();
-        throw new FeatureNotSupportedException();
+        throw new SQLFeatureNotSupportedException();
     }
 
     @Override

--- a/src/main/java/com/mongodb/hibernate/jdbc/MongoPreparedStatement.java
+++ b/src/main/java/com/mongodb/hibernate/jdbc/MongoPreparedStatement.java
@@ -21,7 +21,6 @@ import static java.lang.String.format;
 
 import com.mongodb.client.ClientSession;
 import com.mongodb.client.MongoDatabase;
-import com.mongodb.hibernate.internal.FeatureNotSupportedException;
 import java.math.BigDecimal;
 import java.sql.Array;
 import java.sql.Date;
@@ -168,88 +167,88 @@ final class MongoPreparedStatement extends MongoStatement implements PreparedSta
     public void setDate(int parameterIndex, Date x) throws SQLException {
         checkClosed();
         checkParameterIndex(parameterIndex);
-        throw new FeatureNotSupportedException("TODO-HIBERNATE-42 https://jira.mongodb.org/browse/HIBERNATE-42");
+        throw new SQLFeatureNotSupportedException("TODO-HIBERNATE-42 https://jira.mongodb.org/browse/HIBERNATE-42");
     }
 
     @Override
     public void setTime(int parameterIndex, Time x) throws SQLException {
         checkClosed();
         checkParameterIndex(parameterIndex);
-        throw new FeatureNotSupportedException("TODO-HIBERNATE-42 https://jira.mongodb.org/browse/HIBERNATE-42");
+        throw new SQLFeatureNotSupportedException("TODO-HIBERNATE-42 https://jira.mongodb.org/browse/HIBERNATE-42");
     }
 
     @Override
     public void setTimestamp(int parameterIndex, Timestamp x) throws SQLException {
         checkClosed();
         checkParameterIndex(parameterIndex);
-        throw new FeatureNotSupportedException("TODO-HIBERNATE-42 https://jira.mongodb.org/browse/HIBERNATE-42");
+        throw new SQLFeatureNotSupportedException("TODO-HIBERNATE-42 https://jira.mongodb.org/browse/HIBERNATE-42");
     }
 
     @Override
     public void setObject(int parameterIndex, Object x, int targetSqlType) throws SQLException {
         checkClosed();
         checkParameterIndex(parameterIndex);
-        throw new FeatureNotSupportedException("To be implemented in scope of Array / Struct tickets");
+        throw new SQLFeatureNotSupportedException("To be implemented in scope of Array / Struct tickets");
     }
 
     @Override
     public void setObject(int parameterIndex, Object x) throws SQLException {
         checkClosed();
         checkParameterIndex(parameterIndex);
-        throw new FeatureNotSupportedException("To be implemented in scope of Array / Struct tickets");
+        throw new SQLFeatureNotSupportedException("To be implemented in scope of Array / Struct tickets");
     }
 
     @Override
     public void addBatch() throws SQLException {
         checkClosed();
-        throw new FeatureNotSupportedException("TODO-HIBERNATE-35 https://jira.mongodb.org/browse/HIBERNATE-35");
+        throw new SQLFeatureNotSupportedException("TODO-HIBERNATE-35 https://jira.mongodb.org/browse/HIBERNATE-35");
     }
 
     @Override
     public void setArray(int parameterIndex, Array x) throws SQLException {
         checkClosed();
         checkParameterIndex(parameterIndex);
-        throw new FeatureNotSupportedException();
+        throw new SQLFeatureNotSupportedException();
     }
 
     @Override
     public void setDate(int parameterIndex, Date x, Calendar cal) throws SQLException {
         checkClosed();
         checkParameterIndex(parameterIndex);
-        throw new FeatureNotSupportedException("TODO-HIBERNATE-42 https://jira.mongodb.org/browse/HIBERNATE-42");
+        throw new SQLFeatureNotSupportedException("TODO-HIBERNATE-42 https://jira.mongodb.org/browse/HIBERNATE-42");
     }
 
     @Override
     public void setTime(int parameterIndex, Time x, Calendar cal) throws SQLException {
         checkClosed();
         checkParameterIndex(parameterIndex);
-        throw new FeatureNotSupportedException("TODO-HIBERNATE-42 https://jira.mongodb.org/browse/HIBERNATE-42");
+        throw new SQLFeatureNotSupportedException("TODO-HIBERNATE-42 https://jira.mongodb.org/browse/HIBERNATE-42");
     }
 
     @Override
     public void setTimestamp(int parameterIndex, Timestamp x, Calendar cal) throws SQLException {
         checkClosed();
         checkParameterIndex(parameterIndex);
-        throw new FeatureNotSupportedException("TODO-HIBERNATE-42 https://jira.mongodb.org/browse/HIBERNATE-42");
+        throw new SQLFeatureNotSupportedException("TODO-HIBERNATE-42 https://jira.mongodb.org/browse/HIBERNATE-42");
     }
 
     @Override
     public void setNull(int parameterIndex, int sqlType, String typeName) throws SQLException {
         checkClosed();
         checkParameterIndex(parameterIndex);
-        throw new FeatureNotSupportedException("To be implemented in scope of Array / Struct tickets");
+        throw new SQLFeatureNotSupportedException("To be implemented in scope of Array / Struct tickets");
     }
 
     @Override
     public void setQueryTimeout(int seconds) throws SQLException {
         checkClosed();
-        throw new FeatureNotSupportedException("TODO-HIBERNATE-55 https://jira.mongodb.org/browse/HIBERNATE-55");
+        throw new SQLFeatureNotSupportedException("TODO-HIBERNATE-55 https://jira.mongodb.org/browse/HIBERNATE-55");
     }
 
     @Override
     public void setFetchSize(int rows) throws SQLException {
         checkClosed();
-        throw new FeatureNotSupportedException("TODO-HIBERNATE-54 https://jira.mongodb.org/browse/HIBERNATE-54");
+        throw new SQLFeatureNotSupportedException("TODO-HIBERNATE-54 https://jira.mongodb.org/browse/HIBERNATE-54");
     }
 
     @Override

--- a/src/main/java/com/mongodb/hibernate/jdbc/MongoResultSet.java
+++ b/src/main/java/com/mongodb/hibernate/jdbc/MongoResultSet.java
@@ -37,12 +37,12 @@ import static com.mongodb.hibernate.internal.MongoAssertions.assertNotNull;
 import static java.lang.String.format;
 
 import com.mongodb.client.MongoCursor;
-import com.mongodb.hibernate.internal.FeatureNotSupportedException;
 import java.math.BigDecimal;
 import java.sql.Array;
 import java.sql.Date;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
 import java.sql.Time;
 import java.sql.Timestamp;
 import java.util.Calendar;
@@ -153,35 +153,35 @@ final class MongoResultSet implements ResultSetAdapter {
     public @Nullable Date getDate(int columnIndex) throws SQLException {
         checkClosed();
         checkColumnIndex(columnIndex);
-        throw new FeatureNotSupportedException("TODO-HIBERNATE-42 https://jira.mongodb.org/browse/HIBERNATE-42");
+        throw new SQLFeatureNotSupportedException("TODO-HIBERNATE-42 https://jira.mongodb.org/browse/HIBERNATE-42");
     }
 
     @Override
     public @Nullable Time getTime(int columnIndex) throws SQLException {
         checkClosed();
         checkColumnIndex(columnIndex);
-        throw new FeatureNotSupportedException("TODO-HIBERNATE-42 https://jira.mongodb.org/browse/HIBERNATE-42");
+        throw new SQLFeatureNotSupportedException("TODO-HIBERNATE-42 https://jira.mongodb.org/browse/HIBERNATE-42");
     }
 
     @Override
     public @Nullable Time getTime(int columnIndex, Calendar cal) throws SQLException {
         checkClosed();
         checkColumnIndex(columnIndex);
-        throw new FeatureNotSupportedException("TODO-HIBERNATE-42 https://jira.mongodb.org/browse/HIBERNATE-42");
+        throw new SQLFeatureNotSupportedException("TODO-HIBERNATE-42 https://jira.mongodb.org/browse/HIBERNATE-42");
     }
 
     @Override
     public @Nullable Timestamp getTimestamp(int columnIndex) throws SQLException {
         checkClosed();
         checkColumnIndex(columnIndex);
-        throw new FeatureNotSupportedException("TODO-HIBERNATE-42 https://jira.mongodb.org/browse/HIBERNATE-42");
+        throw new SQLFeatureNotSupportedException("TODO-HIBERNATE-42 https://jira.mongodb.org/browse/HIBERNATE-42");
     }
 
     @Override
     public @Nullable Timestamp getTimestamp(int columnIndex, Calendar cal) throws SQLException {
         checkClosed();
         checkColumnIndex(columnIndex);
-        throw new FeatureNotSupportedException("TODO-HIBERNATE-42 https://jira.mongodb.org/browse/HIBERNATE-42");
+        throw new SQLFeatureNotSupportedException("TODO-HIBERNATE-42 https://jira.mongodb.org/browse/HIBERNATE-42");
     }
 
     @Override
@@ -197,14 +197,14 @@ final class MongoResultSet implements ResultSetAdapter {
     public @Nullable Array getArray(int columnIndex) throws SQLException {
         checkClosed();
         checkColumnIndex(columnIndex);
-        throw new FeatureNotSupportedException();
+        throw new SQLFeatureNotSupportedException();
     }
 
     @Override
     public <T> @Nullable T getObject(int columnIndex, Class<T> type) throws SQLException {
         checkClosed();
         checkColumnIndex(columnIndex);
-        throw new FeatureNotSupportedException("To be implemented in scope of Array / Struct tickets");
+        throw new SQLFeatureNotSupportedException("To be implemented in scope of Array / Struct tickets");
     }
 
     @Override
@@ -216,7 +216,7 @@ final class MongoResultSet implements ResultSetAdapter {
     @Override
     public int findColumn(String columnLabel) throws SQLException {
         checkClosed();
-        throw new FeatureNotSupportedException("To be implemented in scope of native query tickets");
+        throw new SQLFeatureNotSupportedException("To be implemented in scope of native query tickets");
     }
 
     @Override

--- a/src/main/java/com/mongodb/hibernate/jdbc/MongoStatement.java
+++ b/src/main/java/com/mongodb/hibernate/jdbc/MongoStatement.java
@@ -23,11 +23,11 @@ import static java.util.stream.Collectors.toCollection;
 
 import com.mongodb.client.ClientSession;
 import com.mongodb.client.MongoDatabase;
-import com.mongodb.hibernate.internal.FeatureNotSupportedException;
 import com.mongodb.hibernate.internal.VisibleForTesting;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
 import java.sql.SQLSyntaxErrorException;
 import java.sql.SQLWarning;
 import java.util.ArrayList;
@@ -134,7 +134,7 @@ class MongoStatement implements StatementAdapter {
     @Override
     public void cancel() throws SQLException {
         checkClosed();
-        throw new FeatureNotSupportedException();
+        throw new SQLFeatureNotSupportedException();
     }
 
     @Override
@@ -152,44 +152,44 @@ class MongoStatement implements StatementAdapter {
     public boolean execute(String mql) throws SQLException {
         checkClosed();
         closeLastOpenResultSet();
-        throw new FeatureNotSupportedException("To be implemented in scope of index and unique constraint creation");
+        throw new SQLFeatureNotSupportedException("To be implemented in scope of index and unique constraint creation");
     }
 
     @Override
     public @Nullable ResultSet getResultSet() throws SQLException {
         checkClosed();
-        throw new FeatureNotSupportedException("To be implemented in scope of index and unique constraint creation");
+        throw new SQLFeatureNotSupportedException("To be implemented in scope of index and unique constraint creation");
     }
 
     @Override
     public boolean getMoreResults() throws SQLException {
         checkClosed();
-        throw new FeatureNotSupportedException("To be implemented in scope of index and unique constraint creation");
+        throw new SQLFeatureNotSupportedException("To be implemented in scope of index and unique constraint creation");
     }
 
     @Override
     public int getUpdateCount() throws SQLException {
         checkClosed();
-        throw new FeatureNotSupportedException("To be implemented in scope of index and unique constraint creation");
+        throw new SQLFeatureNotSupportedException("To be implemented in scope of index and unique constraint creation");
     }
 
     @Override
     public void addBatch(String mql) throws SQLException {
         checkClosed();
-        throw new FeatureNotSupportedException("TODO-HIBERNATE-35 https://jira.mongodb.org/browse/HIBERNATE-35");
+        throw new SQLFeatureNotSupportedException("TODO-HIBERNATE-35 https://jira.mongodb.org/browse/HIBERNATE-35");
     }
 
     @Override
     public void clearBatch() throws SQLException {
         checkClosed();
-        throw new FeatureNotSupportedException("TODO-HIBERNATE-35 https://jira.mongodb.org/browse/HIBERNATE-35");
+        throw new SQLFeatureNotSupportedException("TODO-HIBERNATE-35 https://jira.mongodb.org/browse/HIBERNATE-35");
     }
 
     @Override
     public int[] executeBatch() throws SQLException {
         checkClosed();
         closeLastOpenResultSet();
-        throw new FeatureNotSupportedException("TODO-HIBERNATE-35 https://jira.mongodb.org/browse/HIBERNATE-35");
+        throw new SQLFeatureNotSupportedException("TODO-HIBERNATE-35 https://jira.mongodb.org/browse/HIBERNATE-35");
     }
 
     @Override

--- a/src/test/java/com/mongodb/hibernate/jdbc/MongoStatementTests.java
+++ b/src/test/java/com/mongodb/hibernate/jdbc/MongoStatementTests.java
@@ -36,9 +36,9 @@ import com.mongodb.client.ClientSession;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoCursor;
 import com.mongodb.client.MongoDatabase;
-import com.mongodb.hibernate.internal.FeatureNotSupportedException;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
 import java.sql.SQLSyntaxErrorException;
 import java.util.List;
 import java.util.function.BiConsumer;
@@ -170,13 +170,13 @@ class MongoStatementTests {
 
         @Test
         void testExecute() throws SQLException {
-            assertThrows(FeatureNotSupportedException.class, () -> mongoStatement.execute(exampleUpdateMql));
+            assertThrows(SQLFeatureNotSupportedException.class, () -> mongoStatement.execute(exampleUpdateMql));
             assertTrue(lastOpenResultSet.isClosed());
         }
 
         @Test
         void testExecuteBatch() throws SQLException {
-            assertThrows(FeatureNotSupportedException.class, () -> mongoStatement.executeBatch());
+            assertThrows(SQLFeatureNotSupportedException.class, () -> mongoStatement.executeBatch());
             assertTrue(lastOpenResultSet.isClosed());
         }
     }


### PR DESCRIPTION
as we discussed in private, SQLException should be thrown invariably from JDBC API methods.