### PR TITLE
add assertion that AstProjectStage must have at least one specification

### DIFF
--- a/src/main/java/com/mongodb/hibernate/internal/MongoAssertions.java
+++ b/src/main/java/com/mongodb/hibernate/internal/MongoAssertions.java
@@ -88,21 +88,6 @@ public final class MongoAssertions {
     }
 
     /**
-     * Asserts that {@code value} is {@code true} with message.
-     *
-     * @param message the message to explain details.
-     * @param value A value to check.
-     * @return {@code true}.
-     * @throws AssertionError If {@code value} is {@code false}.
-     */
-    public static boolean assertTrue(String message, boolean value) throws AssertionError {
-        if (!value) {
-            throw new AssertionError(message);
-        }
-        return true;
-    }
-
-    /**
      * Asserts that {@code value} is {@code false}.
      *
      * @param value A value to check.
@@ -112,21 +97,6 @@ public final class MongoAssertions {
     public static boolean assertFalse(boolean value) throws AssertionError {
         if (value) {
             throw new AssertionError();
-        }
-        return false;
-    }
-
-    /**
-     * Asserts that {@code value} is {@code false} with message.
-     *
-     * @param message the message to explain details.
-     * @param value A value to check.
-     * @return {@code false}.
-     * @throws AssertionError If {@code value} is {@code true}.
-     */
-    public static boolean assertFalse(String message, boolean value) throws AssertionError {
-        if (value) {
-            throw new AssertionError(message);
         }
         return false;
     }

--- a/src/main/java/com/mongodb/hibernate/internal/MongoAssertions.java
+++ b/src/main/java/com/mongodb/hibernate/internal/MongoAssertions.java
@@ -128,6 +128,6 @@ public final class MongoAssertions {
         if (value) {
             throw new AssertionError(message);
         }
-        return true;
+        return false;
     }
 }

--- a/src/main/java/com/mongodb/hibernate/internal/MongoAssertions.java
+++ b/src/main/java/com/mongodb/hibernate/internal/MongoAssertions.java
@@ -115,4 +115,19 @@ public final class MongoAssertions {
         }
         return false;
     }
+
+    /**
+     * Asserts that {@code value} is {@code false} with message.
+     *
+     * @param message the message to explain details.
+     * @param value A value to check.
+     * @return {@code false}.
+     * @throws AssertionError If {@code value} is {@code true}.
+     */
+    public static boolean assertFalse(String message, boolean value) throws AssertionError {
+        if (value) {
+            throw new AssertionError(message);
+        }
+        return true;
+    }
 }

--- a/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/command/aggregate/AstProjectStage.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/command/aggregate/AstProjectStage.java
@@ -24,7 +24,7 @@ import org.bson.BsonWriter;
 public record AstProjectStage(List<? extends AstProjectStageSpecification> specifications) implements AstStage {
 
     public AstProjectStage {
-        assertFalse("Projection stage must have at least one specification", specifications.isEmpty());
+        assertFalse(specifications.isEmpty());
     }
 
     @Override

--- a/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/command/aggregate/AstProjectStage.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/command/aggregate/AstProjectStage.java
@@ -16,10 +16,17 @@
 
 package com.mongodb.hibernate.internal.translate.mongoast.command.aggregate;
 
+import static com.mongodb.hibernate.internal.MongoAssertions.assertFalse;
+
 import java.util.List;
 import org.bson.BsonWriter;
 
 public record AstProjectStage(List<? extends AstProjectStageSpecification> specifications) implements AstStage {
+
+    public AstProjectStage {
+        assertFalse("Projection stage must have at least one specification", specifications.isEmpty());
+    }
+
     @Override
     public void render(BsonWriter writer) {
         writer.writeStartDocument();

--- a/src/test/java/com/mongodb/hibernate/internal/translate/SelectMqlTranslatorTests.java
+++ b/src/test/java/com/mongodb/hibernate/internal/translate/SelectMqlTranslatorTests.java
@@ -22,15 +22,18 @@ import static org.mockito.Mockito.doReturn;
 
 import com.mongodb.hibernate.internal.extension.service.StandardServiceRegistryScopedState;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.metamodel.mapping.SelectableMapping;
 import org.hibernate.persister.entity.EntityPersister;
 import org.hibernate.query.spi.QueryOptions;
 import org.hibernate.service.spi.ServiceRegistryImplementor;
 import org.hibernate.spi.NavigablePath;
 import org.hibernate.sql.ast.spi.SqlAliasBaseImpl;
+import org.hibernate.sql.ast.tree.expression.ColumnReference;
 import org.hibernate.sql.ast.tree.from.NamedTableReference;
 import org.hibernate.sql.ast.tree.from.StandardTableGroup;
 import org.hibernate.sql.ast.tree.select.QuerySpec;
 import org.hibernate.sql.ast.tree.select.SelectStatement;
+import org.hibernate.sql.results.internal.SqlSelectionImpl;
 import org.hibernate.sql.results.jdbc.spi.JdbcValuesMappingProducerProvider;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -47,7 +50,8 @@ class SelectMqlTranslatorTests {
             @Mock(mockMaker = MockMakers.PROXY) SessionFactoryImplementor sessionFactory,
             @Mock JdbcValuesMappingProducerProvider jdbcValuesMappingProducerProvider,
             @Mock(mockMaker = MockMakers.PROXY) ServiceRegistryImplementor serviceRegistry,
-            @Mock StandardServiceRegistryScopedState standardServiceRegistryScopedState) {
+            @Mock StandardServiceRegistryScopedState standardServiceRegistryScopedState,
+            @Mock SelectableMapping selectableMapping) {
 
         var tableName = "books";
         SelectStatement selectFromTableName;
@@ -66,6 +70,10 @@ class SelectMqlTranslatorTests {
                     new SqlAliasBaseImpl("b1"),
                     sessionFactory);
             querySpec.getFromClause().addRoot(tableGroup);
+            querySpec
+                    .getSelectClause()
+                    .addSqlSelection(new SqlSelectionImpl(
+                            new ColumnReference(tableGroup.getPrimaryTableReference(), selectableMapping)));
             selectFromTableName = new SelectStatement(querySpec);
         }
         { // prepare `sessionFactory`

--- a/src/test/java/com/mongodb/hibernate/internal/translate/mongoast/command/aggregate/AstAggregateCommandTests.java
+++ b/src/test/java/com/mongodb/hibernate/internal/translate/mongoast/command/aggregate/AstAggregateCommandTests.java
@@ -18,18 +18,28 @@ package com.mongodb.hibernate.internal.translate.mongoast.command.aggregate;
 
 import static com.mongodb.hibernate.internal.translate.mongoast.AstNodeAssertions.assertRender;
 
+import com.mongodb.hibernate.internal.translate.mongoast.AstLiteralValue;
+import com.mongodb.hibernate.internal.translate.mongoast.filter.AstComparisonFilterOperation;
+import com.mongodb.hibernate.internal.translate.mongoast.filter.AstComparisonFilterOperator;
+import com.mongodb.hibernate.internal.translate.mongoast.filter.AstFieldOperationFilter;
+import com.mongodb.hibernate.internal.translate.mongoast.filter.AstFilterFieldPath;
 import java.util.List;
+import org.bson.BsonInt32;
 import org.junit.jupiter.api.Test;
 
 class AstAggregateCommandTests {
 
     @Test
     void testRendering() {
-        var aggregateCommand = new AstAggregateCommand(
-                "books", List.of(new AstProjectStage(List.of()), new AstProjectStage(List.of())));
+        var matchStage = new AstMatchStage(new AstFieldOperationFilter(
+                new AstFilterFieldPath("_id"),
+                new AstComparisonFilterOperation(
+                        AstComparisonFilterOperator.EQ, new AstLiteralValue(new BsonInt32(1)))));
+        var projectStage = new AstProjectStage(List.of(new AstProjectStageIncludeSpecification("title")));
+        var aggregateCommand = new AstAggregateCommand("books", List.of(matchStage, projectStage));
         var expectedJson =
                 """
-                {"aggregate": "books", "pipeline": [{"$project": {}}, {"$project": {}}]}\
+                {"aggregate": "books", "pipeline": [{"$match": {"_id": {"$eq": 1}}}, {"$project": {"title": true}}]}\
                 """;
         assertRender(expectedJson, aggregateCommand);
     }

--- a/src/test/java/com/mongodb/hibernate/internal/translate/mongoast/command/aggregate/AstProjectStageTests.java
+++ b/src/test/java/com/mongodb/hibernate/internal/translate/mongoast/command/aggregate/AstProjectStageTests.java
@@ -17,17 +17,17 @@
 package com.mongodb.hibernate.internal.translate.mongoast.command.aggregate;
 
 import static com.mongodb.hibernate.internal.translate.mongoast.AstNodeAssertions.assertRender;
+import static java.util.Collections.singletonList;
 
-import java.util.Collections;
 import org.junit.jupiter.api.Test;
 
 class AstProjectStageTests {
 
     @Test
     void testRendering() {
-        var astProjectStage = new AstProjectStage(Collections.emptyList());
+        var astProjectStage = new AstProjectStage(singletonList(new AstProjectStageIncludeSpecification("title")));
         var expectedJson = """
-                           {"$project": {}}\
+                           {"$project": {"title": true}}\
                            """;
         assertRender(expectedJson, astProjectStage);
     }


### PR DESCRIPTION
Seems a minor loophole and tech debt from previous PR. I checked our mongoast classes accepting collection constructor parameters and found only `AstProjectStage` requires this assertion that the collection should be non-empty.

In the future PRs (including the current `simple select query translation`), such collection emptiness assertion would be added whenever applied. Just found this bad-case from previous PRs and tried to fix it.