### PR TITLE
add `spotlessApply` exclusion to evergreen static-checks.sh

### DIFF
--- a/.evergreen/static-checks.sh
+++ b/.evergreen/static-checks.sh
@@ -13,4 +13,4 @@ echo "mongo-hibernate: static checking ..."
 
 ./gradlew -version
 
-./gradlew --info -x test -x integrationTest clean check compileJava
+./gradlew --info -x test -x integrationTest -x spotlessApply clean check compileJava


### PR DESCRIPTION
Previously I emulated Mongo Java driver repo to add the following statement to `build.gradle.kts`:

```
tasks.check { dependsOn(tasks.spotlessApply) }
```

So whenever I run gradle `check` task locally prior to pushing commit `spotlessApply` will be run, ending up with some convenience.

However, I forgot to exclude it in evergreen's static-analysis.sh, so basically static checking always succeeded for `spotlessApply` is always run before `check` task, which defeats the purpose of static analysis totally.

We should add `-x spotlessApply` as in Mongo Java driver repo.