### PR TITLE
Throw `SQLFeatureNotSupportedException` when we encounter unexpected data instead of throwing `AssertionError`

### DIFF
--- a/src/main/java/com/mongodb/hibernate/internal/type/MongoStructJdbcType.java
+++ b/src/main/java/com/mongodb/hibernate/internal/type/MongoStructJdbcType.java
@@ -101,8 +101,8 @@ public final class MongoStructJdbcType implements StructJdbcType {
     }
 
     /**
-     * We replaced this method with {@link #createBsonValue(Object, WrapperOptions)} to make it clear that
-     * {@link #createJdbcValue(Object, WrapperOptions)} is not called by Hibernate ORM.
+     * We replaced this method with {@link #createBsonValue(Object, WrapperOptions)}, to make it clear that this method
+     * is not called by Hibernate ORM.
      */
     @Override
     public BsonValue createJdbcValue(@Nullable Object domainValue, WrapperOptions options) {

--- a/src/main/java/com/mongodb/hibernate/internal/type/ValueConversions.java
+++ b/src/main/java/com/mongodb/hibernate/internal/type/ValueConversions.java
@@ -186,11 +186,7 @@ public final class ValueConversions {
         } else if (value instanceof BsonDecimal128 v) {
             return toDomainValue(v);
         } else if (value instanceof BsonString v) {
-            if (domainType.isArray()) {
-                return toDomainValue(v);
-            } else {
-                return toDomainValue(v, domainType);
-            }
+            return toDomainValue(v, domainType);
         } else if (value instanceof BsonBinary v) {
             return toDomainValue(v);
         } else if (value instanceof BsonObjectId v) {
@@ -251,17 +247,25 @@ public final class ValueConversions {
         return value.decimal128Value().bigDecimalValue();
     }
 
-    public static String toStringDomainValue(BsonValue value) {
+    public static String toStringDomainValue(BsonValue value) throws SQLFeatureNotSupportedException {
         return toDomainValue(value.asString(), String.class);
     }
 
-    private static <T> T toDomainValue(BsonString value, Class<T> domainType) {
-        var v = value.getValue();
+    private static <T> T toDomainValue(BsonString value, Class<T> domainType) throws SQLFeatureNotSupportedException {
         Object result;
-        if (domainType.equals(Character.class)) {
-            result = toDomainValue(v);
+        if (domainType.equals(char[].class)) {
+            result = toDomainValue(value);
         } else {
-            result = v;
+            var v = value.getValue();
+            if (domainType.equals(Character.class) && v.length() == 1) {
+                result = toDomainValue(v);
+            } else if (domainType.equals(String.class) || domainType.equals(Object.class)) {
+                result = v;
+            } else {
+                throw new SQLFeatureNotSupportedException(format(
+                        "Value [%s] of type [%s] is not supported for the domain type [%s]",
+                        value, value.getClass().getTypeName(), domainType));
+            }
         }
         return domainType.cast(result);
     }
@@ -306,7 +310,7 @@ public final class ValueConversions {
     }
 
     /** @see #toBsonValue(char[]) */
-    private static char[] toDomainValue(BsonString value) {
+    private static char[] toDomainValue(BsonString value) throws SQLFeatureNotSupportedException {
         return toDomainValue(value, String.class).toCharArray();
     }
 }


### PR DESCRIPTION
This PR addresses concerns left unaddressed in https://github.com/mongodb/mongo-hibernate/pull/95, more specifically: https://github.com/mongodb/mongo-hibernate/pull/95#discussion_r2205979693.

HIBERNATE-58