### PR TITLE
add a simple Mongo CommandListener as a service to integrationTest

### DIFF
--- a/src/integrationTest/java/com/mongodb/hibernate/internal/MongoTestCommandListener.java
+++ b/src/integrationTest/java/com/mongodb/hibernate/internal/MongoTestCommandListener.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2025-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.hibernate.internal;
+
+import static com.mongodb.hibernate.internal.MongoAssertions.assertNotNull;
+
+import com.mongodb.event.CommandFailedEvent;
+import com.mongodb.event.CommandListener;
+import com.mongodb.event.CommandStartedEvent;
+import com.mongodb.event.CommandSucceededEvent;
+import java.io.Serial;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.bson.BsonDocument;
+import org.hibernate.service.Service;
+import org.jspecify.annotations.NullMarked;
+
+@NullMarked
+public final class MongoTestCommandListener implements CommandListener, Service {
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    static MongoTestCommandListener INSTANCE = new MongoTestCommandListener();
+
+    private MongoTestCommandListener() {}
+
+    private final List<BsonDocument> commandsSucceeded = new ArrayList<>();
+    private final List<BsonDocument> commandsFailed = new ArrayList<>();
+
+    private final Map<Long, BsonDocument> startedCommands = new HashMap<>();
+
+    @Override
+    public void commandStarted(CommandStartedEvent event) {
+        startedCommands.put(event.getOperationId(), event.getCommand().clone());
+    }
+
+    @Override
+    public void commandSucceeded(CommandSucceededEvent event) {
+        var startedCommand = assertNotNull(startedCommands.remove(event.getOperationId()));
+        commandsSucceeded.add(startedCommand);
+    }
+
+    @Override
+    public void commandFailed(CommandFailedEvent event) {
+        var startedCommand = assertNotNull(startedCommands.remove(event.getOperationId()));
+        commandsFailed.add(startedCommand);
+    }
+
+    public boolean allCommandsFinishedAndSucceeded() {
+        return startedCommands.isEmpty() && commandsFailed.isEmpty();
+    }
+
+    public List<BsonDocument> getCommandsSucceeded() {
+        return List.copyOf(commandsSucceeded);
+    }
+
+    public void clear() {
+        startedCommands.clear();
+        commandsSucceeded.clear();
+        commandsFailed.clear();
+    }
+}

--- a/src/integrationTest/java/com/mongodb/hibernate/internal/MongoTestCommandListenerContributor.java
+++ b/src/integrationTest/java/com/mongodb/hibernate/internal/MongoTestCommandListenerContributor.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2025-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.hibernate.internal;
+
+import com.mongodb.hibernate.service.spi.MongoConfigurationContributor;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.service.spi.ServiceContributor;
+
+public final class MongoTestCommandListenerContributor implements ServiceContributor {
+
+    public MongoTestCommandListenerContributor() {}
+
+    @Override
+    public void contribute(StandardServiceRegistryBuilder serviceRegistryBuilder) {
+        serviceRegistryBuilder.addService(MongoConfigurationContributor.class, (MongoConfigurationContributor)
+                configurator -> configurator.applyToMongoClientSettings(
+                        builder -> builder.addCommandListener(MongoTestCommandListener.INSTANCE)));
+        serviceRegistryBuilder.addService(MongoTestCommandListener.class, MongoTestCommandListener.INSTANCE);
+    }
+}

--- a/src/integrationTest/resources/META-INF/services/org.hibernate.service.spi.ServiceContributor
+++ b/src/integrationTest/resources/META-INF/services/org.hibernate.service.spi.ServiceContributor
@@ -1,0 +1,1 @@
+com.mongodb.hibernate.internal.MongoTestCommandListenerContributor


### PR DESCRIPTION
Recent PR requires capturing actual MQL issued, but for historical reason Hibernate only captures the SQL with parameter placeholders, but not the actual one with parameter values embedded.

Seems this issue could be solved elegantly by `CommandListener` + `MongoConfigurationContributor`. This PR added a simple `CommandListener` to mongo client settings, plus exposed it as a separate Hibernate service. 

After this PR got merged, we could follow the below pattern to use the command listener in familiar way as `SessionFactoryScope`:

```
class BasicCrudIntegrationTests implements SessionFactoryScopeAware, ServiceRegistryScopeAware {
    
    private ServiceRegistryScope serviceRegistryScope;

    @Override
    public void injectServiceRegistryScope(ServiceRegistryScope serviceRegistryScope) {
        this.serviceRegistryScope = serviceRegistryScope;
    }

    @Test
     void test() {
    
         // when we need to use the listener, the pattern is the same as the usage of `SessionFactoryScope` as below:
         serviceRegistryScope.withService(MongoTestCommandListener.class, listener -> {

             assertThat(listener.allCommandsFinishedAndSucceeded()).isTrue();
             assertThat(listener.getCommandsSucceeded()).containsExactly(expectedCommand);
         }
         
     }

}
```