### PR TITLE
commit idea inspection settings to disable unnecessary warnings in test code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@
 /*.iws
 /*.iml
 /out/
+!/.idea/inspectionProfiles/Project_Default.xml
 
 # Gradle
 .gradle/

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,11 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="NotNullFieldNotInitialized" enabled="true" level="WARNING" enabled_by_default="false">
+      <scope name="Production" level="WARNING" enabled="true" />
+    </inspection_tool>
+    <inspection_tool class="SameParameterValue" enabled="true" level="WARNING" enabled_by_default="false">
+      <scope name="Production" level="WARNING" enabled="true" />
+    </inspection_tool>
+  </profile>
+</component>

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,11 +1,11 @@
 <component name="InspectionProjectProfileManager">
   <profile version="1.0">
     <option name="myName" value="Project Default" />
-    <inspection_tool class="NotNullFieldNotInitialized" enabled="true" level="WARNING" enabled_by_default="false">
-      <scope name="Production" level="WARNING" enabled="true" />
+    <inspection_tool class="NotNullFieldNotInitialized" enabled="true" level="WARNING" enabled_by_default="true">
+      <scope name="Tests" level="WARNING" enabled="false" />
     </inspection_tool>
-    <inspection_tool class="SameParameterValue" enabled="true" level="WARNING" enabled_by_default="false">
-      <scope name="Production" level="WARNING" enabled="true" />
+    <inspection_tool class="SameParameterValue" enabled="true" level="WARNING" enabled_by_default="true">
+      <scope name="Tests" level="WARNING" enabled="false" />
     </inspection_tool>
   </profile>
 </component>


### PR DESCRIPTION
This PR aims to eliminate the following two annoying inspection warnings in IDEA:

1. **\@NullMarked fieldfs must be initialized** (nullness warnings are only useful for production code; if NPE happens in test code, testing has failed and we should have fixedf it already)
<img width="599" alt="Screenshot 2025-03-21 at 4 32 56 PM" src="https://github.com/user-attachments/assets/66b618ce-52c7-44c8-a233-26444da670ef" />

2. **Value of ??? is always ???** (so common in testing code due to insufficient testing coverage; currently the issue only manifests itself in `com.mongodb.hibernate.internal.cfg.MongoConfigurationBuilderTests`)
<img width="711" alt="Screenshot 2025-03-21 at 4 34 19 PM" src="https://github.com/user-attachments/assets/0962f593-742a-49bb-95d8-619b11a0e1e9" />

The `.idea/inspectionProfiles/Project_Default.xml` was committed, which contains two inspection rules to only enable the above two inspections for Production code.

<img width="1183" alt="Screenshot 2025-03-21 at 4 36 19 PM" src="https://github.com/user-attachments/assets/1e8de723-a109-40d0-a7fd-92853247cc57" />

Note that to test it, you need to restart the IDE when you have switched to the feature branch from main branch. But once restarted, the annoying two warnings for test code would disappear.
