### PR TITLE
HIBERNATE-192: extract Gradle convention plugins into buildSrc

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,27 +16,18 @@
 
 import java.time.Duration
 import net.ltgt.gradle.errorprone.errorprone
-import org.gradle.api.tasks.testing.logging.TestLogEvent
 
 plugins {
     id("eclipse")
-    id("idea")
-    id("java-library")
-    id("spotless-java-extension")
-    id("maven-publish")
-    id("signing")
+    id("mongo-hibernate-java")
+    id("mongo-hibernate-integration-test")
+    id("mongo-hibernate-publish")
     alias(libs.plugins.errorprone)
     alias(libs.plugins.buildconfig)
     alias(libs.plugins.nexus.publish)
 }
 
 repositories { mavenCentral() }
-
-java {
-    toolchain { languageVersion = JavaLanguageVersion.of(17) } // Remember to update javadoc links
-    withJavadocJar()
-    withSourcesJar()
-}
 
 tasks.withType<Javadoc> {
     val standardDocletOptions = options as StandardJavadocDocletOptions
@@ -72,49 +63,6 @@ tasks.withType<Javadoc> {
 }
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-// Integration Test
-
-// Added `Action` explicitly due to an intellij 2025.2 false positive: https://youtrack.jetbrains.com/issue/KTIJ-34210
-sourceSets {
-    create(
-        "integrationTest",
-        Action {
-            compileClasspath += sourceSets.main.get().output
-            runtimeClasspath += sourceSets.main.get().output
-        },
-    )
-}
-
-val integrationTestSourceSet: SourceSet = sourceSets["integrationTest"]
-
-val integrationTestImplementation: Configuration by
-    configurations.getting { extendsFrom(configurations.implementation.get()) }
-val integrationTestRuntimeOnly: Configuration by
-    configurations.getting { extendsFrom(configurations.runtimeOnly.get()) }
-
-val integrationTestTask =
-    tasks.register<Test>("integrationTest") {
-        group = LifecycleBasePlugin.VERIFICATION_GROUP
-        testClassesDirs = integrationTestSourceSet.output.classesDirs
-        classpath = integrationTestSourceSet.runtimeClasspath
-    }
-
-tasks.check { dependsOn(integrationTestTask) }
-
-tasks.withType<Test>().configureEach {
-    useJUnitPlatform()
-    testLogging { events(TestLogEvent.PASSED, TestLogEvent.SKIPPED, TestLogEvent.FAILED) }
-}
-
-// https://youtrack.jetbrains.com/issue/IDEA-234382/Gradle-integration-tests-are-not-marked-as-test-sources-resources
-idea {
-    module {
-        testSources.from(integrationTestSourceSet.allSource.srcDirs)
-        testResources.from(integrationTestSourceSet.resources.srcDirs)
-    }
-}
-
-// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // Static Analysis
 
 spotless {
@@ -144,8 +92,6 @@ spotless {
         endWithNewline()
     }
 }
-
-tasks.check { dependsOn(tasks.spotlessApply) }
 
 tasks.withType<JavaCompile>().configureEach {
     options.compilerArgs.addAll(
@@ -212,25 +158,7 @@ dependencies {
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // Publishing
 
-val localBuildRepo: Provider<Directory> = project.layout.buildDirectory.dir("repo")
-
-tasks.named<Delete>("clean") { delete.add(localBuildRepo) }
-
-tasks.withType<GenerateModuleMetadata> { enabled = false }
-
 publishing {
-    repositories {
-        // publish to local build dir for testing
-        // `./gradlew publishMavenPublicationToLocalBuildRepository`
-        //
-        // publish to the local Maven cache
-        // `./gradlew publishToMavenLocal`
-        maven {
-            url = uri(localBuildRepo.get())
-            name = "LocalBuild"
-        }
-    }
-
     publications {
         create<MavenPublication>("mavenJava") {
             groupId = "org.mongodb"
@@ -239,53 +167,18 @@ publishing {
             pom {
                 name = "MongoDB Extension for Hibernate ORM"
                 description = "An extension providing MongoDB support to Hibernate ORM"
-                url = "https://www.mongodb.com/"
-                licenses {
-                    license {
-                        name = "Apache License, Version 2.0"
-                        url = "https://www.apache.org/licenses/LICENSE-2.0"
-                    }
-                }
-                developers {
-                    developer {
-                        name.set("Various")
-                        organization.set("MongoDB")
-                    }
-                }
-                scm {
-                    url.set("https://github.com/mongodb/mongo-hibernate")
-                    connection.set("scm:git:https://github.com/mongodb/mongo-hibernate.git")
-                    developerConnection.set("scm:git:https://github.com/mongodb/mongo-hibernate.git")
-                }
+                // url, licenses, developers, scm injected by mongo-hibernate-publish plugin
             }
         }
     }
 }
 
-// Artifact signing
-signing {
-    val signingKey: String? = providers.gradleProperty("signingKey").getOrNull()
-    val signingPassword: String? = providers.gradleProperty("signingPassword").getOrNull()
-    if (signingKey != null && signingPassword != null) {
-        logger.info("[${project.displayName}] Signing is enabled")
-        useInMemoryPgpKeys(signingKey, signingPassword)
-        sign(publishing.publications["mavenJava"])
-    } else {
-        logger.info("[${project.displayName}] No Signing keys found, skipping signing configuration")
-    }
-}
-
-// Publishing to the central sonatype portal currently requires the gradle nexus publishing plugin
-// Adds a `publishToSonatype` task
-val nexusUsername: Provider<String> = providers.gradleProperty("nexusUsername")
-val nexusPassword: Provider<String> = providers.gradleProperty("nexusPassword")
-
 nexusPublishing {
     packageGroup.set("org.mongodb")
     repositories {
         sonatype {
-            username.set(nexusUsername)
-            password.set(nexusPassword)
+            username.set(providers.gradleProperty("nexusUsername"))
+            password.set(providers.gradleProperty("nexusPassword"))
 
             // central portal URLs
             nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))

--- a/buildSrc/src/main/kotlin/mongo-hibernate-integration-test.gradle.kts
+++ b/buildSrc/src/main/kotlin/mongo-hibernate-integration-test.gradle.kts
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2025-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins {
+    id("java-library")
+    id("idea")
+}
+
+// Added `Action` explicitly due to an intellij 2025.2 false positive: https://youtrack.jetbrains.com/issue/KTIJ-34210
+sourceSets {
+    create(
+        "integrationTest",
+        Action {
+            compileClasspath += sourceSets.main.get().output
+            runtimeClasspath += sourceSets.main.get().output
+        },
+    )
+}
+
+val integrationTestSourceSet: SourceSet = sourceSets["integrationTest"]
+
+val integrationTestImplementation: Configuration by
+    configurations.getting { extendsFrom(configurations.implementation.get()) }
+val integrationTestRuntimeOnly: Configuration by
+    configurations.getting { extendsFrom(configurations.runtimeOnly.get()) }
+
+tasks.register<Test>("integrationTest") {
+    group = LifecycleBasePlugin.VERIFICATION_GROUP
+    testClassesDirs = integrationTestSourceSet.output.classesDirs
+    classpath = integrationTestSourceSet.runtimeClasspath
+}
+
+tasks.check { dependsOn(tasks.named("integrationTest")) }
+
+// https://youtrack.jetbrains.com/issue/IDEA-234382/Gradle-integration-tests-are-not-marked-as-test-sources-resources
+idea {
+    module {
+        testSources.from(integrationTestSourceSet.allSource.srcDirs)
+        testResources.from(integrationTestSourceSet.resources.srcDirs)
+    }
+}

--- a/buildSrc/src/main/kotlin/mongo-hibernate-java.gradle.kts
+++ b/buildSrc/src/main/kotlin/mongo-hibernate-java.gradle.kts
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2025-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.gradle.api.tasks.testing.logging.TestLogEvent
+
+plugins {
+    id("java-library")
+    id("spotless-java-extension")
+}
+
+java {
+    toolchain { languageVersion = JavaLanguageVersion.of(17) } // Remember to update javadoc links
+    withJavadocJar()
+    withSourcesJar()
+}
+
+tasks.withType<Test>().configureEach {
+    useJUnitPlatform()
+    testLogging { events(TestLogEvent.PASSED, TestLogEvent.SKIPPED, TestLogEvent.FAILED) }
+}
+
+tasks.check { dependsOn(tasks.spotlessApply) }

--- a/buildSrc/src/main/kotlin/mongo-hibernate-publish.gradle.kts
+++ b/buildSrc/src/main/kotlin/mongo-hibernate-publish.gradle.kts
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2025-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins {
+    id("maven-publish")
+    id("signing")
+}
+
+val localBuildRepo: Provider<Directory> = project.layout.buildDirectory.dir("repo")
+
+tasks.named<Delete>("clean") { delete.add(localBuildRepo) }
+
+tasks.withType<GenerateModuleMetadata> { enabled = false }
+
+publishing {
+    repositories {
+        // publish to local build dir for testing:
+        //   ./gradlew publishMavenPublicationToLocalBuildRepository
+        // publish to the local Maven cache:
+        //   ./gradlew publishToMavenLocal
+        maven {
+            url = uri(localBuildRepo.get())
+            name = "LocalBuild"
+        }
+    }
+}
+
+// Inject the common POM fields into every MavenPublication defined in the consuming project.
+publishing {
+    publications.withType<MavenPublication>().configureEach {
+        pom {
+            url = "https://www.mongodb.com/"
+            licenses {
+                license {
+                    name = "Apache License, Version 2.0"
+                    url = "https://www.apache.org/licenses/LICENSE-2.0"
+                }
+            }
+            developers {
+                developer {
+                    name.set("Various")
+                    organization.set("MongoDB")
+                }
+            }
+            scm {
+                url.set("https://github.com/mongodb/mongo-hibernate")
+                connection.set("scm:git:https://github.com/mongodb/mongo-hibernate.git")
+                developerConnection.set("scm:git:https://github.com/mongodb/mongo-hibernate.git")
+            }
+        }
+    }
+}
+
+signing {
+    val signingKey: String? = providers.gradleProperty("signingKey").getOrNull()
+    val signingPassword: String? = providers.gradleProperty("signingPassword").getOrNull()
+    if (signingKey != null && signingPassword != null) {
+        logger.info("[${project.displayName}] Signing is enabled")
+        useInMemoryPgpKeys(signingKey, signingPassword)
+        sign(publishing.publications) // signs all publications in the project, not just a named one
+    } else {
+        logger.info("[${project.displayName}] No Signing keys found, skipping signing configuration")
+    }
+}


### PR DESCRIPTION
Pull the shared java-library, integration-test source set, and publishing/signing configuration out of the root build into reusable convention plugins, so the new Spring Boot subprojects can apply them instead of duplicating the setup.

HIBERNATE-192, which is a subtask of HIBERNATE-172.