### PR TITLE
remove cache plan cache forbidding in AbstractMqlTranslator

### DIFF
--- a/src/integrationTest/java/com/mongodb/hibernate/query/select/SimpleSelectQueryIntegrationTests.java
+++ b/src/integrationTest/java/com/mongodb/hibernate/query/select/SimpleSelectQueryIntegrationTests.java
@@ -18,6 +18,7 @@ package com.mongodb.hibernate.query.select;
 
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.mongodb.hibernate.TestCommandListener;
@@ -320,6 +321,15 @@ class SimpleSelectQueryIntegrationTests implements SessionFactoryScopeAware, Ser
                     q -> q.setParameter("country", null),
                     FeatureNotSupportedException.class,
                     "TODO-HIBERNATE-74 https://jira.mongodb.org/browse/HIBERNATE-74");
+        }
+
+        @Test
+        void testQueryPlanCacheIsNotForbidden() {
+            sessionFactoryScope.inTransaction(
+                    session -> assertThatCode(() -> session.createSelectionQuery("from Contact", Contact.class)
+                                    .setQueryPlanCacheable(true)
+                                    .getResultList())
+                            .doesNotThrowAnyException());
         }
     }
 

--- a/src/integrationTest/java/com/mongodb/hibernate/query/select/SimpleSelectQueryIntegrationTests.java
+++ b/src/integrationTest/java/com/mongodb/hibernate/query/select/SimpleSelectQueryIntegrationTests.java
@@ -324,7 +324,7 @@ class SimpleSelectQueryIntegrationTests implements SessionFactoryScopeAware, Ser
         }
 
         @Test
-        void testQueryPlanCacheIsNotForbidden() {
+        void testQueryPlanCacheIsSupported() {
             sessionFactoryScope.inTransaction(
                     session -> assertThatCode(() -> session.createSelectionQuery("from Contact", Contact.class)
                                     .setQueryPlanCacheable(true)

--- a/src/main/java/com/mongodb/hibernate/internal/translate/AbstractMqlTranslator.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/AbstractMqlTranslator.java
@@ -835,9 +835,6 @@ abstract class AbstractMqlTranslator<T extends JdbcOperation> implements SqlAstT
                 && !queryOptions.getEnabledFetchProfiles().isEmpty()) {
             throw new FeatureNotSupportedException("'enabledFetchProfiles' in QueryOptions not supported");
         }
-        if (Boolean.TRUE.equals(queryOptions.getQueryPlanCachingEnabled())) {
-            throw new FeatureNotSupportedException("'queryPlanCaching' in QueryOptions not supported");
-        }
         if (queryOptions.getLockOptions() != null
                 && !queryOptions.getLockOptions().isEmpty()) {
             throw new FeatureNotSupportedException("'lockOptions' in QueryOptions not supported");


### PR DESCRIPTION
This is a defect I found recently. Initially we went about `defensive programming` by throwing `FeatureNotSupportedException` for any meaningful configuration in `QueryOptions`, including `getQueryPlanCachingEnabled()` as below:

```
        if (Boolean.TRUE.equals(queryOptions.getQueryPlanCachingEnabled())) {
            throw new FeatureNotSupportedException("'queryPlanCaching' in QueryOptions not supported");
        }
```
However, this is insane for whether to enable query plan cache almost has nothing to do with MQL translating and it is mainly meant for upper level code to decide whether to cache or not, so unlike the other query options which are related to query features, we should not forbid the following usage by end-user:

```
var selectQuery = session.createSelectQuery("from Book where id = 1", Book.class);
selectQuery.setQueryPlanCacheable(true);
// get query result like selectQuery.getSingleResult();
```

If you search in Hibernate's default `AbstractSqlAstTranslator`, you can see `getQueryPlanCachingEnabled()` is never used in any way.
An overlooking from my previous PR. Still not too late to fix it though.

Added a testing case to cover our asses.