### PR TITLE
bump gradle to v9

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -142,7 +142,6 @@ dependencies {
     testCompileOnly(libs.checker.qual)
 
     integrationTestImplementation(libs.bundles.test.common)
-    @Suppress("UnstableApiUsage")
     integrationTestImplementation(libs.hibernate.testing) {
         exclude(group = "org.apache.logging.log4j", module = "log4j-core")
     }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.0.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Gradle v9.0.0 was released recently; however, it seems friendly to this repo. Given it is a major version bumping, it deserves a PR to upgrade.