### PR TITLE
tighten mongoast testing by using extended format

### DIFF
--- a/src/main/java/com/mongodb/hibernate/internal/MongoConstants.java
+++ b/src/main/java/com/mongodb/hibernate/internal/MongoConstants.java
@@ -16,9 +16,15 @@
 
 package com.mongodb.hibernate.internal;
 
+import org.bson.json.JsonMode;
+import org.bson.json.JsonWriterSettings;
+
 public final class MongoConstants {
 
     private MongoConstants() {}
+
+    public static final JsonWriterSettings EXTENDED_JSON_WRITER_SETTINGS =
+            JsonWriterSettings.builder().outputMode(JsonMode.EXTENDED).build();
 
     public static final String MONGO_DBMS_NAME = "MongoDB";
     public static final String MONGO_JDBC_DRIVER_NAME = "MongoDB Java Driver JDBC Adapter";

--- a/src/main/java/com/mongodb/hibernate/internal/translate/AbstractMqlTranslator.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/AbstractMqlTranslator.java
@@ -18,6 +18,7 @@ package com.mongodb.hibernate.internal.translate;
 
 import static com.mongodb.hibernate.internal.MongoAssertions.assertNotNull;
 import static com.mongodb.hibernate.internal.MongoAssertions.assertTrue;
+import static com.mongodb.hibernate.internal.MongoConstants.EXTENDED_JSON_WRITER_SETTINGS;
 import static com.mongodb.hibernate.internal.MongoConstants.ID_FIELD_NAME;
 import static com.mongodb.hibernate.internal.MongoConstants.MONGO_DBMS_NAME;
 import static com.mongodb.hibernate.internal.translate.AstVisitorValueDescriptor.COLLECTION_AGGREGATE;
@@ -77,9 +78,7 @@ import org.bson.BsonInt32;
 import org.bson.BsonInt64;
 import org.bson.BsonString;
 import org.bson.BsonValue;
-import org.bson.json.JsonMode;
 import org.bson.json.JsonWriter;
-import org.bson.json.JsonWriterSettings;
 import org.bson.types.Decimal128;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.internal.util.collections.Stack;
@@ -179,8 +178,6 @@ import org.hibernate.sql.model.internal.TableUpdateStandard;
 import org.jspecify.annotations.Nullable;
 
 abstract class AbstractMqlTranslator<T extends JdbcOperation> implements SqlAstTranslator<T> {
-    private static final JsonWriterSettings JSON_WRITER_SETTINGS =
-            JsonWriterSettings.builder().outputMode(JsonMode.EXTENDED).build();
 
     private final SessionFactoryImplementor sessionFactory;
 
@@ -234,7 +231,7 @@ abstract class AbstractMqlTranslator<T extends JdbcOperation> implements SqlAstT
 
     static String renderMongoAstNode(AstNode rootAstNode) {
         try (var stringWriter = new StringWriter();
-                var jsonWriter = new JsonWriter(stringWriter, JSON_WRITER_SETTINGS)) {
+                var jsonWriter = new JsonWriter(stringWriter, EXTENDED_JSON_WRITER_SETTINGS)) {
             rootAstNode.render(jsonWriter);
             jsonWriter.flush();
             return stringWriter.toString();

--- a/src/test/java/com/mongodb/hibernate/internal/translate/mongoast/AstNodeAssertions.java
+++ b/src/test/java/com/mongodb/hibernate/internal/translate/mongoast/AstNodeAssertions.java
@@ -16,6 +16,7 @@
 
 package com.mongodb.hibernate.internal.translate.mongoast;
 
+import static com.mongodb.hibernate.internal.MongoConstants.EXTENDED_JSON_WRITER_SETTINGS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
@@ -26,17 +27,17 @@ public final class AstNodeAssertions {
 
     private AstNodeAssertions() {}
 
-    public static void assertRender(String expectedJson, AstNode node) {
-        doAssertRender(expectedJson, node, false);
+    public static void assertRendering(String expectedJson, AstNode node) {
+        doAssertRendering(expectedJson, node, false);
     }
 
-    public static void assertElementRender(String expectedJson, AstNode node) {
-        doAssertRender(expectedJson, node, true);
+    public static void assertElementRendering(String expectedJson, AstNode node) {
+        doAssertRendering(expectedJson, node, true);
     }
 
-    private static void doAssertRender(String expectedJson, AstNode node, boolean isElement) {
+    private static void doAssertRendering(String expectedJson, AstNode node, boolean isElement) {
         try (var stringWriter = new StringWriter();
-                var jsonWriter = new JsonWriter(stringWriter)) {
+                var jsonWriter = new JsonWriter(stringWriter, EXTENDED_JSON_WRITER_SETTINGS)) {
             if (isElement) {
                 jsonWriter.writeStartDocument();
             }

--- a/src/test/java/com/mongodb/hibernate/internal/translate/mongoast/command/AstDeleteCommandTests.java
+++ b/src/test/java/com/mongodb/hibernate/internal/translate/mongoast/command/AstDeleteCommandTests.java
@@ -16,7 +16,7 @@
 
 package com.mongodb.hibernate.internal.translate.mongoast.command;
 
-import static com.mongodb.hibernate.internal.translate.mongoast.AstNodeAssertions.assertRender;
+import static com.mongodb.hibernate.internal.translate.mongoast.AstNodeAssertions.assertRendering;
 import static com.mongodb.hibernate.internal.translate.mongoast.filter.AstComparisonFilterOperator.EQ;
 
 import com.mongodb.hibernate.internal.translate.mongoast.AstLiteralValue;
@@ -40,9 +40,9 @@ class AstDeleteCommandTests {
 
         var expectedJson =
                 """
-                {"delete": "books", "deletes": [{"q": {"isbn": {"$eq": "978-3-16-148410-0"}}, "limit": 0}]}\
+                {"delete": "books", "deletes": [{"q": {"isbn": {"$eq": "978-3-16-148410-0"}}, "limit": {"$numberInt": "0"}}]}\
                 """;
 
-        assertRender(expectedJson, deleteCommand);
+        assertRendering(expectedJson, deleteCommand);
     }
 }

--- a/src/test/java/com/mongodb/hibernate/internal/translate/mongoast/command/AstInsertCommandTests.java
+++ b/src/test/java/com/mongodb/hibernate/internal/translate/mongoast/command/AstInsertCommandTests.java
@@ -16,7 +16,7 @@
 
 package com.mongodb.hibernate.internal.translate.mongoast.command;
 
-import static com.mongodb.hibernate.internal.translate.mongoast.AstNodeAssertions.assertRender;
+import static com.mongodb.hibernate.internal.translate.mongoast.AstNodeAssertions.assertRendering;
 
 import com.mongodb.hibernate.internal.translate.mongoast.AstDocument;
 import com.mongodb.hibernate.internal.translate.mongoast.AstElement;
@@ -41,8 +41,8 @@ class AstInsertCommandTests {
 
         var expectedJson =
                 """
-                {"insert": "books", "documents": [{"title": "War and Peace", "year": 1867, "_id": {"$undefined": true}}]}\
+                {"insert": "books", "documents": [{"title": "War and Peace", "year": {"$numberInt": "1867"}, "_id": {"$undefined": true}}]}\
                 """;
-        assertRender(expectedJson, insertCommand);
+        assertRendering(expectedJson, insertCommand);
     }
 }

--- a/src/test/java/com/mongodb/hibernate/internal/translate/mongoast/command/AstUpdateCommandTests.java
+++ b/src/test/java/com/mongodb/hibernate/internal/translate/mongoast/command/AstUpdateCommandTests.java
@@ -16,7 +16,7 @@
 
 package com.mongodb.hibernate.internal.translate.mongoast.command;
 
-import static com.mongodb.hibernate.internal.translate.mongoast.AstNodeAssertions.assertRender;
+import static com.mongodb.hibernate.internal.translate.mongoast.AstNodeAssertions.assertRendering;
 
 import com.mongodb.hibernate.internal.translate.mongoast.AstFieldUpdate;
 import com.mongodb.hibernate.internal.translate.mongoast.AstLiteralValue;
@@ -49,8 +49,8 @@ class AstUpdateCommandTests {
 
         final String expectedJson =
                 """
-                {"update": "books", "updates": [{"q": {"_id": {"$eq": 12345}}, "u": {"$set": {"title": "War and Peace", "author": "Leo Tolstoy"}}, "multi": true}]}\
+                {"update": "books", "updates": [{"q": {"_id": {"$eq": {"$numberLong": "12345"}}}, "u": {"$set": {"title": "War and Peace", "author": "Leo Tolstoy"}}, "multi": true}]}\
                 """;
-        assertRender(expectedJson, updateCommand);
+        assertRendering(expectedJson, updateCommand);
     }
 }

--- a/src/test/java/com/mongodb/hibernate/internal/translate/mongoast/command/aggregate/AstAggregateCommandTests.java
+++ b/src/test/java/com/mongodb/hibernate/internal/translate/mongoast/command/aggregate/AstAggregateCommandTests.java
@@ -16,7 +16,7 @@
 
 package com.mongodb.hibernate.internal.translate.mongoast.command.aggregate;
 
-import static com.mongodb.hibernate.internal.translate.mongoast.AstNodeAssertions.assertRender;
+import static com.mongodb.hibernate.internal.translate.mongoast.AstNodeAssertions.assertRendering;
 
 import com.mongodb.hibernate.internal.translate.mongoast.AstLiteralValue;
 import com.mongodb.hibernate.internal.translate.mongoast.filter.AstComparisonFilterOperation;
@@ -39,8 +39,8 @@ class AstAggregateCommandTests {
         var aggregateCommand = new AstAggregateCommand("books", List.of(matchStage, projectStage));
         var expectedJson =
                 """
-                {"aggregate": "books", "pipeline": [{"$match": {"_id": {"$eq": 1}}}, {"$project": {"title": true}}]}\
+                {"aggregate": "books", "pipeline": [{"$match": {"_id": {"$eq": {"$numberInt": "1"}}}}, {"$project": {"title": true}}]}\
                 """;
-        assertRender(expectedJson, aggregateCommand);
+        assertRendering(expectedJson, aggregateCommand);
     }
 }

--- a/src/test/java/com/mongodb/hibernate/internal/translate/mongoast/command/aggregate/AstMatchStageTests.java
+++ b/src/test/java/com/mongodb/hibernate/internal/translate/mongoast/command/aggregate/AstMatchStageTests.java
@@ -16,7 +16,7 @@
 
 package com.mongodb.hibernate.internal.translate.mongoast.command.aggregate;
 
-import static com.mongodb.hibernate.internal.translate.mongoast.AstNodeAssertions.assertRender;
+import static com.mongodb.hibernate.internal.translate.mongoast.AstNodeAssertions.assertRendering;
 import static com.mongodb.hibernate.internal.translate.mongoast.filter.AstComparisonFilterOperator.EQ;
 
 import com.mongodb.hibernate.internal.translate.mongoast.AstLiteralValue;
@@ -38,6 +38,6 @@ class AstMatchStageTests {
         var expectedJson = """
                 {"$match": {"title": {"$eq": "Jane Eyre"}}}\
                 """;
-        assertRender(expectedJson, astMatchStage);
+        assertRendering(expectedJson, astMatchStage);
     }
 }

--- a/src/test/java/com/mongodb/hibernate/internal/translate/mongoast/command/aggregate/AstProjectStageIncludeSpecificationTests.java
+++ b/src/test/java/com/mongodb/hibernate/internal/translate/mongoast/command/aggregate/AstProjectStageIncludeSpecificationTests.java
@@ -16,7 +16,7 @@
 
 package com.mongodb.hibernate.internal.translate.mongoast.command.aggregate;
 
-import static com.mongodb.hibernate.internal.translate.mongoast.AstNodeAssertions.assertElementRender;
+import static com.mongodb.hibernate.internal.translate.mongoast.AstNodeAssertions.assertElementRendering;
 
 import org.junit.jupiter.api.Test;
 
@@ -28,6 +28,6 @@ class AstProjectStageIncludeSpecificationTests {
         var expectedJson = """
                            {"name": true}\
                            """;
-        assertElementRender(expectedJson, projectStageIncludeSpecification);
+        assertElementRendering(expectedJson, projectStageIncludeSpecification);
     }
 }

--- a/src/test/java/com/mongodb/hibernate/internal/translate/mongoast/command/aggregate/AstProjectStageTests.java
+++ b/src/test/java/com/mongodb/hibernate/internal/translate/mongoast/command/aggregate/AstProjectStageTests.java
@@ -16,7 +16,7 @@
 
 package com.mongodb.hibernate.internal.translate.mongoast.command.aggregate;
 
-import static com.mongodb.hibernate.internal.translate.mongoast.AstNodeAssertions.assertRender;
+import static com.mongodb.hibernate.internal.translate.mongoast.AstNodeAssertions.assertRendering;
 import static java.util.Collections.singletonList;
 
 import org.junit.jupiter.api.Test;
@@ -29,6 +29,6 @@ class AstProjectStageTests {
         var expectedJson = """
                            {"$project": {"title": true}}\
                            """;
-        assertRender(expectedJson, astProjectStage);
+        assertRendering(expectedJson, astProjectStage);
     }
 }

--- a/src/test/java/com/mongodb/hibernate/internal/translate/mongoast/filter/AstComparisonFilterOperationTests.java
+++ b/src/test/java/com/mongodb/hibernate/internal/translate/mongoast/filter/AstComparisonFilterOperationTests.java
@@ -16,7 +16,7 @@
 
 package com.mongodb.hibernate.internal.translate.mongoast.filter;
 
-import static com.mongodb.hibernate.internal.translate.mongoast.AstNodeAssertions.assertRender;
+import static com.mongodb.hibernate.internal.translate.mongoast.AstNodeAssertions.assertRendering;
 
 import com.mongodb.hibernate.internal.translate.mongoast.AstLiteralValue;
 import org.bson.BsonInt32;
@@ -31,9 +31,9 @@ class AstComparisonFilterOperationTests {
         var operation = new AstComparisonFilterOperation(operator, new AstLiteralValue(new BsonInt32(1)));
 
         var expectedJson = """
-                           {"%s": 1}\
+                           {"%s": {"$numberInt": "1"}}\
                            """
                 .formatted(operator.getOperatorName());
-        assertRender(expectedJson, operation);
+        assertRendering(expectedJson, operation);
     }
 }

--- a/src/test/java/com/mongodb/hibernate/internal/translate/mongoast/filter/AstFieldOperationFilterTests.java
+++ b/src/test/java/com/mongodb/hibernate/internal/translate/mongoast/filter/AstFieldOperationFilterTests.java
@@ -16,7 +16,7 @@
 
 package com.mongodb.hibernate.internal.translate.mongoast.filter;
 
-import static com.mongodb.hibernate.internal.translate.mongoast.AstNodeAssertions.assertRender;
+import static com.mongodb.hibernate.internal.translate.mongoast.AstNodeAssertions.assertRendering;
 import static com.mongodb.hibernate.internal.translate.mongoast.filter.AstComparisonFilterOperator.EQ;
 import static com.mongodb.hibernate.internal.translate.mongoast.filter.FilterTestUtils.createFieldOperationFilter;
 
@@ -31,8 +31,8 @@ class AstFieldOperationFilterTests {
         var astFieldOperationFilter = createFieldOperationFilter("fieldName", EQ, new BsonInt32(1));
 
         var expectedJson = """
-                           {"fieldName": {"$eq": 1}}\
-                           """;
-        assertRender(expectedJson, astFieldOperationFilter);
+                {"fieldName": {"$eq": {"$numberInt": "1"}}}\
+                """;
+        assertRendering(expectedJson, astFieldOperationFilter);
     }
 }

--- a/src/test/java/com/mongodb/hibernate/internal/translate/mongoast/filter/AstLogicalFilterTests.java
+++ b/src/test/java/com/mongodb/hibernate/internal/translate/mongoast/filter/AstLogicalFilterTests.java
@@ -16,7 +16,7 @@
 
 package com.mongodb.hibernate.internal.translate.mongoast.filter;
 
-import static com.mongodb.hibernate.internal.translate.mongoast.AstNodeAssertions.assertRender;
+import static com.mongodb.hibernate.internal.translate.mongoast.AstNodeAssertions.assertRendering;
 import static com.mongodb.hibernate.internal.translate.mongoast.filter.AstComparisonFilterOperator.EQ;
 import static com.mongodb.hibernate.internal.translate.mongoast.filter.FilterTestUtils.createFieldOperationFilter;
 
@@ -38,9 +38,9 @@ class AstLogicalFilterTests {
 
         var expectedJson =
                 """
-                {"%s": [{"field1": {"$eq": 1}}, {"field2": {"$eq": "1"}}]}\
+                {"%s": [{"field1": {"$eq": {"$numberInt": "1"}}}, {"field2": {"$eq": "1"}}]}\
                 """
                         .formatted(operator.getOperatorName());
-        assertRender(expectedJson, astLogicalFilter);
+        assertRendering(expectedJson, astLogicalFilter);
     }
 }


### PR DESCRIPTION
During MQL translation, we opted for extended JSON format to ensure type safety. However, in our mongoast rendering unit testing, we still rely on relax format, which defeats the purpose of our design.
This minor PR aims to tighten the testing to ensure the rendering should be 100% as expected in terms of extended format.