### PR TITLE
HIBERNATE-71 allow isNull

### DIFF
--- a/src/integrationTest/java/com/mongodb/hibernate/query/select/SimpleSelectQueryIntegrationTests.java
+++ b/src/integrationTest/java/com/mongodb/hibernate/query/select/SimpleSelectQueryIntegrationTests.java
@@ -872,6 +872,195 @@ class SimpleSelectQueryIntegrationTests extends AbstractQueryIntegrationTests {
         }
     }
 
+    /**
+     * HQL {@code is null} / {@code is not null} are translated to MongoDB's native equality against {@code null}, so
+     * {@code is null} matches both null-valued and missing fields and {@code is not null} matches the complement
+     * (existing and non-null). This is consistent with the MQL semantics adopted in HIBERNATE-74.
+     */
+    @Nested
+    class IsNull {
+
+        private static final List<Contact> testingContacts = List.of(
+                new Contact(1, "Bob", 18, Country.USA),
+                new Contact(2, "Mary", 35, null),
+                new Contact(3, "Dylan", 7, Country.CANADA),
+                new Contact(4, "Lucy", 78, null));
+
+        @BeforeEach
+        void beforeEach() {
+            getSessionFactoryScope().inTransaction(session -> testingContacts.forEach(session::persist));
+            getTestCommandListener().clear();
+        }
+
+        private static List<Contact> getTestingContacts(final Predicate<Contact> filter) {
+            return testingContacts.stream().filter(filter).toList();
+        }
+
+        @Test
+        void testIsNull() {
+            assertSelectionQuery(
+                    "from Contact where country is null",
+                    Contact.class,
+                    """
+                    {
+                      "aggregate": "contacts",
+                      "pipeline": [
+                        {
+                          "$match": {
+                            "country": {
+                              "$eq": null
+                            }
+                          }
+                        },
+                        {
+                          "$project": {
+                            "_id": true,
+                            "age": true,
+                            "country": true,
+                            "name": true
+                          }
+                        }
+                      ]
+                    }""",
+                    getTestingContacts(contact -> contact.country == null),
+                    Set.of(Contact.COLLECTION_NAME));
+        }
+
+        @Test
+        void testIsNullOnAliasQualifiedPath() {
+            // Goes through BasicValuedPathInterpretation rather than a bare ColumnReference
+            assertSelectionQuery(
+                    "from Contact c where c.country is null",
+                    Contact.class,
+                    """
+                    {
+                      "aggregate": "contacts",
+                      "pipeline": [
+                        {
+                          "$match": {
+                            "country": {
+                              "$eq": null
+                            }
+                          }
+                        },
+                        {
+                          "$project": {
+                            "_id": true,
+                            "age": true,
+                            "country": true,
+                            "name": true
+                          }
+                        }
+                      ]
+                    }""",
+                    getTestingContacts(contact -> contact.country == null),
+                    Set.of(Contact.COLLECTION_NAME));
+        }
+
+        @Test
+        void testIsNotNull() {
+            assertSelectionQuery(
+                    "from Contact where country is not null",
+                    Contact.class,
+                    """
+                    {
+                      "aggregate": "contacts",
+                      "pipeline": [
+                        {
+                          "$match": {
+                            "country": {
+                              "$ne": null
+                            }
+                          }
+                        },
+                        {
+                          "$project": {
+                            "_id": true,
+                            "age": true,
+                            "country": true,
+                            "name": true
+                          }
+                        }
+                      ]
+                    }""",
+                    getTestingContacts(contact -> contact.country != null),
+                    Set.of(Contact.COLLECTION_NAME));
+        }
+
+        @Test
+        void testIsNullAndOtherPredicate() {
+            assertSelectionQuery(
+                    "from Contact where country is null and age > 30",
+                    Contact.class,
+                    """
+                    {
+                      "aggregate": "contacts",
+                      "pipeline": [
+                        {
+                          "$match": {
+                            "$and": [
+                              {
+                                "country": {
+                                  "$eq": null
+                                }
+                              },
+                              {
+                                "age": {
+                                  "$gt": 30
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "$project": {
+                            "_id": true,
+                            "age": true,
+                            "country": true,
+                            "name": true
+                          }
+                        }
+                      ]
+                    }""",
+                    getTestingContacts(contact -> contact.country == null && contact.age > 30),
+                    Set.of(Contact.COLLECTION_NAME));
+        }
+
+        @Test
+        void testNotIsNull() {
+            assertSelectionQuery(
+                    "from Contact where not (country is null)",
+                    Contact.class,
+                    """
+                    {
+                      "aggregate": "contacts",
+                      "pipeline": [
+                        {
+                          "$match": {
+                            "$nor": [
+                              {
+                                "country": {
+                                  "$eq": null
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "$project": {
+                            "_id": true,
+                            "age": true,
+                            "country": true,
+                            "name": true
+                          }
+                        }
+                      ]
+                    }""",
+                    getTestingContacts(contact -> contact.country != null),
+                    Set.of(Contact.COLLECTION_NAME));
+        }
+    }
+
     @Nested
     class Unsupported {
         @Test
@@ -919,6 +1108,16 @@ class SimpleSelectQueryIntegrationTests extends AbstractQueryIntegrationTests {
                     q -> q.setParameter("param", 1),
                     FeatureNotSupportedException.class,
                     "Only the following comparisons are supported: field vs literal, field vs parameter");
+        }
+
+        @Test
+        void testIsNullOnParameterNotSupported() {
+            assertSelectQueryFailure(
+                    "from Contact where :param is null",
+                    Contact.class,
+                    q -> q.setParameter("param", "x"),
+                    FeatureNotSupportedException.class,
+                    "Only the following nullness predicates are supported: field is [not] null");
         }
 
         @Test

--- a/src/main/java/com/mongodb/hibernate/internal/translate/AbstractMqlTranslator.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/AbstractMqlTranslator.java
@@ -93,6 +93,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import org.bson.BsonNull;
 import org.bson.BsonValue;
 import org.bson.json.JsonWriter;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
@@ -1050,7 +1051,15 @@ public abstract class AbstractMqlTranslator<T extends JdbcOperation> implements 
 
     @Override
     public void visitNullnessPredicate(NullnessPredicate nullnessPredicate) {
-        throw new FeatureNotSupportedException();
+        var expression = nullnessPredicate.getExpression();
+        if (!isFieldPathExpression(expression)) {
+            throw new FeatureNotSupportedException(
+                    "Only the following nullness predicates are supported: field is [not] null");
+        }
+        var fieldPath = acceptAndYield(expression, FIELD_PATH);
+        var operator = nullnessPredicate.isNegated() ? NE : EQ;
+        var operation = new AstComparisonFilterOperation(operator, new AstLiteral(BsonNull.VALUE));
+        astVisitorValueHolder.yield(FILTER, new AstFieldOperationFilter(fieldPath, operation));
     }
 
     @Override


### PR DESCRIPTION
[HIBERNATE-71](https://jira.mongodb.org/browse/HIBERNATE-71) allow isNull keyword to be used in HQL 