### PR TITLE
Minor improvements to AST stuff (generics usage and naming)

### DIFF
--- a/src/main/java/com/mongodb/hibernate/internal/translate/AbstractMqlTranslator.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/AbstractMqlTranslator.java
@@ -214,20 +214,20 @@ abstract class AbstractMqlTranslator<T extends JdbcOperation> implements SqlAstT
         if (tableInsert.getNumberOfReturningColumns() > 0) {
             throw new FeatureNotSupportedException();
         }
-        var tableName = tableInsert.getTableName();
         var astElements = new ArrayList<AstElement>(tableInsert.getNumberOfValueBindings());
         for (var columnValueBinding : tableInsert.getValueBindings()) {
-            var columnExpression = columnValueBinding.getColumnReference().getColumnExpression();
+            var fieldName = columnValueBinding.getColumnReference().getColumnExpression();
 
             var valueExpression = columnValueBinding.getValueExpression();
             if (valueExpression == null) {
                 throw new FeatureNotSupportedException();
             }
-            var astValue = acceptAndYield(valueExpression, FIELD_VALUE);
+            var fieldValue = acceptAndYield(valueExpression, FIELD_VALUE);
 
-            astElements.add(new AstElement(columnExpression, astValue));
+            astElements.add(new AstElement(fieldName, fieldValue));
         }
-        astVisitorValueHolder.yield(COLLECTION_MUTATION, new AstInsertCommand(tableName, new AstDocument(astElements)));
+        astVisitorValueHolder.yield(
+                COLLECTION_MUTATION, new AstInsertCommand(tableInsert.getTableName(), new AstDocument(astElements)));
     }
 
     @Override
@@ -266,9 +266,9 @@ abstract class AbstractMqlTranslator<T extends JdbcOperation> implements SqlAstT
         var keyFilter = getKeyFilter(tableUpdate);
         var updates = new ArrayList<AstFieldUpdate>(tableUpdate.getNumberOfValueBindings());
         for (var valueBinding : tableUpdate.getValueBindings()) {
-            var columnExpression = valueBinding.getColumnReference().getColumnExpression();
-            var astValue = acceptAndYield(valueBinding.getValueExpression(), FIELD_VALUE);
-            updates.add(new AstFieldUpdate(columnExpression, astValue));
+            var fieldName = valueBinding.getColumnReference().getColumnExpression();
+            var fieldValue = acceptAndYield(valueBinding.getValueExpression(), FIELD_VALUE);
+            updates.add(new AstFieldUpdate(fieldName, fieldValue));
         }
         astVisitorValueHolder.yield(
                 COLLECTION_MUTATION,
@@ -289,8 +289,8 @@ abstract class AbstractMqlTranslator<T extends JdbcOperation> implements SqlAstT
 
         var astFilterFieldPath =
                 new AstFilterFieldPath(keyBinding.getColumnReference().getColumnExpression());
-        var astValue = acceptAndYield(keyBinding.getValueExpression(), FIELD_VALUE);
-        return new AstFieldOperationFilter(astFilterFieldPath, new AstComparisonFilterOperation(EQ, astValue));
+        var fieldValue = acceptAndYield(keyBinding.getValueExpression(), FIELD_VALUE);
+        return new AstFieldOperationFilter(astFilterFieldPath, new AstComparisonFilterOperation(EQ, fieldValue));
     }
 
     @Override

--- a/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/AstDocument.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/AstDocument.java
@@ -19,7 +19,7 @@ package com.mongodb.hibernate.internal.translate.mongoast;
 import java.util.List;
 import org.bson.BsonWriter;
 
-public record AstDocument(List<AstElement> elements) implements AstValue {
+public record AstDocument(List<? extends AstElement> elements) implements AstValue {
     @Override
     public void render(BsonWriter writer) {
         writer.writeStartDocument();

--- a/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/command/AstUpdateCommand.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/command/AstUpdateCommand.java
@@ -22,7 +22,8 @@ import com.mongodb.hibernate.internal.translate.mongoast.filter.AstFilter;
 import java.util.List;
 import org.bson.BsonWriter;
 
-public record AstUpdateCommand(String collection, AstFilter filter, List<AstFieldUpdate> updates) implements AstNode {
+public record AstUpdateCommand(String collection, AstFilter filter, List<? extends AstFieldUpdate> updates)
+        implements AstNode {
     @Override
     public void render(BsonWriter writer) {
         writer.writeStartDocument();


### PR DESCRIPTION
minor improvements based on recent code review comments for https://github.com/mongodb/mongo-hibernate/pull/69

1. lowerer bounded wildcards generics usage is preferrable for incoming collection parameter
2. ast variable are better named to reflect domain model (Mongo semantics, as opposed to SQL or generic ast names)