### PR TITLE
ternary nullness logic implementation

### DIFF
--- a/src/integrationTest/java/com/mongodb/hibernate/query/select/Book.java
+++ b/src/integrationTest/java/com/mongodb/hibernate/query/select/Book.java
@@ -43,6 +43,20 @@ class Book {
         this.outOfStock = outOfStock;
     }
 
+    public Book(
+            int id,
+            String title,
+            Integer publishYear,
+            Boolean outOfStock,
+            Long isbn13,
+            Double discount,
+            BigDecimal price) {
+        this(id, title, publishYear, outOfStock);
+        this.isbn13 = isbn13;
+        this.discount = discount;
+        this.price = price;
+    }
+
     @Override
     public String toString() {
         return "Book{" + "id=" + id + '}';

--- a/src/integrationTest/java/com/mongodb/hibernate/query/select/BooleanExpressionWhereClauseIntegrationTests.java
+++ b/src/integrationTest/java/com/mongodb/hibernate/query/select/BooleanExpressionWhereClauseIntegrationTests.java
@@ -54,9 +54,41 @@ class BooleanExpressionWhereClauseIntegrationTests extends AbstractSelectionQuer
         assertSelectionQuery(
                 "from Book where" + (negated ? " not " : " ") + "outOfStock",
                 Book.class,
-                "{'aggregate': 'books', 'pipeline': [{'$match': {'outOfStock': {'$eq': "
-                        + (negated ? "false" : "true")
-                        + "}}}, {'$project': {'_id': true, 'discount': true, 'isbn13': true, 'outOfStock': true, 'price': true, 'publishYear': true, 'title': true}}]}",
+                """
+                {
+                  "aggregate": "books",
+                  "pipeline": [
+                    {
+                      "$match": {
+                        "$and": [
+                          {
+                            "outOfStock": {
+                              "$eq": %s
+                            }
+                          },
+                          {
+                            "outOfStock": {
+                              "$ne": null
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "$project": {
+                        "_id": true,
+                        "discount": true,
+                        "isbn13": true,
+                        "outOfStock": true,
+                        "price": true,
+                        "publishYear": true,
+                        "title": true
+                      }
+                    }
+                  ]
+                }
+                """
+                        .formatted(negated ? "false" : "true"),
                 negated ? singletonList(bookInStock) : singletonList(bookOutOfStock));
     }
 

--- a/src/integrationTest/java/com/mongodb/hibernate/query/select/SortingSelectQueryIntegrationTests.java
+++ b/src/integrationTest/java/com/mongodb/hibernate/query/select/SortingSelectQueryIntegrationTests.java
@@ -146,9 +146,18 @@ class SortingSelectQueryIntegrationTests extends AbstractSelectionQueryIntegrati
                   "pipeline": [
                     {
                       "$match": {
-                        "outOfStock": {
-                          "$eq": false
-                        }
+                        "$and": [
+                          {
+                            "outOfStock": {
+                              "$eq": false
+                            }
+                          },
+                          {
+                            "outOfStock": {
+                              "$ne": null
+                            }
+                          }
+                        ]
                       }
                     },
                     {

--- a/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/AstLiteralValue.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/AstLiteralValue.java
@@ -17,6 +17,7 @@
 package com.mongodb.hibernate.internal.translate.mongoast;
 
 import org.bson.BsonBoolean;
+import org.bson.BsonNull;
 import org.bson.BsonValue;
 import org.bson.BsonWriter;
 import org.bson.codecs.BsonValueCodec;
@@ -30,6 +31,7 @@ public record AstLiteralValue(BsonValue literalValue) implements AstValue {
 
     public static final AstLiteralValue TRUE = new AstLiteralValue(BsonBoolean.TRUE);
     public static final AstLiteralValue FALSE = new AstLiteralValue(BsonBoolean.FALSE);
+    public static final AstLiteralValue NULL = new AstLiteralValue(BsonNull.VALUE);
 
     @Override
     public void render(BsonWriter writer) {

--- a/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/filter/AstFieldOperationFilter.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/filter/AstFieldOperationFilter.java
@@ -16,9 +16,15 @@
 
 package com.mongodb.hibernate.internal.translate.mongoast.filter;
 
+import static com.mongodb.hibernate.internal.translate.mongoast.filter.AstComparisonFilterOperator.NE;
+import static com.mongodb.hibernate.internal.translate.mongoast.filter.AstLogicalFilterOperator.AND;
+
+import com.mongodb.hibernate.internal.translate.mongoast.AstLiteralValue;
+import java.util.List;
 import org.bson.BsonWriter;
 
 public record AstFieldOperationFilter(String fieldPath, AstFilterOperation filterOperation) implements AstFilter {
+
     @Override
     public void render(BsonWriter writer) {
         writer.writeStartDocument();
@@ -27,5 +33,11 @@ public record AstFieldOperationFilter(String fieldPath, AstFilterOperation filte
             filterOperation.render(writer);
         }
         writer.writeEndDocument();
+    }
+
+    public AstFilter withTernaryNullnessLogicEnforced() {
+        var nullFieldExclusionFilter =
+                new AstFieldOperationFilter(fieldPath, new AstComparisonFilterOperation(NE, AstLiteralValue.NULL));
+        return new AstLogicalFilter(AND, List.<AstFilter>of(this, nullFieldExclusionFilter));
     }
 }


### PR DESCRIPTION
https://jira.mongodb.org/browse/HIBERNATE-74

The most complex and challenging task in m3!

The following constraints are put into place for this PR:

1. only `find` expression is invovled (as discussed previously, `$expr` is out of scope of m3)
2. no field-wise comparison is involved (which shares the above reason for it is not supported by find expression)
3. ternary logic scope is restrictive to filter, not to projection (m3's projection is still restrictive to entity fields, not ad-hoc expression)

The basic idea is to exclude null fields preemptively to emulate HQL/SQL's ternary nullness logic for and only for `AstFieldOperationFilter` translation (`AstLogicalFilter` won't be touched).

for instance, the following is the original Mql translation result containing JDBC placeholder (as the `$match` aggregation stage) for the `from Book where title = :title` HQL selection query):

```
{
  "$match": {
      {
        "title": {
          "$eq": {"$undefined: true}
        }
      }
  }
}
```
This PR will transform it as belows to exclude null title to emulate ternary logic
```
{
  "$match": {
    {
      "$and": [
        {
          "title": {
            "$eq": {"$undefined: true}
          }
        },
        {
          "title": {
            "$ne": null
          }
        }
      ]
    }
}
```

An example involving logical operator (corresponds to HQL: `... where country = :country and age > :age`):

```
{
    "$match": {
      "$and": [
        {
          "$and": [
            {
              "country": {
                "$eq": "CANADA"
              }
            },
            {
              "country": {
                "$ne": null
              }
            }
          ]
        },
        {
          "$and": [
            {
              "age": {
                "$gt": 18
              }
            },
            {
              "age": {
                "$ne": null
              }
            }
          ]
        }
      ]
    }
  }
```
Note that we only replace file comparison expression with its nullness exclusion condition.

Why excluding null field during comparison could work? I give some reasons below:

1. when HQL/SQL encounters a null field, NULL value would be generated and propergated all the way up until it either reaches the where clause top level or some internal `or` operator; regardless it will end up with false and won't contribute to the record to be returned; excluding null fields preemptively ends up with the same retrieval result; in this sense it is an indirect emulation.
2. another natural alternative is to emulate ternary null logic using Mql's verbose counterpart, but it would end up with performance issue for it requires dynamic computing so ended up with linear scanning; the nullness exclusion approach will tap into existing field index without such perf issue

Existing `SimpleSelectQueryIntegrationTests` integration testing cases will showcase the new `null-safe` Mql translation results for they contain resulting Mql validation logic.