### PR TITLE
use Hibernate's short-name strategy mechanism to avoid exposing implementation details

### DIFF
--- a/src/integrationTest/resources/hibernate.properties
+++ b/src/integrationTest/resources/hibernate.properties
@@ -1,4 +1,4 @@
-hibernate.dialect=com.mongodb.hibernate.dialect.MongoDialect
-hibernate.connection.provider_class=com.mongodb.hibernate.jdbc.MongoConnectionProvider
+hibernate.dialect=mongodb
+hibernate.connection.provider_class=mongodb-connection-provider
 jakarta.persistence.jdbc.url=mongodb://localhost/mongo-hibernate-test?directConnection=false
 hibernate.query.plan_cache_enabled=false #make tests more isolated from each other

--- a/src/main/java/com/mongodb/hibernate/internal/MongoConstants.java
+++ b/src/main/java/com/mongodb/hibernate/internal/MongoConstants.java
@@ -29,4 +29,7 @@ public final class MongoConstants {
     public static final String MONGO_DBMS_NAME = "MongoDB";
     public static final String MONGO_JDBC_DRIVER_NAME = "MongoDB Java Driver JDBC Adapter";
     public static final String ID_FIELD_NAME = "_id";
+
+    public static final String MONGO_DIALECT_SHORT_NAME = "mongodb";
+    public static final String MONGO_CONNECTION_PROVIDER_SHORT_NAME = "mongodb-connection-provider";
 }

--- a/src/main/java/com/mongodb/hibernate/internal/extension/MongoStrategyContributor.java
+++ b/src/main/java/com/mongodb/hibernate/internal/extension/MongoStrategyContributor.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2025-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.hibernate.internal.extension;
+
+import static com.mongodb.hibernate.internal.MongoConstants.MONGO_CONNECTION_PROVIDER_SHORT_NAME;
+import static com.mongodb.hibernate.internal.MongoConstants.MONGO_DIALECT_SHORT_NAME;
+
+import com.mongodb.hibernate.dialect.MongoDialect;
+import com.mongodb.hibernate.jdbc.MongoConnectionProvider;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.boot.registry.selector.spi.StrategySelector;
+import org.hibernate.dialect.Dialect;
+import org.hibernate.engine.jdbc.connections.spi.ConnectionProvider;
+import org.hibernate.service.spi.ServiceContributor;
+
+public final class MongoStrategyContributor implements ServiceContributor {
+
+    @Override
+    public void contribute(StandardServiceRegistryBuilder serviceRegistryBuilder) {
+        var selector = serviceRegistryBuilder.getBootstrapServiceRegistry().requireService(StrategySelector.class);
+        selector.registerStrategyImplementor(Dialect.class, MONGO_DIALECT_SHORT_NAME, MongoDialect.class);
+        selector.registerStrategyImplementor(
+                ConnectionProvider.class, MONGO_CONNECTION_PROVIDER_SHORT_NAME, MongoConnectionProvider.class);
+    }
+}

--- a/src/main/resources/META-INF/services/org.hibernate.service.spi.ServiceContributor
+++ b/src/main/resources/META-INF/services/org.hibernate.service.spi.ServiceContributor
@@ -1,1 +1,2 @@
 com.mongodb.hibernate.internal.extension.service.StandardServiceRegistryScopedState$ServiceContributor
+com.mongodb.hibernate.internal.extension.MongoStrategyContributor

--- a/src/test/resources/hibernate.properties
+++ b/src/test/resources/hibernate.properties
@@ -1,4 +1,4 @@
-hibernate.dialect=com.mongodb.hibernate.dialect.MongoDialect
-hibernate.connection.provider_class=com.mongodb.hibernate.jdbc.MongoConnectionProvider
+hibernate.dialect=mongodb
+hibernate.connection.provider_class=mongodb-connection-provider
 hibernate.boot.allow_jdbc_metadata_access=false
 jakarta.persistence.jdbc.url=mongodb://host/mongo-hibernate-test?directConnection=false


### PR DESCRIPTION
Hibernate has a Strategy mechanism (a little misleading for it refers to 'short-name' service, instead of Strategy Pattern) as exemplified in Hibernate Integration Guide(https://docs.jboss.org/hibernate/orm/6.6/integrationguide/html_single/Hibernate_Integration_Guide.html) . As the doc explains:

> Think of this as the short naming service. Historically to configure Hibernate users would often need to give fully-qualified name references to internal Hibernate classes. Of course, this has caused lots of problems as we refactor internal code and move these classes around into different package structures. Enter the concept of short-naming, using a well defined and well known short name for the strategy/implementation class.

It might be a good feature to our product with similar concern. The customization is based on the common ServiceLoader mechanism Hibernate mainly depends on (as an example Strategy registration implementation in the doc).

A similar PR used to be created previously: https://github.com/mongodb/mongo-hibernate/pull/34. This PR is a new one based on the latest codebase.

HIBERNATE-124