### PR TITLE
Make use of the project name consistent with the POM project `name`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# MongoDB Extension of Hibernate ORM
+# MongoDB Hibernate Extension
 
 This product enables applications to use databases managed by the [MongoDB](https://www.mongodb.com/) DBMS
 via [Hibernate ORM](https://hibernate.org/orm/).

--- a/src/main/java/com/mongodb/hibernate/cfg/MongoConfigurator.java
+++ b/src/main/java/com/mongodb/hibernate/cfg/MongoConfigurator.java
@@ -26,7 +26,7 @@ import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.service.spi.Configurable;
 
 /**
- * The configurator of the MongoDB extension of Hibernate ORM.
+ * The configurator of the MongoDB Hibernate Extension.
  *
  * <table>
  *     <caption>Supported configuration properties</caption>

--- a/src/main/java/com/mongodb/hibernate/cfg/package-info.java
+++ b/src/main/java/com/mongodb/hibernate/cfg/package-info.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-/** Program elements related to configuring the MongoDB extension of Hibernate ORM. */
+/** Program elements related to configuring the MongoDB Hibernate Extension. */
 @NullMarked
 package com.mongodb.hibernate.cfg;
 

--- a/src/main/java/com/mongodb/hibernate/internal/cfg/MongoConfiguration.java
+++ b/src/main/java/com/mongodb/hibernate/internal/cfg/MongoConfiguration.java
@@ -21,7 +21,7 @@ import com.mongodb.hibernate.cfg.MongoConfigurator;
 import java.util.function.Consumer;
 
 /**
- * The configuration of the MongoDB extension of Hibernate ORM.
+ * The configuration of the MongoDB Hibernate Extension.
  *
  * @param mongoClientSettings {@link MongoConfigurator#applyToMongoClientSettings(Consumer)}.
  * @param databaseName {@link MongoConfigurator#databaseName(String)}.

--- a/src/main/java/com/mongodb/hibernate/jdbc/MongoConnectionProvider.java
+++ b/src/main/java/com/mongodb/hibernate/jdbc/MongoConnectionProvider.java
@@ -40,7 +40,7 @@ import org.hibernate.service.spi.Stoppable;
 import org.jspecify.annotations.Nullable;
 
 /**
- * A {@link ConnectionProvider} for the MongoDB extension of Hibernate ORM.
+ * A {@link ConnectionProvider} for the MongoDB Hibernate Extension.
  *
  * <p>All the work done via a {@link Connection} {@linkplain MongoConnectionProvider#getConnection() obtained} from this
  * {@linkplain ConnectionProvider} is done within the same {@link ClientSession}.

--- a/src/main/java/com/mongodb/hibernate/service/spi/MongoConfigurationContributor.java
+++ b/src/main/java/com/mongodb/hibernate/service/spi/MongoConfigurationContributor.java
@@ -25,7 +25,7 @@ import org.hibernate.service.spi.Configurable;
 import org.hibernate.service.spi.ServiceContributor;
 
 /**
- * A {@link Service} an application may use for programmatically configuring the MongoDB extension of Hibernate ORM.
+ * A {@link Service} an application may use for programmatically configuring the MongoDB Hibernate Extension.
  *
  * <p>This {@link Service} may be contributed either via a {@link ServiceContributor}, which allows access to
  * {@link StandardServiceRegistryBuilder}, or via a {@link StandardServiceRegistryBuilder} directly, as shown below:
@@ -54,7 +54,7 @@ import org.hibernate.service.spi.ServiceContributor;
 public interface MongoConfigurationContributor extends Service {
 
     /**
-     * Configures the MongoDB extension of Hibernate ORM. This method is called once per instance of
+     * Configures the MongoDB Hibernate Extension. This method is called once per instance of
      * {@link StandardServiceRegistry} that has this {@link MongoConfigurationContributor}
      * {@linkplain StandardServiceRegistryBuilder#addService(Class, Service) added}.
      *


### PR DESCRIPTION
We currently use "MongoDB Hibernate Extension" as the project `name` in the POM, and "A MongoDB Extension of Hibernate ORM" as the project `description` in the POM:https://github.com/mongodb/mongo-hibernate/blob/33d10d52e9994de6b41c864105026a4df2068f62/build.gradle.kts#L168-L169

- This PR makes use of the name in the codebase consistent with aforementioned POM project `name`.
- The GitHub project "About" is equal to the POM project `description`.