### PR TITLE
Replace `Session.get` calls with `Session.find` calls, because Hibernate ORM 7.0 deprecated `Session.get`

### DIFF
--- a/src/integrationTest/java/com/mongodb/hibernate/BasicCrudIntegrationTests.java
+++ b/src/integrationTest/java/com/mongodb/hibernate/BasicCrudIntegrationTests.java
@@ -210,7 +210,7 @@ class BasicCrudIntegrationTests implements SessionFactoryScopeAware {
     class SelectTests {
 
         @Test
-        void testGetByPrimaryKeyWithoutNullValueField() {
+        void testFindByPrimaryKeyWithoutNullValueField() {
             var book = new Book();
             book.id = 1;
             book.author = "Marcel Proust";
@@ -218,13 +218,12 @@ class BasicCrudIntegrationTests implements SessionFactoryScopeAware {
             book.publishYear = 1913;
 
             sessionFactoryScope.inTransaction(session -> session.persist(book));
-
-            var loadedBook = sessionFactoryScope.fromTransaction(session -> session.get(Book.class, 1));
+            var loadedBook = sessionFactoryScope.fromTransaction(session -> session.find(Book.class, 1));
             assertEquals(book, loadedBook);
         }
 
         @Test
-        void testGetByPrimaryKeyWithNullValueField() {
+        void testFindByPrimaryKeyWithNullValueField() {
             var book = new Book();
             book.id = 1;
             book.title = "Brave New World";
@@ -236,8 +235,7 @@ class BasicCrudIntegrationTests implements SessionFactoryScopeAware {
             book.publishYear = 1932;
 
             sessionFactoryScope.inTransaction(session -> session.persist(book));
-
-            var loadedBook = sessionFactoryScope.fromTransaction(session -> session.get(Book.class, 1));
+            var loadedBook = sessionFactoryScope.fromTransaction(session -> session.find(Book.class, 1));
             assertEquals(book, loadedBook);
         }
     }

--- a/src/integrationTest/java/com/mongodb/hibernate/IdentifierIntegrationTests.java
+++ b/src/integrationTest/java/com/mongodb/hibernate/IdentifierIntegrationTests.java
@@ -95,7 +95,7 @@ class IdentifierIntegrationTests implements SessionFactoryScopeAware {
                 .containsExactly(new BsonDocument()
                         .append(ID_FIELD_NAME, new BsonInt32(item.id))
                         .append(WithSpaceAndDotAndMixedCase.FIELD_NAME, new BsonInt32(item.v)));
-        sessionFactoryScope.inTransaction(session -> session.get(WithSpaceAndDotAndMixedCase.class, item.id));
+        sessionFactoryScope.inTransaction(session -> session.find(WithSpaceAndDotAndMixedCase.class, item.id));
     }
 
     @Test
@@ -106,7 +106,7 @@ class IdentifierIntegrationTests implements SessionFactoryScopeAware {
                 .containsExactly(new BsonDocument()
                         .append(ID_FIELD_NAME, new BsonInt32(item.id))
                         .append(StartingAndEndingWithBackticks.ACTUAL_FIELD_NAME, new BsonInt32(item.v)));
-        sessionFactoryScope.inTransaction(session -> session.get(StartingAndEndingWithBackticks.class, item.id));
+        sessionFactoryScope.inTransaction(session -> session.find(StartingAndEndingWithBackticks.class, item.id));
     }
 
     @Test
@@ -117,7 +117,7 @@ class IdentifierIntegrationTests implements SessionFactoryScopeAware {
                 .containsExactly(new BsonDocument()
                         .append(ID_FIELD_NAME, new BsonInt32(item.id))
                         .append(StartingWithBacktick.FIELD_NAME, new BsonInt32(item.v)));
-        sessionFactoryScope.inTransaction(session -> session.get(StartingWithBacktick.class, item.id));
+        sessionFactoryScope.inTransaction(session -> session.find(StartingWithBacktick.class, item.id));
     }
 
     @Test
@@ -128,7 +128,7 @@ class IdentifierIntegrationTests implements SessionFactoryScopeAware {
                 .containsExactly(new BsonDocument()
                         .append(ID_FIELD_NAME, new BsonInt32(item.id))
                         .append(EndingWithBacktick.FIELD_NAME, new BsonInt32(item.v)));
-        sessionFactoryScope.inTransaction(session -> session.get(EndingWithBacktick.class, item.id));
+        sessionFactoryScope.inTransaction(session -> session.find(EndingWithBacktick.class, item.id));
     }
 
     @Test
@@ -139,7 +139,7 @@ class IdentifierIntegrationTests implements SessionFactoryScopeAware {
                 .containsExactly(new BsonDocument()
                         .append(ID_FIELD_NAME, new BsonInt32(item.id))
                         .append(StartingAndEndingWithDoubleQuotes.ACTUAL_FIELD_NAME, new BsonInt32(item.v)));
-        sessionFactoryScope.inTransaction(session -> session.get(StartingAndEndingWithDoubleQuotes.class, item.id));
+        sessionFactoryScope.inTransaction(session -> session.find(StartingAndEndingWithDoubleQuotes.class, item.id));
     }
 
     @Test
@@ -150,7 +150,7 @@ class IdentifierIntegrationTests implements SessionFactoryScopeAware {
                 .containsExactly(new BsonDocument()
                         .append(ID_FIELD_NAME, new BsonInt32(item.id))
                         .append(StartingWithDoubleQuote.FIELD_NAME, new BsonInt32(item.v)));
-        sessionFactoryScope.inTransaction(session -> session.get(StartingWithDoubleQuote.class, item.id));
+        sessionFactoryScope.inTransaction(session -> session.find(StartingWithDoubleQuote.class, item.id));
     }
 
     @Test
@@ -161,7 +161,7 @@ class IdentifierIntegrationTests implements SessionFactoryScopeAware {
                 .containsExactly(new BsonDocument()
                         .append(ID_FIELD_NAME, new BsonInt32(item.id))
                         .append(EndingWithDoubleQuote.FIELD_NAME, new BsonInt32(item.v)));
-        sessionFactoryScope.inTransaction(session -> session.get(EndingWithDoubleQuote.class, item.id));
+        sessionFactoryScope.inTransaction(session -> session.find(EndingWithDoubleQuote.class, item.id));
     }
 
     @Test
@@ -172,7 +172,7 @@ class IdentifierIntegrationTests implements SessionFactoryScopeAware {
                 .containsExactly(new BsonDocument()
                         .append(ID_FIELD_NAME, new BsonInt32(item.id))
                         .append(StartingAndEndingWithSquareBrackets.ACTUAL_FIELD_NAME, new BsonInt32(item.v)));
-        sessionFactoryScope.inTransaction(session -> session.get(StartingAndEndingWithSquareBrackets.class, item.id));
+        sessionFactoryScope.inTransaction(session -> session.find(StartingAndEndingWithSquareBrackets.class, item.id));
     }
 
     @Test
@@ -183,7 +183,7 @@ class IdentifierIntegrationTests implements SessionFactoryScopeAware {
                 .containsExactly(new BsonDocument()
                         .append(ID_FIELD_NAME, new BsonInt32(item.id))
                         .append(StartingWithLeftSquareBracket.FIELD_NAME, new BsonInt32(item.v)));
-        sessionFactoryScope.inTransaction(session -> session.get(StartingWithLeftSquareBracket.class, item.id));
+        sessionFactoryScope.inTransaction(session -> session.find(StartingWithLeftSquareBracket.class, item.id));
     }
 
     @Test
@@ -194,7 +194,7 @@ class IdentifierIntegrationTests implements SessionFactoryScopeAware {
                 .containsExactly(new BsonDocument()
                         .append(ID_FIELD_NAME, new BsonInt32(item.id))
                         .append(EndingWithRightSquareBracket.FIELD_NAME, new BsonInt32(item.v)));
-        sessionFactoryScope.inTransaction(session -> session.get(EndingWithRightSquareBracket.class, item.id));
+        sessionFactoryScope.inTransaction(session -> session.find(EndingWithRightSquareBracket.class, item.id));
     }
 
     @Override

--- a/src/integrationTest/java/com/mongodb/hibernate/id/ObjectIdAsIdIntegrationTests.java
+++ b/src/integrationTest/java/com/mongodb/hibernate/id/ObjectIdAsIdIntegrationTests.java
@@ -62,11 +62,11 @@ class ObjectIdAsIdIntegrationTests implements SessionFactoryScopeAware {
     }
 
     @Test
-    void getById() {
+    void findById() {
         var item = new Item();
         item.id = new ObjectId(1, 0);
         sessionFactoryScope.inTransaction(session -> session.persist(item));
-        var loadedItem = sessionFactoryScope.fromTransaction(session -> session.get(Item.class, item.id));
+        var loadedItem = sessionFactoryScope.fromTransaction(session -> session.find(Item.class, item.id));
         assertEquals(item.id, loadedItem.id);
     }
 

--- a/src/integrationTest/java/com/mongodb/hibernate/type/ObjectIdIntegrationTests.java
+++ b/src/integrationTest/java/com/mongodb/hibernate/type/ObjectIdIntegrationTests.java
@@ -80,7 +80,7 @@ class ObjectIdIntegrationTests implements SessionFactoryScopeAware {
     }
 
     @Test
-    void getById() {
+    void findById() {
         var item = new Item();
         item.id = 1;
         item.v = new ObjectId(2, 0);
@@ -90,7 +90,7 @@ class ObjectIdIntegrationTests implements SessionFactoryScopeAware {
         item.vNull = new ObjectId();
         item.vExplicitlyAnnotatedNotForThePublic = new ObjectId(3, 4);
         sessionFactoryScope.inTransaction(session -> session.persist(item));
-        var loadedItem = sessionFactoryScope.fromTransaction(session -> session.get(Item.class, item.id));
+        var loadedItem = sessionFactoryScope.fromTransaction(session -> session.find(Item.class, item.id));
         assertEquals(item, loadedItem);
     }
 


### PR DESCRIPTION
https://docs.jboss.org/hibernate/orm/7.0/javadocs/org/hibernate/Session.html#get(java.lang.Class,java.lang.Object)

Where there is no Jakarta alternative, we'll keep using Hibernate-specific methods.