### PR TITLE
Add `ObjectIdGenerator`

### DIFF
--- a/src/integrationTest/java/com/mongodb/hibernate/type/ObjectIdIntegrationTests.java
+++ b/src/integrationTest/java/com/mongodb/hibernate/type/ObjectIdIntegrationTests.java
@@ -97,7 +97,7 @@ class ObjectIdIntegrationTests implements SessionFactoryScopeAware {
         @Test
         void insert() {
             var item = new ItemGenerated();
-            item.id = 123;
+            item.id = 1;
             sessionFactoryScope.inTransaction(session -> session.persist(item));
             assertNotNull(item.v);
             assertThat(mongoCollection.find())

--- a/src/integrationTest/java/com/mongodb/hibernate/type/ObjectIdIntegrationTests.java
+++ b/src/integrationTest/java/com/mongodb/hibernate/type/ObjectIdIntegrationTests.java
@@ -96,7 +96,7 @@ class ObjectIdIntegrationTests implements SessionFactoryScopeAware {
     class Generated {
         @Test
         void insert() {
-            var item = new ObjectIdIntegrationTests.ItemGenerated();
+            var item = new ItemGenerated();
             item.id = 123;
             sessionFactoryScope.inTransaction(session -> session.persist(item));
             assertNotNull(item.v);
@@ -108,7 +108,7 @@ class ObjectIdIntegrationTests implements SessionFactoryScopeAware {
 
         @Test
         void insertWithPropertyAccess() {
-            var item = new ObjectIdIntegrationTests.ItemGeneratedWithPropertyAccess().setId(1);
+            var item = new ItemGeneratedWithPropertyAccess().setId(1);
             sessionFactoryScope.inTransaction(session -> session.persist(item));
             assertNotNull(item.getV());
             assertThat(mongoCollection.find())
@@ -120,7 +120,7 @@ class ObjectIdIntegrationTests implements SessionFactoryScopeAware {
         @Test
         void assignedValue() {
             var v = new ObjectId(1, 0);
-            var item = new ObjectIdIntegrationTests.ItemGenerated();
+            var item = new ItemGenerated();
             item.id = 1;
             item.v = v;
             sessionFactoryScope.inTransaction(session -> session.persist(item));

--- a/src/integrationTest/java/com/mongodb/hibernate/type/ObjectIdIntegrationTests.java
+++ b/src/integrationTest/java/com/mongodb/hibernate/type/ObjectIdIntegrationTests.java
@@ -19,8 +19,10 @@ package com.mongodb.hibernate.type;
 import static com.mongodb.hibernate.internal.MongoConstants.ID_FIELD_NAME;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.mongodb.client.MongoCollection;
+import com.mongodb.hibernate.annotations.ObjectIdGenerator;
 import com.mongodb.hibernate.internal.type.ObjectIdJavaType;
 import com.mongodb.hibernate.internal.type.ObjectIdJdbcType;
 import com.mongodb.hibernate.junit.InjectMongoCollection;
@@ -40,11 +42,17 @@ import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
 import org.hibernate.testing.orm.junit.SessionFactoryScopeAware;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @SessionFactory(exportSchema = false)
-@DomainModel(annotatedClasses = {ObjectIdIntegrationTests.Item.class})
+@DomainModel(
+        annotatedClasses = {
+            ObjectIdIntegrationTests.Item.class,
+            ObjectIdIntegrationTests.ItemGenerated.class,
+            ObjectIdIntegrationTests.ItemGeneratedWithPropertyAccess.class
+        })
 @ExtendWith(MongoExtension.class)
 class ObjectIdIntegrationTests implements SessionFactoryScopeAware {
     @InjectMongoCollection("items")
@@ -84,6 +92,42 @@ class ObjectIdIntegrationTests implements SessionFactoryScopeAware {
         this.sessionFactoryScope = sessionFactoryScope;
     }
 
+    @Nested
+    class Generated {
+        @Test
+        void insert() {
+            var item = new ObjectIdIntegrationTests.ItemGenerated();
+            item.id = 123;
+            sessionFactoryScope.inTransaction(session -> session.persist(item));
+            assertNotNull(item.v);
+            assertThat(mongoCollection.find())
+                    .containsExactly(new BsonDocument()
+                            .append(ID_FIELD_NAME, new BsonInt32(item.id))
+                            .append("v", new BsonObjectId(item.v)));
+        }
+
+        @Test
+        void insertWithPropertyAccess() {
+            var item = new ObjectIdIntegrationTests.ItemGeneratedWithPropertyAccess().setId(1);
+            sessionFactoryScope.inTransaction(session -> session.persist(item));
+            assertNotNull(item.getV());
+            assertThat(mongoCollection.find())
+                    .containsExactly(new BsonDocument()
+                            .append(ID_FIELD_NAME, new BsonInt32(item.getId()))
+                            .append("v", new BsonObjectId(item.getV())));
+        }
+
+        @Test
+        void assignedValue() {
+            var v = new ObjectId(1, 0);
+            var item = new ObjectIdIntegrationTests.ItemGenerated();
+            item.id = 1;
+            item.v = v;
+            sessionFactoryScope.inTransaction(session -> session.persist(item));
+            assertEquals(v, item.v);
+        }
+    }
+
     @Entity
     @Table(name = "items")
     static class Item {
@@ -112,6 +156,43 @@ class ObjectIdIntegrationTests implements SessionFactoryScopeAware {
         @Override
         public int hashCode() {
             return Objects.hash(id, v, vNull, vExplicitlyAnnotatedNotForThePublic);
+        }
+    }
+
+    @Entity
+    @Table(name = "items")
+    static class ItemGenerated {
+        @Id
+        int id;
+
+        @ObjectIdGenerator
+        ObjectId v;
+    }
+
+    @Entity
+    @Table(name = "items")
+    static class ItemGeneratedWithPropertyAccess {
+        private int id;
+        private ObjectId v;
+
+        @Id
+        int getId() {
+            return id;
+        }
+
+        ItemGeneratedWithPropertyAccess setId(int id) {
+            this.id = id;
+            return this;
+        }
+
+        @ObjectIdGenerator
+        ObjectId getV() {
+            return v;
+        }
+
+        ItemGeneratedWithPropertyAccess setV(ObjectId v) {
+            this.v = v;
+            return this;
         }
     }
 }

--- a/src/main/java/com/mongodb/hibernate/annotations/ObjectIdGenerator.java
+++ b/src/main/java/com/mongodb/hibernate/annotations/ObjectIdGenerator.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2024-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.hibernate.annotations;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import org.hibernate.annotations.IdGeneratorType;
+import org.hibernate.annotations.ValueGenerationType;
+import org.hibernate.generator.BeforeExecutionGenerator;
+import org.hibernate.generator.EventType;
+
+/**
+ * Specifies that the value of an annotated persistent attribute, including an entity identifier, is generated using
+ * {@link org.bson.codecs.ObjectIdGenerator} {@linkplain BeforeExecutionGenerator before} {@linkplain EventType#INSERT
+ * inserting}. If the value is explicitly assigned, then the assigned value is used instead of generating a different
+ * one.
+ */
+@IdGeneratorType(com.mongodb.hibernate.internal.id.objectid.ObjectIdGenerator.class)
+@ValueGenerationType(generatedBy = com.mongodb.hibernate.internal.id.objectid.ObjectIdGenerator.class)
+@Retention(RUNTIME)
+@Target({FIELD, METHOD})
+public @interface ObjectIdGenerator {}

--- a/src/main/java/com/mongodb/hibernate/annotations/package-info.java
+++ b/src/main/java/com/mongodb/hibernate/annotations/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2024-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NullMarked
+package com.mongodb.hibernate.annotations;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/com/mongodb/hibernate/internal/id/objectid/ObjectIdGenerator.java
+++ b/src/main/java/com/mongodb/hibernate/internal/id/objectid/ObjectIdGenerator.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2024-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.hibernate.internal.id.objectid;
+
+import static org.hibernate.generator.EventTypeSets.INSERT_ONLY;
+
+import java.io.Serial;
+import java.lang.reflect.Member;
+import java.util.EnumSet;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.generator.BeforeExecutionGenerator;
+import org.hibernate.generator.EventType;
+import org.hibernate.generator.GeneratorCreationContext;
+import org.hibernate.id.factory.spi.CustomIdGeneratorCreationContext;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Tread-safe.
+ *
+ * @see com.mongodb.hibernate.annotations.ObjectIdGenerator
+ */
+public final class ObjectIdGenerator implements BeforeExecutionGenerator {
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    private static final org.bson.codecs.ObjectIdGenerator GENERATOR = new org.bson.codecs.ObjectIdGenerator();
+
+    private final boolean forIdentifier;
+
+    public ObjectIdGenerator(
+            com.mongodb.hibernate.annotations.ObjectIdGenerator config,
+            Member annotatedMember,
+            CustomIdGeneratorCreationContext context) {
+        this(true);
+    }
+
+    public ObjectIdGenerator(
+            com.mongodb.hibernate.annotations.ObjectIdGenerator config,
+            Member annotatedMember,
+            GeneratorCreationContext context) {
+        this(false);
+    }
+
+    private ObjectIdGenerator(boolean forIdentifier) {
+        this.forIdentifier = forIdentifier;
+    }
+
+    @Override
+    public Object generate(
+            SharedSessionContractImplementor session,
+            Object owner,
+            @Nullable Object currentValue,
+            EventType eventType) {
+        if (currentValue != null) {
+            return currentValue;
+        } else if (forIdentifier) {
+            // Hibernate ORM provides `null` as `currentValue` when generating an entity identifier value.
+            // To work around that behavior we have to read the value explicitly.
+            var currentId = session.getEntityPersister(null, owner).getIdentifier(owner, session);
+            if (currentId != null) {
+                return currentId;
+            }
+        }
+        return GENERATOR.generate();
+    }
+
+    @Override
+    public EnumSet<EventType> getEventTypes() {
+        return INSERT_ONLY;
+    }
+
+    @Override
+    public boolean allowAssignedIdentifiers() {
+        return true;
+    }
+}

--- a/src/main/java/com/mongodb/hibernate/internal/id/objectid/package-info.java
+++ b/src/main/java/com/mongodb/hibernate/internal/id/objectid/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2024-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** The program elements within this package are not part of the public API and may be removed or changed at any time */
+@NullMarked
+package com.mongodb.hibernate.internal.id.objectid;
+
+import org.jspecify.annotations.NullMarked;


### PR DESCRIPTION
HIBERNATE-24

Links that were useful to me:

- https://in.relation.to/2024/03/20/orm-65cr1/#manually-assigned-generated-ids
- https://discourse.hibernate.org/t/manually-setting-the-identifier-results-in-object-optimistic-locking-failure-exception/10743
- https://discourse.hibernate.org/t/migrating-from-genericgenerator-to-idgeneratortype/11079