### PR TITLE
introduce lombok usage in integrationTest to decrease boilerplate

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -53,6 +53,10 @@ val integrationTestImplementation: Configuration by
     configurations.getting { extendsFrom(configurations.implementation.get()) }
 val integrationTestRuntimeOnly: Configuration by
     configurations.getting { extendsFrom(configurations.runtimeOnly.get()) }
+val integrationTestCompileOnly: Configuration by
+    configurations.getting { extendsFrom(configurations.compileOnly.get()) }
+val integrationTestAnnotationProcessor: Configuration by
+    configurations.getting { extendsFrom(configurations.annotationProcessor.get()) }
 
 val integrationTestTask =
     tasks.register<Test>("integrationTest") {
@@ -110,7 +114,7 @@ spotless {
 tasks.check { dependsOn(tasks.spotlessApply) }
 
 tasks.withType<JavaCompile>().configureEach {
-    options.compilerArgs.addAll(listOf("-Xlint:all", "-Werror"))
+    options.compilerArgs.addAll(listOf("-Xlint:all,-serial,-processing", "-Werror"))
     when (this) {
         tasks.compileJava.get() ->
             options.errorprone {
@@ -138,15 +142,18 @@ buildConfig {
 dependencies {
     testImplementation(libs.bundles.test.common)
     testImplementation(libs.mockito.junit.jupiter)
-    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+    testRuntimeOnly(libs.junit.platform.launcher)
     testCompileOnly(libs.checker.qual)
 
     integrationTestImplementation(libs.bundles.test.common)
-    @Suppress("UnstableApiUsage")
     integrationTestImplementation(libs.hibernate.testing) {
         exclude(group = "org.apache.logging.log4j", module = "log4j-core")
     }
-    integrationTestRuntimeOnly("org.junit.platform:junit-platform-launcher")
+    integrationTestImplementation(libs.lombok)
+    integrationTestRuntimeOnly(libs.junit.platform.launcher)
+
+    integrationTestCompileOnly(libs.lombok)
+    integrationTestAnnotationProcessor(libs.lombok)
 
     api(libs.jspecify)
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,6 +24,7 @@ slf4j-api = "2.0.16"
 logback-classic = "1.5.16"
 mockito = "5.16.0"
 checker-qual = "3.49.1"
+lombok = "1.18.38"
 
 plugin-spotless = "7.0.2"
 plugin-errorprone = "4.1.0"
@@ -33,6 +34,7 @@ plugin-ktfmt = "0.54"
 
 [libraries]
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit-jupiter" }
+junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher" }
 assertj = { module = "org.assertj:assertj-core", version.ref = "assertj" }
 nullaway = { module = "com.uber.nullaway:nullaway", version.ref = "nullaway" }
 jspecify = { module = "org.jspecify:jspecify", version.ref = "jspecify" }
@@ -44,6 +46,7 @@ sl4j-api = { module = "org.slf4j:slf4j-api", version.ref = "slf4j-api" }
 logback-classic = { module = "ch.qos.logback:logback-classic", version.ref = "logback-classic" }
 mockito-junit-jupiter = { module = "org.mockito:mockito-junit-jupiter", version.ref = "mockito" }
 checker-qual = { module = "org.checkerframework:checker-qual", version.ref = "checker-qual" }
+lombok = { module = "org.projectlombok:lombok", version.ref = "lombok" }
 
 [bundles]
 test-common = ["junit-jupiter", "assertj", "logback-classic"]

--- a/src/integrationTest/java/com/mongodb/hibernate/embeddable/EmbeddableIntegrationTests.java
+++ b/src/integrationTest/java/com/mongodb/hibernate/embeddable/EmbeddableIntegrationTests.java
@@ -31,7 +31,9 @@ import jakarta.persistence.Embeddable;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
-import java.util.Objects;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
 import org.bson.BsonDocument;
 import org.hibernate.annotations.Parent;
 import org.hibernate.boot.MetadataSources;
@@ -138,6 +140,8 @@ class EmbeddableIntegrationTests implements SessionFactoryScopeAware {
 
     @Entity
     @Table(name = "items")
+    @NoArgsConstructor
+    @AllArgsConstructor
     static class ItemWithFlattenedValues {
         @Id
         Single flattenedId;
@@ -149,49 +153,23 @@ class EmbeddableIntegrationTests implements SessionFactoryScopeAware {
         @AttributeOverride(name = "flattened.a", column = @Column(name = "flattened2_flattened_a"))
         @AttributeOverride(name = "flattened.b", column = @Column(name = "flattened2_flattened_b"))
         PairWithParent flattened2;
-
-        ItemWithFlattenedValues() {}
-
-        ItemWithFlattenedValues(Single flattenedId, Single flattened1, PairWithParent flattened2) {
-            this.flattenedId = flattenedId;
-            this.flattened1 = flattened1;
-            this.flattened2 = flattened2;
-        }
     }
 
     @Embeddable
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @EqualsAndHashCode
     static class Single {
         int a;
-
-        Single() {}
-
-        Single(int a) {
-            this.a = a;
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (o == null || getClass() != o.getClass()) {
-                return false;
-            }
-            Single single = (Single) o;
-            return a == single.a;
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hashCode(a);
-        }
     }
 
     @Embeddable
+    @NoArgsConstructor
     static class PairWithParent {
         int a;
         Pair flattened;
 
         @Parent ItemWithFlattenedValues parent;
-
-        PairWithParent() {}
 
         PairWithParent(int a, Pair flattened) {
             this.a = a;
@@ -220,18 +198,13 @@ class EmbeddableIntegrationTests implements SessionFactoryScopeAware {
 
     @Entity
     @Table(name = "items")
+    @NoArgsConstructor
+    @AllArgsConstructor
     static class ItemWithOmittedEmptyValue {
         @Id
         int id;
 
         Empty omitted;
-
-        ItemWithOmittedEmptyValue() {}
-
-        ItemWithOmittedEmptyValue(int id, Empty omitted) {
-            this.id = id;
-            this.omitted = omitted;
-        }
     }
 
     @Embeddable

--- a/src/integrationTest/java/com/mongodb/hibernate/embeddable/StructAggregateEmbeddableIntegrationTests.java
+++ b/src/integrationTest/java/com/mongodb/hibernate/embeddable/StructAggregateEmbeddableIntegrationTests.java
@@ -31,6 +31,8 @@ import jakarta.persistence.Embeddable;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
 import org.bson.BsonDocument;
 import org.hibernate.annotations.Parent;
 import org.hibernate.annotations.Struct;
@@ -157,6 +159,8 @@ class StructAggregateEmbeddableIntegrationTests implements SessionFactoryScopeAw
 
     @Entity
     @Table(name = "items")
+    @NoArgsConstructor
+    @AllArgsConstructor
     static class ItemWithNestedValues {
         @Id
         EmbeddableIntegrationTests.Single flattenedId;
@@ -164,37 +168,24 @@ class StructAggregateEmbeddableIntegrationTests implements SessionFactoryScopeAw
         Single nested1;
 
         PairWithParent nested2;
-
-        ItemWithNestedValues() {}
-
-        ItemWithNestedValues(EmbeddableIntegrationTests.Single flattenedId, Single nested1, PairWithParent nested2) {
-            this.flattenedId = flattenedId;
-            this.nested1 = nested1;
-            this.nested2 = nested2;
-        }
     }
 
     @Embeddable
     @Struct(name = "Single")
+    @NoArgsConstructor
+    @AllArgsConstructor
     static class Single {
         int a;
-
-        Single() {}
-
-        Single(int a) {
-            this.a = a;
-        }
     }
 
     @Embeddable
     @Struct(name = "PairWithParent")
+    @NoArgsConstructor
     static class PairWithParent {
         int a;
         Pair nested;
 
         @Parent ItemWithNestedValues parent;
-
-        PairWithParent() {}
 
         PairWithParent(int a, Pair nested) {
             this.a = a;
@@ -224,18 +215,13 @@ class StructAggregateEmbeddableIntegrationTests implements SessionFactoryScopeAw
 
     @Entity
     @Table(name = "items")
+    @NoArgsConstructor
+    @AllArgsConstructor
     static class ItemWithOmittedEmptyValue {
         @Id
         int id;
 
         Empty omitted;
-
-        ItemWithOmittedEmptyValue() {}
-
-        ItemWithOmittedEmptyValue(int id, Empty omitted) {
-            this.id = id;
-            this.omitted = omitted;
-        }
     }
 
     @Embeddable
@@ -315,34 +301,24 @@ class StructAggregateEmbeddableIntegrationTests implements SessionFactoryScopeAw
 
         @Embeddable
         @Struct(name = "PairHavingNonUpdatable")
+        @NoArgsConstructor
+        @AllArgsConstructor
         static class PairHavingNonUpdatable {
             @Column(updatable = false)
             int a;
 
             int b;
-
-            PairHavingNonUpdatable() {}
-
-            PairHavingNonUpdatable(int a, int b) {
-                this.a = a;
-                this.b = b;
-            }
         }
 
         @Entity
         @Table(name = "items")
+        @NoArgsConstructor
+        @AllArgsConstructor
         static class ItemWithNestedValueHavingAllNonInsertable {
             @Id
             int id;
 
             PairAllNonInsertable omitted;
-
-            ItemWithNestedValueHavingAllNonInsertable() {}
-
-            ItemWithNestedValueHavingAllNonInsertable(int id, PairAllNonInsertable omitted) {
-                this.id = id;
-                this.omitted = omitted;
-            }
         }
 
         @Embeddable
@@ -351,36 +327,26 @@ class StructAggregateEmbeddableIntegrationTests implements SessionFactoryScopeAw
 
         @Entity
         @Table(name = "items")
+        @NoArgsConstructor
+        @AllArgsConstructor
         static class ItemWithPolymorphicPersistentAttribute {
             @Id
             int id;
 
             Polymorphic polymorphic;
-
-            ItemWithPolymorphicPersistentAttribute() {}
-
-            ItemWithPolymorphicPersistentAttribute(int id, Polymorphic polymorphic) {
-                this.id = id;
-                this.polymorphic = polymorphic;
-            }
         }
 
         @Embeddable
         @Struct(name = "Polymorphic")
-        abstract static class Polymorphic {
-            Polymorphic() {}
-        }
+        @NoArgsConstructor
+        abstract static class Polymorphic {}
 
         @Embeddable
         @Struct(name = "Concrete")
+        @NoArgsConstructor
+        @AllArgsConstructor
         static class Concrete extends Polymorphic {
             int a;
-
-            Concrete() {}
-
-            Concrete(int a) {
-                this.a = a;
-            }
         }
     }
 }


### PR DESCRIPTION
Forsee a prospect that lots of boilerplate code is required in future integration testing cases. Seems lombok could be exploited to decrease boilerplate so we could focus more on business logic. Only integration test is touched.