### PR TITLE
[Hibernate-92] Fix for java.lang.ClassNotFoundException: com.mongodb.MongoClientSettings

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,9 +35,7 @@ java {
     withSourcesJar()
 }
 
-tasks.withType<Javadoc> {
-    exclude("/com/mongodb/hibernate/internal/**")
-}
+tasks.withType<Javadoc> { exclude("/com/mongodb/hibernate/internal/**") }
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // Integration Test


### PR DESCRIPTION
Updated gradle dependencies for` libs.hibernate.core `and` libs.mongo.java.driver.sync ` to use api instead of implementation based on the issue outlined in [Hibernate-92](https://jira.mongodb.org/browse/HIBERNATE-92)

HIBERNATE-92