### PR TITLE
Make `MongoArray` internal

### DIFF
--- a/src/main/java/com/mongodb/hibernate/internal/jdbc/ArrayAdapter.java
+++ b/src/main/java/com/mongodb/hibernate/internal/jdbc/ArrayAdapter.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.mongodb.hibernate.jdbc;
+package com.mongodb.hibernate.internal.jdbc;
 
 import java.sql.Array;
 import java.sql.ResultSet;

--- a/src/main/java/com/mongodb/hibernate/internal/jdbc/MongoArray.java
+++ b/src/main/java/com/mongodb/hibernate/internal/jdbc/MongoArray.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2025-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.hibernate.internal.jdbc;
+
+public final class MongoArray implements ArrayAdapter {
+    private final Object contents;
+
+    public MongoArray(Object contents) {
+        this.contents = contents;
+    }
+
+    @Override
+    public Object getArray() {
+        // Hibernate ORM does not call `Connection.getTypeMap`/`setTypeMap`, therefore we are free to ignore it
+        return contents;
+    }
+}

--- a/src/main/java/com/mongodb/hibernate/internal/jdbc/package-info.java
+++ b/src/main/java/com/mongodb/hibernate/internal/jdbc/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-present MongoDB, Inc.
+ * Copyright 2024-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,18 +14,8 @@
  * limitations under the License.
  */
 
-package com.mongodb.hibernate.jdbc;
+/** The program elements within this package are not part of the public API and may be removed or changed at any time */
+@NullMarked
+package com.mongodb.hibernate.internal.jdbc;
 
-public final class MongoArray implements ArrayAdapter {
-    private final Object contents;
-
-    public MongoArray(Object contents) {
-        this.contents = contents;
-    }
-
-    @Override
-    public Object getArray() {
-        // Hibernate ORM does not call `Connection.getTypeMap`/`setTypeMap`, therefore we are free to ignore it
-        return contents;
-    }
-}
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/com/mongodb/hibernate/internal/type/ValueConversions.java
+++ b/src/main/java/com/mongodb/hibernate/internal/type/ValueConversions.java
@@ -21,7 +21,7 @@ import static com.mongodb.hibernate.internal.MongoAssertions.assertTrue;
 import static com.mongodb.hibernate.internal.MongoAssertions.fail;
 import static java.lang.String.format;
 
-import com.mongodb.hibernate.jdbc.MongoArray;
+import com.mongodb.hibernate.internal.jdbc.MongoArray;
 import java.lang.reflect.Array;
 import java.math.BigDecimal;
 import java.sql.JDBCType;

--- a/src/main/java/com/mongodb/hibernate/jdbc/MongoConnection.java
+++ b/src/main/java/com/mongodb/hibernate/jdbc/MongoConnection.java
@@ -24,6 +24,7 @@ import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoDatabase;
 import com.mongodb.hibernate.internal.BuildConfig;
 import com.mongodb.hibernate.internal.cfg.MongoConfiguration;
+import com.mongodb.hibernate.internal.jdbc.MongoArray;
 import java.sql.Array;
 import java.sql.DatabaseMetaData;
 import java.sql.PreparedStatement;


### PR DESCRIPTION
I noticed that `MongoArray` is `public` (and has to be), and is in the `com.mongodb.hibernate.jdbc` package, which makes it part of the public API, and is not right.