### PR TITLE
HIBERNATE-172: Spring Boot auto-configuration and starter for MongoDB-backed JPA

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,40 +71,40 @@ spring.mongodb.uri=mongodb://localhost/mydb
 When `spring.jpa.database-platform` is `MongoDB`, the starter auto-configures a JPA
 `EntityManagerFactory`, a `JpaTransactionManager`, and Spring Data JPA repositories backed by MongoDB.
 The connection is configured through Spring Boot's `spring-boot-mongodb` support (the `spring.mongodb.*`
-namespace), and the integration **borrows that `MongoClient`** rather than creating its own — a single
+namespace), and the integration **borrows that `MongoClient`** rather than creating its own: a single
 connection pool shared with health checks, metrics, and any other use of the Spring-managed client. This
 reuses `spring-boot-mongodb`'s client infrastructure and is **not** Spring Data MongoDB.
 
 The starter brings no SQL connection pool, so a MongoDB-only application needs no `spring.datasource.url`
 and Spring Boot's `DataSourceAutoConfiguration` stays inert. Without `spring.jpa.database-platform=MongoDB`
-the starter contributes nothing — it is safe to have on the classpath of a non-MongoDB application.
+the starter contributes nothing. It is safe to have on the classpath of a non-MongoDB application.
 
 #### Requirements
 
-The starter requires **Spring Boot 4.x** and **Hibernate ORM 7.3 or later** (the version the MongoDB
+The starter requires **Spring Boot 4.x** and **Hibernate ORM 7.4 or later** (the version the MongoDB
 extension is built against). Spring Boot manages the Hibernate version through its BOM, and some
-Spring Boot 4.x releases still ship an older Hibernate — for example, Spring Boot 4.0.6 manages
-Hibernate 7.2.12. When the managed version is below 7.3, the application fails to start with a
-`NoSuchMethodError` from the MongoDB dialect. Until your Spring Boot version's BOM ships Hibernate 7.3
+Spring Boot 4.x releases still ship an older Hibernate, for example, Spring Boot 4.0.6 manages
+Hibernate 7.2.12. When the managed version is below 7.4, the application fails to start with a
+`NoSuchMethodError` from the MongoDB dialect. Until your Spring Boot version's BOM ships Hibernate 7.4
 or later, override the managed version:
 
 Gradle (with the Spring Boot or `io.spring.dependency-management` plugin):
 
 ```groovy
-ext['hibernate.version'] = '7.3.6.Final'
+ext['hibernate.version'] = '7.4.1.Final'
 ```
 
 Maven:
 
 ```xml
 <properties>
-    <hibernate.version>7.3.6.Final</hibernate.version>
+    <hibernate.version>7.4.1.Final</hibernate.version>
 </properties>
 ```
 
 #### Configuration
 
-The standard Spring Boot JPA properties under `spring.jpa.*` are honored — for example
+The standard Spring Boot JPA properties under `spring.jpa.*` are honored. For example
 `spring.jpa.show-sql`, `spring.jpa.hibernate.ddl-auto`, and `spring.jpa.properties.*`, along with any
 `HibernatePropertiesCustomizer` / `EntityManagerFactoryBuilderCustomizer` beans and
 `spring.jpa.open-in-view` (Open Session in View, on by default in servlet web applications).

--- a/README.md
+++ b/README.md
@@ -53,6 +53,93 @@ The Java module with example applications is located in
 
 The examples may be run by running the smoke tests as specified in [Run Smoke Tests](#run-smoke-tests).
 
+### Spring Boot
+
+A [Spring Boot](https://spring.io/projects/spring-boot) starter lets a Spring Boot 4.x application use
+MongoDB through JPA. Add the starter
+
+`org.mongodb:mongodb-hibernate-spring-boot-starter`
+
+declare MongoDB as the JPA platform, and configure the connection with Spring Boot's standard
+`spring.mongodb.*` properties (the value is a [MongoDB connection string](https://www.mongodb.com/docs/manual/reference/connection-string/)):
+
+```properties
+spring.jpa.database-platform=MongoDB
+spring.mongodb.uri=mongodb://localhost/mydb
+```
+
+When `spring.jpa.database-platform` is `MongoDB`, the starter auto-configures a JPA
+`EntityManagerFactory`, a `JpaTransactionManager`, and Spring Data JPA repositories backed by MongoDB.
+The connection is configured through Spring Boot's `spring-boot-mongodb` support (the `spring.mongodb.*`
+namespace), and the integration **borrows that `MongoClient`** rather than creating its own — a single
+connection pool shared with health checks, metrics, and any other use of the Spring-managed client. This
+reuses `spring-boot-mongodb`'s client infrastructure and is **not** Spring Data MongoDB.
+
+The starter brings no SQL connection pool, so a MongoDB-only application needs no `spring.datasource.url`
+and Spring Boot's `DataSourceAutoConfiguration` stays inert. Without `spring.jpa.database-platform=MongoDB`
+the starter contributes nothing — it is safe to have on the classpath of a non-MongoDB application.
+
+#### Requirements
+
+The starter requires **Spring Boot 4.x** and **Hibernate ORM 7.3 or later** (the version the MongoDB
+extension is built against). Spring Boot manages the Hibernate version through its BOM, and some
+Spring Boot 4.x releases still ship an older Hibernate — for example, Spring Boot 4.0.6 manages
+Hibernate 7.2.12. When the managed version is below 7.3, the application fails to start with a
+`NoSuchMethodError` from the MongoDB dialect. Until your Spring Boot version's BOM ships Hibernate 7.3
+or later, override the managed version:
+
+Gradle (with the Spring Boot or `io.spring.dependency-management` plugin):
+
+```groovy
+ext['hibernate.version'] = '7.3.6.Final'
+```
+
+Maven:
+
+```xml
+<properties>
+    <hibernate.version>7.3.6.Final</hibernate.version>
+</properties>
+```
+
+#### Configuration
+
+The standard Spring Boot JPA properties under `spring.jpa.*` are honored — for example
+`spring.jpa.show-sql`, `spring.jpa.hibernate.ddl-auto`, and `spring.jpa.properties.*`, along with any
+`HibernatePropertiesCustomizer` / `EntityManagerFactoryBuilderCustomizer` beans and
+`spring.jpa.open-in-view` (Open Session in View, on by default in servlet web applications).
+
+The MongoDB connection uses Spring Boot's `spring.mongodb.*` properties. To customize the borrowed
+client further — connection pool sizing, command listeners, UUID representation, and so on — declare a
+`MongoClientSettingsBuilderCustomizer` bean, exactly as for any other `spring-boot-mongodb` application.
+
+#### Field naming
+
+Unlike a SQL Spring Boot application, the default physical naming strategy is **Hibernate's own** (the
+Java property name, e.g. `publishYear`) rather than Spring Boot's `snake_case`. MongoDB has no schema
+to catch a naming mismatch, so a `snake_case` default could silently leave a collection holding a mix
+of field names; keeping Hibernate's default means an entity persists the same way whether bootstrapped
+through this starter or through plain Hibernate ORM. To use `snake_case` (or any other strategy), set
+it explicitly:
+
+```properties
+spring.jpa.hibernate.naming.physical-strategy=org.hibernate.boot.model.naming.PhysicalNamingStrategySnakeCaseImpl
+```
+
+> **Note:** changing the naming strategy after documents have been written changes the field names of
+> *new* documents only; existing documents are not migrated, which can leave a collection with mixed
+> field names.
+
+#### Limitations
+
+- **Testing:** the `@DataJpaTest` slice is not supported (it wires Spring Boot's SQL JPA
+  auto-configuration); use `@SpringBootTest` to test against MongoDB. Slice support is tracked by
+  [HIBERNATE-179](https://jira.mongodb.org/browse/HIBERNATE-179).
+- **Single persistence unit:** a single `@Primary` `EntityManagerFactory` is auto-configured.
+- **Native image:** GraalVM native-image execution is not yet validated.
+- A [replica set](https://www.mongodb.com/docs/manual/reference/glossary/#std-term-replica-set) is
+  required, as transactions are (see [User Documentation](#user-documentation) above).
+
 ### Bug Reports
 
 Use ["Extension for Hibernate ORM" at jira.mongodb.org](https://jira.mongodb.org/projects/HIBERNATE/issues).

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The Java module with example applications is located in
 
 The examples may be run by running the smoke tests as specified in [Run Smoke Tests](#run-smoke-tests).
 
-### Spring Boot
+### Spring Boot & Spring Data JPA
 
 A [Spring Boot](https://spring.io/projects/spring-boot) starter lets a Spring Boot 4.x application use
 MongoDB through JPA. Add the starter
@@ -137,8 +137,6 @@ spring.jpa.hibernate.naming.physical-strategy=org.hibernate.boot.model.naming.Ph
   [HIBERNATE-179](https://jira.mongodb.org/browse/HIBERNATE-179).
 - **Single persistence unit:** a single `@Primary` `EntityManagerFactory` is auto-configured.
 - **Native image:** GraalVM native-image execution is not yet validated.
-- A [replica set](https://www.mongodb.com/docs/manual/reference/glossary/#std-term-replica-set) is
-  required, as transactions are (see [User Documentation](#user-documentation) above).
 
 ### Bug Reports
 

--- a/docs/superpowers/specs/2026-06-07-hibernate-172-design.md
+++ b/docs/superpowers/specs/2026-06-07-hibernate-172-design.md
@@ -1,0 +1,719 @@
+# HIBERNATE-172: Spring Boot auto-configuration and starter for MongoDB-backed JPA
+
+## Goal
+
+In a Spring Boot application, integrate MongoDB-backed JPA via the MongoDB Extension for Hibernate ORM
+with:
+
+- standard Spring configuration of the MongoDB connection (through `spring-boot-mongodb`),
+- a single shared `MongoClient` (connection pool) — no second pool when the application also uses
+  Spring's MongoDB support,
+- the full `spring.jpa.*` property surface (`ddl-auto`, `show-sql`, naming strategies,
+  `HibernatePropertiesCustomizer` / `EntityManagerFactoryBuilderCustomizer` beans),
+- Spring Data JPA repository support without a SQL `DataSource`,
+- a manual path for applications that want a dedicated client or multiple persistence units.
+
+## Background
+
+mongo-hibernate is the MongoDB Extension for Hibernate ORM: it plugs a `MongoDialect` and a
+`MongoConnectionProvider` into Hibernate so JPA entities map to MongoDB. On its own it connects through
+a `MongoClient` created by `MongoConnectionProvider`.
+
+Spring Boot auto-configuration registers `@Configuration` classes that activate conditionally; Spring
+Boot scans `META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports` and loads
+each listed class subject to its `@Conditional` guards. User-defined beans win, and a configuration
+activates only when its prerequisites are met. The conditions used here are `@ConditionalOnClass`
+(class on the classpath), `@ConditionalOnMissingBean` (no user bean of that type),
+`@ConditionalOnBean` / `@ConditionalOnSingleCandidate` (a bean is present), and
+`@ConditionalOnProperty` / `@ConditionalOnBooleanProperty`.
+
+In a Spring Boot 4.x application Spring Boot does not create a `MongoClient` automatically: Spring Boot
+4.0 moved MongoDB auto-configuration out of the monolithic `spring-boot-autoconfigure` into a separate
+`spring-boot-mongodb` module that is not on the classpath unless added explicitly.
+
+A second `MongoClient` is introduced only when the application pursues Spring-native client
+customization. Applications and Spring customize a `MongoClient` through
+`MongoClientSettingsBuilderCustomizer` beans (Micrometer metrics, SSL, UUID representation, event
+listeners). That hook, and the `MongoConnectionDetails` connection infrastructure (Testcontainers,
+Docker Compose, cloud bindings), live in `spring-boot-mongodb`. Using them requires
+`spring-boot-mongodb` on the classpath, at which point its `MongoAutoConfiguration` creates a
+`MongoClient` bean. Building a separate mongo-hibernate client from a connection URL would then yield
+two clients — two connection pools to the same cluster (see [Rejected alternatives](#rejected-alternatives)).
+
+This design keeps `spring-boot-mongodb` available for customization and keeps the client count at one,
+by having `MongoConnectionProvider` borrow the Spring-managed client instead of building its own.
+
+## Version compatibility
+
+The integration targets Spring Boot 4.x and requires Hibernate ORM 7.3 or later; it uses Hibernate 7.3
+APIs and does not run on earlier 7.x.
+
+Spring Boot 3.x (Spring Framework 6.x, Hibernate ORM 6.x) is not compatible. Spring Boot 4.x is the
+first generation that works with the extension, but its BOM may still manage a Hibernate version below
+7.3 (for example, Spring Boot 4.0.6 manages Hibernate 7.2.x). Spring Boot's dependency management
+forces the BOM's Hibernate version onto the application even though the extension requests 7.3, and
+startup then fails with a `NoSuchMethodError` from the dialect. A library cannot raise a dependency
+above the consumer's BOM, so this is resolved on the consumer side.
+
+| Spring Boot | Hibernate ORM in its BOM | Works out of the box |
+|---|---|---|
+| 3.x | 6.x | No — incompatible |
+| 4.x, BOM Hibernate < 7.3 | e.g. 7.2.x | Only after overriding `hibernate.version` to ≥ 7.3 |
+| 4.x, BOM Hibernate ≥ 7.3 | ≥ 7.3 | Yes |
+
+Until a supported Spring Boot release ships Hibernate ≥ 7.3, consumers override the managed version:
+Gradle `ext['hibernate.version'] = '7.3.x.Final'` (with the Spring Boot / `io.spring.dependency-management`
+plugin) or Maven `<hibernate.version>7.3.x.Final</hibernate.version>`. The clean resolution is to set
+the minimum supported Spring Boot version to the first whose BOM ships Hibernate ≥ 7.3, after which no
+override is needed.
+
+## Module structure
+
+Two Gradle subprojects sit alongside the root `mongo-hibernate` project:
+
+```
+mongo-hibernate/                             ← core extension (dialect, connection provider, SPI)
+mongodb-hibernate-spring-boot-autoconfigure/ ← auto-configuration logic
+mongodb-hibernate-spring-boot-starter/       ← zero-code dependency aggregator
+```
+
+`settings.gradle.kts` includes both subprojects.
+
+### Convention plugins
+
+Common build configuration lives in three precompiled script plugins in `buildSrc/src/main/kotlin/`,
+applied by the relevant modules:
+
+- `mongo-hibernate-java` — Java 17 toolchain, `withJavadocJar` / `withSourcesJar`, JUnit test logging,
+  `check → spotlessApply`.
+- `mongo-hibernate-integration-test` — the `integrationTest` source set, task registration, IDEA
+  wiring. It declares `id("java-library")` in its own `plugins {}` block because precompiled script
+  plugins resolve type-safe accessors (`sourceSets`, `configurations`) at compile time.
+- `mongo-hibernate-publish` — `maven-publish` + `signing` + common POM fields (url, license,
+  developers, SCM).
+
+### `mongodb-hibernate-spring-boot-autoconfigure`
+
+Ships no `module-info.java`; declares a stable `Automatic-Module-Name`:
+
+```kotlin
+tasks.jar { manifest { attributes("Automatic-Module-Name" to "com.mongodb.hibernate.spring.boot.autoconfigure") } }
+```
+
+The module lives in the Spring ecosystem, where every Spring Framework / Spring Boot jar is an
+automatic module. A full JPMS descriptor would add friction (reflective access for
+`@Bean`/`@Autowired`, an `opens` set) with no benefit, since module-path execution is not a tested
+mode for a Spring Boot application. The core module remains a full JPMS module because it sits in
+Hibernate's world.
+
+Dependencies:
+
+```kotlin
+api(platform(libs.spring.boot.bom))            // BOM published as a dependencyManagement import
+api(project(":"))                              // mongo-hibernate; exposes the MongoConfigurationContributor SPI
+implementation(libs.spring.boot.autoconfigure) // @AutoConfiguration, @ConditionalOn*, repository config base
+implementation(libs.spring.boot.persistence)   // EntityScanPackages
+implementation("org.springframework.boot:spring-boot-jpa")       // JpaProperties, EntityManagerFactoryBuilder
+implementation("org.springframework.boot:spring-boot-hibernate") // HibernateProperties, HibernateSettings, HibernatePropertiesCustomizer
+implementation("org.springframework:spring-orm")              // LocalContainerEntityManagerFactoryBean, JpaTransactionManager
+implementation("jakarta.persistence:jakarta.persistence-api") // EntityManagerFactory
+compileOnly(libs.jspecify)                     // compile-time annotations only
+optional(libs.spring.data.jpa)                 // repository auto-config only
+optional("org.springframework:spring-webmvc")  // Open-Session-in-View only (servlet web apps)
+optional("org.springframework.boot:spring-boot-mongodb") // MongoConnectionDetails / MongoClient bean for borrowing
+```
+
+The `optional` configuration holds dependencies published as `<optional>true</optional>`: declared so a
+consumer depending on the artifact directly can resolve them, but not forced transitively.
+`compileOnly` and `testImplementation` extend it; it is mapped to Maven optional scope via Gradle's
+`AdhocComponentWithVariants.addVariantsFromConfiguration { mapToOptional() }`. In the published POM,
+`api` → compile scope, `implementation` → runtime scope, and `api(platform(...))` → a
+`<dependencyManagement>` BOM import.
+
+Spring Boot 4.0 module split: `@EntityScan` / `EntityScanPackages` moved from
+`org.springframework.boot.autoconfigure.domain` to `org.springframework.boot.persistence.autoconfigure`
+in `spring-boot-persistence`; JPA support split into `spring-boot-jpa` (`JpaProperties`,
+`EntityManagerFactoryBuilder`), `spring-boot-hibernate` (`HibernateProperties`, `HibernateSettings`,
+`HibernatePropertiesCustomizer`), and `spring-boot-data-jpa` (`JpaRepositoriesAutoConfiguration`); and
+MongoDB client support into `spring-boot-mongodb` (`MongoAutoConfiguration`, `MongoConnectionDetails`,
+`MongoClientSettingsBuilderCustomizer`, `MongoProperties` under the `spring.mongodb.*` prefix).
+
+Published artifact: `org.mongodb:mongodb-hibernate-spring-boot-autoconfigure`.
+
+### `mongodb-hibernate-spring-boot-starter`
+
+No source code; a `build.gradle.kts`:
+
+```kotlin
+dependencies {
+    api(project(":"))                                              // mongo-hibernate
+    api(project(":mongodb-hibernate-spring-boot-autoconfigure"))
+    api("org.springframework.boot:spring-boot-data-jpa")           // Spring Data JPA + Hibernate ORM, no SQL pool
+    api("org.springframework.boot:spring-boot-mongodb")            // MongoClient infrastructure to borrow
+}
+```
+
+Maven optional is not transitive, so the starter supplies Spring Data JPA and `spring-boot-mongodb`
+itself, making repository support and the borrowable `MongoClient` available by default for starter
+users while keeping them opt-in for direct autoconfigure consumers.
+
+The starter depends on the granular `spring-boot-data-jpa` module, **not** `spring-boot-starter-data-jpa`.
+The latter also pulls in `spring-boot-starter-jdbc` → HikariCP, a SQL connection pool a MongoDB-backed
+application does not want; with a pool on the classpath but no `spring.datasource.url`,
+`DataSourceAutoConfiguration` fails fast at startup (see [Auto-configuration ordering](#auto-configuration-ordering)).
+The starter also omits the base `spring-boot-starter`: a feature starter should not impose a logging
+backend or other application foundation — the application's primary starter (`spring-boot-starter-web`, or
+plain `spring-boot-starter`) provides that. A `check`-wired Gradle task fails the build if a SQL connection
+pool ever reappears on the starter's runtime classpath. Published artifact:
+`org.mongodb:mongodb-hibernate-spring-boot-starter`.
+
+## Prior art: how Spring Boot shares one `DataSource`
+
+A `MongoClient` is a connection pool, the MongoDB analogue of a JDBC `DataSource`. Spring Boot's SQL
+stack has an established pattern for sharing one pool between JPA and other consumers (raw JDBC, health,
+metrics), which this design follows.
+
+The SQL stack treats the pool as a shared bean that JPA borrows:
+
+- `DataSourceAutoConfiguration`'s pooled-`DataSource` creation is
+  `@ConditionalOnMissingBean({ DataSource.class, XADataSource.class })`. If the application supplies a
+  `DataSource` bean, Boot's creation backs off. `spring.datasource.url` is the recipe for the
+  auto-created pool only.
+- `JpaBaseConfiguration` receives the `DataSource` in its constructor and passes it to the
+  `EntityManagerFactory` (`factoryBuilder.dataSource(this.dataSource)…`). JPA does not create a pool or
+  re-specify connection coordinates.
+- `HibernateJpaConfiguration` is `@ConditionalOnSingleCandidate(DataSource.class)`; it binds to the
+  single pool that exists.
+- The pool's lifecycle is Spring's: Hibernate borrows connections and does not close the `DataSource`.
+- JPA intent comes from the JPA classes on the classpath (`HibernateJpaAutoConfiguration` is
+  `@ConditionalOnClass({ LocalContainerEntityManagerFactoryBean, EntityManager, SessionImplementor })`),
+  not from the `DataSource` bean. A `DataSource` is also used for raw JDBC, Batch, Quartz, and Flyway
+  with no JPA. `@ConditionalOnSingleCandidate(DataSource.class)` is a pool-availability gate, not an
+  intent gate.
+
+Two points from this model inform the design:
+
+- Duplicate pools are prevented structurally, not by configuration discipline. The SQL stack does this
+  by backing off auto-creation when a pool bean exists
+  (`@ConditionalOnMissingBean(DataSource.class)`), with the URL as the fallback recipe. This design has
+  no URL fallback in the Spring path: it borrows an existing `MongoClient` and fails fast if none is
+  present (see [Pool: borrow-only](#pool-borrow-only)).
+- The pool bean is not the activation signal. Activation is a separate concern. In the SQL stack the
+  signal is the JPA classes on the classpath. For MongoDB the classpath is insufficient, because the
+  auto-configure jar can be present on a SQL-JPA application's classpath; JPA-on-classpath does not
+  distinguish MongoDB JPA from SQL JPA. The design uses an explicit property,
+  `spring.jpa.database-platform=MongoDB` (see [Activation model](#activation-model)). The carried-over
+  point is that the `MongoClient` bean is not the trigger.
+
+## Where the `DataSource` analogy does not hold
+
+Two concerns are not covered by the borrowed pool: dialect and database name.
+
+- Dialect. When neither `spring.jpa.database-platform` nor `spring.jpa.database` is set, Hibernate
+  determines the dialect by opening a JDBC connection and reading `java.sql.DatabaseMetaData` (product
+  name and version). A `MongoClient` cannot be read this way, so the dialect must be named explicitly.
+  `spring.jpa.database` is a closed, SQL-only enum (`H2`, `MYSQL`, `POSTGRESQL`, …; no `MONGODB`, not
+  extensible). `spring.jpa.database-platform` is a free-form dialect string that maps to
+  `hibernate.dialect` and takes precedence over the enum, and is the mechanism used here.
+- Database name. A JDBC connection is database-scoped (the catalog is in the URL, e.g.
+  `jdbc:postgresql://host/mydb`), so Hibernate inherits it. A `MongoClient` is cluster-scoped; the
+  database is chosen per operation. The database name comes from an explicit source (see
+  [Database name](#database-name)).
+
+## User-facing configuration
+
+```properties
+spring.jpa.database-platform=MongoDB
+spring.mongodb.uri=mongodb://localhost/mydb
+```
+
+`spring.jpa.database-platform=MongoDB` activates the integration and selects the dialect.
+`spring.mongodb.*` configures the `MongoClient` that `spring-boot-mongodb` builds and the integration
+borrows. The full `spring.jpa.*` surface applies as in any Spring Boot JPA application.
+
+Client customization uses Spring's `MongoClientSettingsBuilderCustomizer`, which `spring-boot-mongodb`
+applies when it builds the `MongoClient`:
+
+```java
+@Bean
+MongoClientSettingsBuilderCustomizer mongoCustomizer() {
+    return builder -> builder.addCommandListener(myListener);
+}
+```
+
+The integration borrows the already-built client, so `MongoConfigurationContributor.applyToMongoClientSettings(...)`
+has no effect on the Spring path (it remains the customization mechanism for the standalone/manual
+path). `MongoConfigurationContributor.databaseName(...)` is honored on either path.
+
+## Activation model
+
+The trigger is `spring.jpa.database-platform=MongoDB`.
+
+There is no URL-based activation in the Spring layer; `spring.datasource.url=mongodb://…` is not a
+Spring activation path.
+
+- JPA intent comes from the JPA classes on the classpath, as in the SQL stack.
+- The MongoDB-specific need is a database-flavor signal. The auto-configure jar can be present on a
+  SQL-JPA application's classpath (transitively, shared parent POM, multi-module build), where
+  JPA-on-classpath is true but the application uses SQL. `spring.jpa.database-platform=MongoDB`
+  identifies the JPA platform as MongoDB.
+- A `MongoClient` bean is not a trigger. A `MongoClient` is the normal state of any Spring + MongoDB
+  application; it is usually present for `MongoTemplate` / Spring Data MongoDB rather than Hibernate, so
+  its presence does not indicate Hibernate-JPA intent. Triggering on it would activate in ordinary
+  Spring Data MongoDB applications. An explicit property also keeps activation controllable (toggle a
+  property rather than restructure dependencies, which supports staged `MongoTemplate` → Hibernate
+  migration) and reuses the dialect declaration. `@ConditionalOnSingleCandidate(MongoClient.class)` is
+  not used (see [Rejected alternatives](#rejected-alternatives)).
+
+The condition matches the literal string `MongoDB`, the dialect short name (see [Dialect](#dialect)).
+The extension supports only that short name; no `MongoDialect` FQCN or test-dialect accommodation is
+required.
+
+`spring.jpa.database-platform=MongoDB` serves three purposes through existing machinery:
+
+1. Dialect selection: the module's `jpaVendorAdapter` bean applies it via `setDatabasePlatform`,
+   yielding `hibernate.dialect=MongoDB`.
+2. Connection-provider selection: the core treats `MongoDB` as a Mongo dialect and selects
+   `MongoConnectionProvider`.
+3. Activation trigger.
+
+The condition is a `SpringBootCondition` reading `spring.jpa.database-platform` from the environment. It
+gates both `MongoHibernateAutoConfiguration` and `MongoJpaRepositoriesAutoConfiguration`.
+
+## `MongoHibernateAutoConfiguration`
+
+Registered in `META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports`.
+Activates when mongo-hibernate is on the classpath
+(`@ConditionalOnClass(MongoConfigurationContributor.class)` — the exported SPI class, not the internal
+`MongoDialect`) and the activation condition matches.
+
+Rather than hand-assembling the `EntityManagerFactory`, the configuration reuses Spring Boot's JPA
+property machinery — `JpaProperties`, `HibernateProperties`, `EntityManagerFactoryBuilder` — so the
+full `spring.jpa.*` surface applies: `ddl-auto`, `show-sql`, `generate-ddl`, database/platform, naming
+strategies, and `HibernatePropertiesCustomizer` / `EntityManagerFactoryBuilderCustomizer` beans. Spring
+Boot's `HibernateJpaAutoConfiguration` cannot be reused directly: it is
+`@ConditionalOnSingleCandidate(DataSource.class)` and its constructor and ddl-auto defaulting require a
+non-null `DataSource`. The property-merge classes are public and DataSource-free, so the configuration
+replicates the small `getVendorProperties` flow with a MongoDB-appropriate ddl-auto default and reuses
+the rest. `@EnableConfigurationProperties({JpaProperties.class, HibernateProperties.class})` binds the
+configuration.
+
+Back-off is per bean, not class-wide: each bean carries `@ConditionalOnMissingBean`, so a user-supplied
+`EntityManagerFactory` suppresses only the `EntityManagerFactory` bean rather than disabling the whole
+configuration.
+
+Beans:
+
+- `JpaVendorAdapter` — a `HibernateJpaVendorAdapter` with `show-sql`, `database`, `database-platform`,
+  and `generate-ddl` applied from `JpaProperties`, as `JpaBaseConfiguration.jpaVendorAdapter` does.
+  `database-platform` is `MongoDB`, which produces `hibernate.dialect=MongoDB`.
+- `EntityManagerFactoryBuilder` — constructed with a JPA-properties factory that ignores its
+  `DataSource` argument and returns the assembled Hibernate property map;
+  `EntityManagerFactoryBuilderCustomizer` beans are applied in `@Order` order.
+- `LocalContainerEntityManagerFactoryBean` (`@Primary`,
+  `@ConditionalOnMissingBean({LocalContainerEntityManagerFactoryBean.class, EntityManagerFactory.class})`)
+  — built via `factoryBuilder.dataSource(null)…build()`. No `DataSource`; the borrowed client is passed
+  through the `MongoConfigurationContributor` bridge (see [Core module change](#core-module-change)).
+  `@Primary` matches Spring Boot and avoids ambiguity when a second `EntityManagerFactory` is present
+  (single persistence unit is the auto-configured model; see [Multiple persistence units](#multiple-persistence-units)).
+  Packages to scan come from `EntityScanPackages` (populated by `@EntityScan`), falling back to
+  `AutoConfigurationPackages`.
+- `JpaTransactionManager` (`@ConditionalOnMissingBean(TransactionManager.class)`) — wired to the
+  `EntityManagerFactory`.
+
+The Hibernate property map is `HibernateProperties.determineHibernateProperties(base, settings)`, with
+`settings` carrying a fixed `ddlAuto(() -> "none")` default (MongoDB has no embedded-database notion, so
+Spring Boot's `DataSource`-dependent `HibernateDefaultDdlAutoProvider` is not used) plus the ordered
+`HibernatePropertiesCustomizer` beans.
+
+### Naming strategy
+
+Spring Boot's `HibernateProperties` defaults the physical naming strategy to
+`PhysicalNamingStrategySnakeCaseImpl` (camelCase → snake_case). This configuration keeps Hibernate's
+own default (`PhysicalNamingStrategyStandardImpl`, the Java property name). snake_case is safe on a
+relational store because the schema is a guardrail and a mismatch errors. MongoDB is schemaless, so
+writes under two naming strategies coexist silently in one collection (old documents `firstName`, new
+documents `first_name`, reads see `null`). The core extension sets no naming strategy (plain Hibernate
+→ camelCase), so matching that here means an entity persists identically whether bootstrapped via the
+core extension or via this starter. The implicit naming strategy is likewise kept at Hibernate's default
+(`ImplicitNamingStrategyJpaCompliantImpl`) rather than Spring Boot's `SpringImplicitNamingStrategy`.
+
+Implemented by seeding Hibernate's default strategy class names with `putIfAbsent` before
+`determineHibernateProperties`. An explicit `spring.jpa.hibernate.naming.physical-strategy` /
+`implicit-strategy` (which Spring Boot applies with `put`) or a raw
+`spring.jpa.properties.hibernate.*_naming_strategy` still wins; only the unset case falls back to the
+Hibernate default. Detection keys off whether the property is set, not its value, so a user requesting
+snake_case explicitly gets it.
+
+### Open Session in View
+
+An inner `@Configuration` mirrors Spring Boot's `JpaWebConfiguration`:
+`@ConditionalOnWebApplication(type = SERVLET)`, `@ConditionalOnClass(WebMvcConfigurer)`,
+`@ConditionalOnMissingBean(OpenEntityManagerInViewInterceptor.class)`,
+`@ConditionalOnBooleanProperty(name = "spring.jpa.open-in-view", matchIfMissing = true)`. It registers
+an `OpenEntityManagerInViewInterceptor` (with Spring Boot's default-on warning when
+`spring.jpa.open-in-view` is unset) and a `WebMvcConfigurer` that adds it. `spring-webmvc` is an
+optional dependency; OSIV applies only to servlet web applications.
+
+### Native image
+
+An `@ImportRuntimeHints` registrar mirrors Spring Boot's `HibernateRuntimeHints` for the naming-strategy
+types and the `NoJtaPlatform` types Hibernate instantiates reflectively, so the configuration works in a
+native image.
+
+## Pool: borrow-only
+
+Once activated, the integration borrows an existing `MongoClient` bean and does not create one in the
+Spring path.
+
+- The client normally comes from `spring-boot-mongodb`'s `MongoAutoConfiguration`, configured through
+  the `spring.mongodb.*` namespace. (The `spring.data.mongodb.*` keys carry an error-level deprecation
+  `since: 4.0.0` with `replacement: spring.mongodb.*` in `spring-boot-mongodb`'s configuration metadata;
+  they no longer bind.) The client may instead be a user-supplied `MongoClient @Bean`, or one built from
+  a custom `MongoConnectionDetails` (Testcontainers `@ServiceConnection`, Docker Compose, cloud service
+  binding).
+- Spring's `MongoClient` is not suppressed. It backs health indicators, Micrometer metrics, and
+  `MongoTemplate`; suppressing it would break those. When one exists, it is shared, not replaced.
+- No second pool is created. This mirrors `@ConditionalOnMissingBean(DataSource.class)`: an existing
+  client bean wins.
+- If activated with no `MongoClient` bean to borrow (e.g. `spring-boot-mongodb` absent and no user
+  `MongoClient @Bean`), startup fails with an actionable message: a MongoDB JPA platform is configured
+  but no `MongoClient` bean is available; add `spring-boot-mongodb` (configure `spring.mongodb.*`),
+  define a `MongoClient @Bean`, or use the manual path. Without this check, bootstrap fails later in
+  Hibernate with a `jakarta.persistence.jdbc.url` is required error.
+
+### Borrowing a Spring-built client is correctness-safe
+
+Everything that configures a Spring `MongoClient` flows through ordered
+`MongoClientSettingsBuilderCustomizer` beans applied by `MongoClientFactory` over an empty base
+`MongoClientSettings`:
+
+- `StandardMongoClientSettingsBuilderCustomizer` applies the connection string (from
+  `MongoConnectionDetails`), UUID representation, and SSL.
+- `MongoMetricsAutoConfiguration` contributes the Micrometer command- and connection-pool-listener
+  customizers.
+- User `MongoClientSettingsBuilderCustomizer` beans add listeners, application name, and similar.
+
+A borrowed client already carries coordinates, metrics, and user customizations, so the integration
+does not collect customizers itself. The extension injects no mandatory client-level settings: it
+operates at the `BsonDocument` level (`mongoClient.getDatabase(name).getCollection(name,
+BsonDocument.class)`) using the driver's default codec registry, and `MongoConfigurationBuilder` applies
+only `MongoClientSettings.builder()` plus the connection string. A Spring-built client has what the
+extension requires.
+
+## Lifecycle / ownership
+
+The component that supplies the client decides whether to close it:
+
+- Borrowed (Spring path): `MongoConnectionProvider` does not close the client; Spring owns its
+  lifecycle.
+- Self-created (standalone path, unchanged): `MongoConnectionProvider` closes it in `stop()`.
+
+This is expressed in the core SPI (see [Core module change](#core-module-change)).
+
+## Dialect
+
+Spring Boot binds `spring.jpa.database-platform` to `JpaProperties`; it does nothing further on this
+path, because its own `HibernateJpaAutoConfiguration` (which would build a vendor adapter and apply the
+property) is off without a `DataSource`. The module's `jpaVendorAdapter` bean reads
+`JpaProperties.getDatabasePlatform()` and calls `HibernateJpaVendorAdapter.setDatabasePlatform("MongoDB")`;
+the adapter's JPA property map then carries `hibernate.dialect=MongoDB` into the `EntityManagerFactory`
+properties. Hibernate resolves `MongoDB` → `MongoDialect` through the core module's
+`MongoNamedStrategyContributor`, registered via Hibernate's `NamedStrategyContributor` SPI
+(`META-INF/services/org.hibernate.boot.registry.selector.spi.NamedStrategyContributor`).
+
+The `jpaVendorAdapter` bean already applies `database-platform` (it honors the full `spring.jpa.*`
+surface), so no new dialect wiring is needed; resolution is the same as for standalone use.
+
+## Database name
+
+A `MongoClient` is not database-scoped, so the database name needs an explicit source. The precedence
+mirrors Spring's own `MongoDatabaseFactoryConfiguration` (which builds the `MongoDatabaseFactory`
+behind `MongoTemplate`): it reads `MongoProperties.getDatabase()` (`spring.mongodb.database`) first,
+falls back to `connectionDetails.getConnectionString().getDatabase()` when that is null, then asserts
+the result is non-empty. Reading `getDatabase()` directly (not relying on the connection string) is
+necessary because `PropertiesMongoConnectionDetails.getConnectionString()` folds the database in only
+for the host/properties form; its URI branch returns the raw URI and ignores `spring.mongodb.database`.
+Using the same order keeps Hibernate on the same database the rest of the Spring MongoDB stack targets.
+In order:
+
+1. `MongoConfigurationContributor.databaseName(…)` — an explicit override. It is applied last in the
+   contributor composite, and the autoconfigure's database-name contributor is ordered
+   `@Order(HIGHEST_PRECEDENCE)`, so a user contributor wins.
+2. `spring.mongodb.database`, read from the `MongoProperties` bean (`getDatabase()`), when set. It
+   overrides a database embedded in `spring.mongodb.uri`, as `MongoDatabaseFactoryConfiguration` does.
+   `MongoProperties` is always present on the borrow path (registered by `MongoAutoConfiguration`
+   whenever `spring-boot-mongodb` is on the classpath), so reading it is not fragile.
+3. `MongoConnectionDetails.getConnectionString().getDatabase()` — the connection string's database.
+   This is the source-agnostic step: it covers a URI with a database path
+   (`spring.mongodb.uri=mongodb://host/db`), the `host` + `database` form, and custom
+   `MongoConnectionDetails` sources (Testcontainers and similar) that have no `MongoProperties` behind
+   them. It yields `test` for the bare default (`MongoProperties.DEFAULT_URI` is
+   `mongodb://localhost/test`), which is honored rather than treated as an error.
+4. Otherwise, fail with an actionable message: put the database in the URI (`mongodb://host/<db>`), set
+   `spring.mongodb.database`, or set `MongoConfigurationContributor.databaseName(…)`.
+
+## `MongoJpaRepositoriesAutoConfiguration`
+
+Spring Boot's `JpaRepositoriesAutoConfiguration` activates `@EnableJpaRepositories` but carries
+`@ConditionalOnBean(DataSource.class)`, so it never fires without a SQL `DataSource`.
+`MongoJpaRepositoriesAutoConfiguration` is a replacement that drops the `DataSource` requirement. It
+activates when `JpaRepository` is on the classpath (`@ConditionalOnClass(JpaRepository.class)`), the
+activation condition matches, no `JpaRepositoryFactoryBean` / `JpaRepositoryConfigExtension` bean
+exists (`@ConditionalOnMissingBean`), and
+`@ConditionalOnBooleanProperty(name = "spring.data.jpa.repositories.enabled", matchIfMissing = true)`.
+
+It uses `AbstractRepositoryConfigurationSourceSupport` (the Spring Boot base class for repository
+auto-configurations) to wire `@EnableJpaRepositories` with `AutoConfigurationPackages` as the scan base,
+so `@EntityScan` and the main application package work without extra configuration. A user who declares
+`@EnableJpaRepositories` takes precedence and this configuration backs off.
+
+It is ordered `@AutoConfiguration(after = MongoHibernateAutoConfiguration.class)` and `beforeName`
+Spring Boot's `JpaRepositoriesAutoConfiguration` (see [Auto-configuration ordering](#auto-configuration-ordering)).
+
+## Core module change
+
+The Spring layer cannot inject a pre-built `MongoClient` into Hibernate today;
+`MongoConnectionProvider` always calls `MongoClients.create(...)`. The core gains the ability to accept
+a supplied client and to not close it. This is the only core change, and it also serves the manual path
+(with or without Spring).
+
+1. `MongoConfigurator` (public SPI): add `mongoClient(MongoClient)`. Supplying a client means use this
+   client and do not close it. The API is flat — no compile-time type-state separating it from
+   `applyToMongoClientSettings`. The conflict it would guard against is across separate contributor
+   beans, which a type-state cannot catch, and the resolution is that the supplied client wins.
+2. `MongoConfiguration` (record): carry an optional external `MongoClient` alongside
+   `mongoClientSettings` and `databaseName`.
+3. `MongoConfigurationBuilder`: store the optional client. When present, the connection string and
+   `applyToMongoClientSettings` are not used to build a connection (the supplied pool wins; the URL is
+   ignored).
+4. `MongoConnectionProvider`: if an external client is present, use it and do not call `close()` in
+   `stop()`; otherwise create and own the client as today.
+
+The existing JPA-properties bridge passes the client across the module boundary: the autoconfigure
+places a `MongoConfigurationContributor` under the configuration key
+`com.mongodb.hibernate.configurationContributor`, which the core consults before its service-registry
+lookup. No cross-module surface is added beyond the `mongoClient(...)` method.
+
+The autoconfigure's share bridge bean is gated by `@ConditionalOnClass(MongoConnectionDetails.class)` +
+`@ConditionalOnBean(MongoClient.class)` + the activation condition. It registers a
+`MongoConfigurationContributor` (ordered `@Order(HIGHEST_PRECEDENCE)`) that calls
+`configurator.mongoClient(theBean)` and sets the database name resolved per
+[Database name](#database-name) (`spring.mongodb.database` if set, otherwise the `MongoConnectionDetails`
+connection string). The bridge depends on the `MongoConnectionDetails` and `MongoProperties` beans.
+
+## Auto-configuration ordering
+
+This design uses no `EnvironmentPostProcessor`. A URL-based approach might use one to copy
+`spring.datasource.url` into `spring.jpa.properties.jakarta.persistence.jdbc.url` and to exclude
+`DataSourceAutoConfiguration` and `HibernateJpaAutoConfiguration` via `spring.autoconfigure.exclude`.
+Neither is needed:
+
+- There is no `spring.datasource.url` in the Spring path; the dialect comes from
+  `spring.jpa.database-platform=MongoDB`.
+- The exclusion existed because, with `spring.datasource.url=mongodb://…`,
+  `DataSourceAutoConfiguration` would attempt and fail to build a SQL connection pool from a Mongo URL.
+
+There is a second failure mode the exclusion also masked: when a pooled `DataSource` implementation
+(HikariCP) is on the classpath but no `spring.datasource.url` is set, `DataSourceAutoConfiguration`
+fails fast with "'url' attribute is not specified." Rather than re-introduce an exclusion (which would
+break a user who legitimately wants a SQL `DataSource`, see below), the starter avoids the trigger: it
+depends on the granular `spring-boot-data-jpa` module instead of `spring-boot-starter-data-jpa`, so it
+does **not** drag in `spring-boot-starter-jdbc` → HikariCP. With no pooled `DataSource` on the classpath
+and no `url`, `DataSourceAutoConfiguration` finds nothing to do and creates nothing — no failure. A user
+who genuinely wants SQL alongside MongoDB adds HikariCP and a `url` themselves, and Spring behaves
+normally.
+
+The remaining concern is a stray `DataSource` — an embedded database (e.g. H2 on the test classpath) or
+a non-JPA `DataSource` (for `JdbcTemplate`, Flyway, Batch) — causing Spring's
+`HibernateJpaAutoConfiguration` (`@ConditionalOnSingleCandidate(DataSource.class)`) to build a competing
+SQL `EntityManagerFactory`. The `entityManagerFactory` and `transactionManager` beans here are
+`@Primary` and back off if Spring's are registered first
+(`@ConditionalOnMissingBean({LocalContainerEntityManagerFactoryBean.class, EntityManagerFactory.class})`).
+Precedence is handled by ordering: `MongoHibernateAutoConfiguration` is declared
+`@AutoConfiguration(before = HibernateJpaAutoConfiguration.class)`, so the `@Primary` Mongo
+`EntityManagerFactory` and `JpaTransactionManager` register first and Spring's SQL-JPA beans back off
+through their own `@ConditionalOnMissingBean`. `MongoJpaRepositoriesAutoConfiguration` is ordered
+`beforeName` Spring Boot's `JpaRepositoriesAutoConfiguration` for the same reason (a string reference,
+since Spring Data JPA is an `optional` dependency).
+
+`DataSourceAutoConfiguration` is not excluded: a MongoDB-JPA application may use a SQL `DataSource` for
+non-JPA purposes (`JdbcTemplate`, Flyway, Batch), and excluding it would break that. Because the starter
+brings no connection pool (above), a pure-MongoDB application never triggers it; the only consequence is
+that an idle embedded `DataSource` may be created when an embedded-database driver is on the classpath
+(e.g. H2 on the test classpath), which is Spring Boot's documented behavior, and nothing binds to it.
+
+## Manual path
+
+The auto-configuration covers the single-persistence-unit case. Applications that want a dedicated
+client, multiple persistence units (see [below](#multiple-persistence-units)), or other custom wiring
+configure JPA manually — outside Spring, or with Spring using hand-written JPA `@Configuration`. In both
+cases the application builds the Mongo persistence unit and supplies the client through
+`MongoConfigurator.mongoClient(...)` (owned or closed per the provider's ownership rule). The starter is
+the share-the-pool turnkey path on top of that SPI.
+
+## Multiple persistence units
+
+Running MongoDB and a SQL database (e.g. Postgres) in one application, each with its own
+`EntityManagerFactory`, is supported through the standard Spring manual multi-persistence-unit pattern,
+not through auto-configuration.
+
+Two auto-configured `EntityManagerFactory` beans are not possible, and this is a Spring Boot trait
+rather than a limitation of this extension: Spring's `HibernateJpaConfiguration` is
+`@ConditionalOnSingleCandidate(DataSource.class)` and its EMF bean is
+`@ConditionalOnMissingBean({LocalContainerEntityManagerFactoryBean.class, EntityManagerFactory.class})`
+(this module's EMF carries the same back-off), so auto-configured EMFs are mutually exclusive: the first
+registered wins and the rest back off. The `spring.jpa.*` surface, including `database-platform`, is a
+single global setting feeding one vendor adapter, and is single-PU.
+
+The multi-PU setup is the conventional one: the application defines both persistence units by hand —
+two `LocalContainerEntityManagerFactoryBean`s, two transaction managers, `@EnableJpaRepositories` per
+unit with explicit `entityManagerFactoryRef` / `transactionManagerRef` / `basePackages`, one marked
+`@Primary`. In that configuration:
+
+- This module's auto-configuration stays inert: a multi-PU application does not set the global
+  `spring.jpa.database-platform=MongoDB` (each unit names its dialect locally), so the activation
+  condition does not match. Nothing needs to be excluded.
+- The MongoDB unit is built with `MongoDialect`, `MongoConnectionProvider`, and, to share a
+  Spring-managed client, `MongoConfigurator.mongoClient(...)`.
+- Core-level coexistence already holds: this module's global Hibernate `ServiceContributor` and
+  `MongoConnectionProvider` engage only when the dialect is `MongoDB`, so a SQL `SessionFactory` is
+  untouched. This is covered by the existing negative-coexistence integration test (a SQL application
+  with this module on its classpath boots and round-trips).
+
+## Not in scope
+
+- Suppressing Spring's `MongoClient` bean.
+- Collecting `MongoClientSettingsBuilderCustomizer` beans; they are already applied to the borrowed
+  client by Spring.
+- Compile-time type-state separating `mongoClient()` from `applyToMongoClientSettings()`.
+- URL-based activation in the Spring layer. Standalone, non-Spring Hibernate retains its URL-driven,
+  self-created-client behavior as one of the manual paths.
+
+## Rejected alternatives
+
+### Zero-config activation on `MongoClient` presence
+
+Activate whenever a single `MongoClient` bean is present —
+`@ConditionalOnSingleCandidate(MongoClient.class)` plus JPA classes and `spring-boot-mongodb` on the
+classpath — and default `hibernate.dialect` to `MongoDB` in the borrow path. The application would add
+the starter, configure `spring.mongodb.*`, write `@Entity` classes, and the integration would activate
+with no MongoDB-specific property.
+
+Arguments for: it is the turnkey experience, analogous to `spring-boot-starter-data-mongodb`. It treats
+presence of the deliberately-added integration module as the opt-in, which is reasonable for a leaf
+integration starter that is not a typical transitive dependency. It avoids requiring the
+`spring.jpa.database-platform` property, which is real and non-deprecated but documented only in Spring
+Boot's generated "Common Application Properties" appendix.
+
+Reasons rejected:
+
+- `MongoClient` presence is a weak signal. Unlike a `DataSource`, a `MongoClient` bean is the normal
+  state of any Spring + MongoDB application; it is usually present for `MongoTemplate` / Spring Data
+  MongoDB. Triggering on it would activate in Spring Data MongoDB applications that do not use Hibernate,
+  registering a `@Primary` `EntityManagerFactory` and `JpaTransactionManager` that scan `@Entity`
+  classes.
+- Controllability. A property can be toggled; a dependency cannot, without restructuring or explicit
+  excludes. An application migrating from `MongoTemplate` to Hibernate-JPA over the same database can add
+  the dependency first and enable the JPA layer later by setting the property; presence-based activation
+  would enable everything immediately.
+- The explicit signal is low-cost. The dialect must be named somewhere regardless: a borrowed
+  `MongoClient` cannot be read for it (unlike a JDBC `DataSource`), and the `spring.jpa.database` enum
+  has no `MongoDB` value. `spring.jpa.database-platform=MongoDB` is where the dialect is named, so
+  requiring it is not an additional step.
+- Spring Boot's gating convention is to not activate on a bean that commonly exists for other reasons.
+
+The decision is close; the discoverability cost is accepted in exchange for not activating on a signal
+(`MongoClient` presence) that does not indicate Hibernate-JPA over MongoDB. Discoverability is handled
+with getting-started documentation.
+
+### URL-based activation with a self-created client
+
+Activate on `spring.datasource.url=mongodb://…`, copy it to `jakarta.persistence.jdbc.url` through an
+`EnvironmentPostProcessor`, and have `MongoConnectionProvider` build and own a `MongoClient` from it.
+
+Reasons rejected:
+
+- Duplicate connection pools. Spring-native client customization requires `spring-boot-mongodb`, whose
+  `MongoAutoConfiguration` creates a `MongoClient` bean (also used for health checks, Micrometer metrics,
+  and Spring Data MongoDB); a separately URL-built client is a second pool to the same cluster.
+- `spring.datasource.url` implies a SQL `DataSource`, which is not created for MongoDB.
+
+## Testing
+
+Per the module's conventions: `ApplicationContextRunner` / `WebApplicationContextRunner` for
+auto-configuration unit tests (no MongoDB), `@SpringBootTest` for integration tests (MongoDB required).
+Auto-configurations are registered with the runner via
+`withConfiguration(AutoConfigurations.of(...))`, not `withUserConfiguration(...)`, so
+`@ConditionalOnMissingBean` orders reliably (auto-configurations are evaluated after user beans).
+
+### Unit (no MongoDB)
+
+- Activation gate: the auto-configurations activate when `spring.jpa.database-platform=MongoDB` and stay
+  inert otherwise, including when a `MongoClient` bean is present but the property is unset, and for a
+  non-MongoDB platform.
+- Share bridge present/absent: with `spring-boot-mongodb` on the classpath and a `MongoClient` bean, the
+  bridge `MongoConfigurationContributor` is registered; with `MongoConnectionDetails` absent
+  (`FilteredClassLoader`), it is not.
+- Database-name resolution: `spring.mongodb.database` overrides a URI-embedded database (matching
+  `getMongoClientDatabase()`); otherwise the connection string's database is used (URI-with-db,
+  `host`+`database`, custom `MongoConnectionDetails`); fails when no source provides a database; a user
+  `databaseName(...)` contributor overrides all.
+- Activated but no client: with `spring.jpa.database-platform=MongoDB` set and no `MongoClient` bean,
+  startup fails with the "no `MongoClient` bean" message rather than the Hibernate
+  `jakarta.persistence.jdbc.url` error.
+- Property assembly: `spring.jpa.hibernate.ddl-auto` produces `hibernate.hbm2ddl.auto`; the physical and
+  implicit naming strategies default to Hibernate's own (identity/camelCase and JPA-compliant) when unset
+  and honor explicit `spring.jpa.hibernate.naming.physical-strategy` / `implicit-strategy` overrides; a
+  `HibernatePropertiesCustomizer` bean's mutation appears; the contributor composite lands under the
+  bridge key. (Exercised via the
+  `EntityManagerFactoryBuilder`'s `getJpaPropertyMap()` without bootstrapping Hibernate, with a mock
+  `EntityManagerFactory` bean making the EMF bean back off.)
+- Open Session in View: present by default in a servlet web context, absent when
+  `spring.jpa.open-in-view=false`.
+- Repository back-off: a user `JpaRepositoryFactoryBean` suppresses repository scanning; with
+  `JpaRepository` absent (`FilteredClassLoader`) no repository infrastructure is created.
+- SQL-JPA precedence (ordering, not exclusion): with `spring.jpa.database-platform=MongoDB`, a
+  `MongoClient` bean, and a `DataSource` bean present (a stray/embedded `DataSource`), the context has
+  one `EntityManagerFactory` — the `@Primary` Mongo one — and Spring's `HibernateJpaAutoConfiguration`
+  EMF and `JpaTransactionManager` back off.
+
+### Core (no MongoDB)
+
+- `MongoConnectionProvider` borrow path: given a `MongoConfiguration` carrying an external client,
+  `getConnection()` uses it and `stop()` does not close it; given none, it creates and closes its own.
+- `MongoConfigurationBuilder`: a supplied client wins over connection-string settings.
+
+### Integration (MongoDB)
+
+- Share, end to end: with `spring-boot-mongodb` configuring a `MongoClient` and
+  `spring.jpa.database-platform=MongoDB`, an entity round-trips, and entity-manager operations issue
+  their commands through the Spring-managed `MongoClient` — observed via a `CommandListener` registered
+  on it — proving the borrow.
+- Transactions: a rolled-back transaction persists nothing.
+- Database name: `spring.mongodb.database` overrides the database embedded in `spring.mongodb.uri`, with
+  the document landing in the overriding database (verified against the raw driver).
+- Repository: a `JpaRepository` bean is created and a find returns results.
+- Naming: a multi-word field persists with a camelCase document key by default, and snake_case when
+  `spring.jpa.hibernate.naming.physical-strategy` is set to the snake_case strategy (asserted against
+  the raw BSON document).
+- Entity scanning: an entity in a separate package referenced via `@EntityScan` is discovered.
+- Negative coexistence: a SQL JPA application (in-memory H2, no MongoDB) with this module on its
+  classpath boots and round-trips.
+- Manual path: a contributor supplying its own `MongoClient` via `mongoClient(...)` is used, and
+  `MongoConnectionProvider` closes it (owned path), exercised via the core/standalone path.
+
+## Limitations and follow-ups
+
+- `MongoClient` present but `spring.jpa.database-platform` unset: the integration is inert (`MongoClient`
+  is lazy, so there is no startup connection attempt). Consider a `FailureAnalyzer` or documentation
+  note: a `MongoClient` is present but `spring.jpa.database-platform=MongoDB` is not set.
+- Documentation: the README and the external test application are updated to the activation model
+  (`spring.mongodb.*` + `spring.jpa.database-platform=MongoDB`, plus the starter or `spring-boot-mongodb`
+  dependency). A note states that the integration reuses `spring-boot-mongodb`'s client infrastructure
+  and is not Spring Data MongoDB.
+- `@DataJpaTest` slice is unsupported. The slice imports a fixed set of auto-configurations
+  (`HibernateJpaAutoConfiguration`, `DataSourceAutoConfiguration`) and replaces the `DataSource` with an
+  embedded SQL database, none of which match this integration. Full slice support would need a dedicated
+  test-slice annotation with its own `TypeExcludeFilter` and `@ImportAutoConfiguration` set. Tracked as
+  HIBERNATE-179.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -43,6 +43,7 @@ plugin-buildconfig = "5.6.8"
 plugin-palantir = "2.77.0"
 plugin-ktfmt = "0.59"
 plugin-nexus-publish = "2.0.0"
+spring-boot = "4.0.6"
 
 [libraries]
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit-jupiter" }
@@ -59,6 +60,12 @@ logback-classic = { module = "ch.qos.logback:logback-classic", version.ref = "lo
 mockito-junit-jupiter = { module = "org.mockito:mockito-junit-jupiter", version.ref = "mockito" }
 h2 = { module = "com.h2database:h2", version.ref = "h2" }
 checker-qual = { module = "org.checkerframework:checker-qual", version.ref = "checker-qual" }
+spring-boot-bom = { module = "org.springframework.boot:spring-boot-dependencies", version.ref = "spring-boot" }
+spring-boot-autoconfigure = { module = "org.springframework.boot:spring-boot-autoconfigure" }
+spring-boot-persistence = { module = "org.springframework.boot:spring-boot-persistence" }
+spring-boot-test-autoconfigure = { module = "org.springframework.boot:spring-boot-test-autoconfigure" }
+spring-boot-starter-data-jpa = { module = "org.springframework.boot:spring-boot-starter-data-jpa" }
+spring-data-jpa = { module = "org.springframework.data:spring-data-jpa" }
 
 [bundles]
 test-common = ["junit-jupiter", "assertj", "logback-classic"]

--- a/mongodb-hibernate-spring-boot-autoconfigure/build.gradle.kts
+++ b/mongodb-hibernate-spring-boot-autoconfigure/build.gradle.kts
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2025-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins {
+    id("mongo-hibernate-java")
+    id("mongo-hibernate-integration-test")
+    id("mongo-hibernate-publish")
+}
+
+repositories { mavenCentral() }
+
+// This module ships no module-info.java — like Spring Boot's own autoconfigure jars (which are
+// automatic modules), it lives in a Spring ecosystem that is entirely automatic modules, so a full
+// JPMS module descriptor would force an explicit module onto a sea of automatic ones for no benefit
+// (module-path execution is not a tested mode). A stable Automatic-Module-Name is declared instead.
+tasks.jar { manifest { attributes("Automatic-Module-Name" to "com.mongodb.hibernate.spring.boot.autoconfigure") } }
+
+// 'optional' holds dependencies published in the POM at compile scope marked <optional>true</optional>:
+// declared so a consumer depending on this artifact directly can resolve them, but not forced
+// transitively. compileOnly/test extend it so the code compiles and is exercised against these
+// libraries; it is deliberately NOT in 'implementation', so it isn't also published as a regular
+// (non-optional) dependency.
+val optional = configurations.create("optional") {
+    isCanBeConsumed = false
+    isCanBeResolved = false
+}
+listOf("compileOnly", "testImplementation").forEach { cfg ->
+    configurations.named(cfg) { extendsFrom(optional) }
+}
+// Publish the 'optional' dependencies as Maven <optional>true</optional> via Gradle's native component
+// variant mapping (replaces the need for pom.withXml).
+(components["java"] as AdhocComponentWithVariants)
+        .addVariantsFromConfiguration(optional) {
+            mapToMavenScope("compile")
+            mapToOptional()
+        }
+
+dependencies {
+    // The Spring Boot BOM — published as a <dependencyManagement> import via api(platform) — manages
+    // the versions of the version-less spring-*/jakarta.* entries below.
+    api(platform(libs.spring.boot.bom))
+
+    // Hard dependencies: required whenever the auto-configuration is active.
+    api(project(":")) // mongodb-hibernate: required, and exposes the MongoConfigurationContributor SPI to consumers
+    implementation(libs.spring.boot.autoconfigure) // @AutoConfiguration, @ConditionalOn*, AbstractRepositoryConfigurationSourceSupport
+    implementation(libs.spring.boot.persistence) // EntityScanPackages — used unconditionally on the EntityManagerFactory path
+    implementation("org.springframework.boot:spring-boot-jpa") // JpaProperties, EntityManagerFactoryBuilder, EntityManagerFactoryBuilderCustomizer
+    implementation("org.springframework.boot:spring-boot-hibernate") // HibernateProperties, HibernateSettings, HibernatePropertiesCustomizer
+    implementation("org.springframework:spring-orm") // LocalContainerEntityManagerFactoryBean, JpaTransactionManager
+    implementation("jakarta.persistence:jakarta.persistence-api") // EntityManagerFactory
+
+    compileOnly(libs.jspecify) // @NullMarked / @Nullable: compile-time annotations, not needed by consumers at runtime
+
+    // Optional: only MongoJpaRepositoriesAutoConfiguration uses Spring Data JPA, and it is
+    // @ConditionalOnClass(JpaRepository.class). Spring Boot filters that auto-configuration via
+    // bytecode before loading it when Spring Data JPA is absent, so the dependency can back off cleanly.
+    optional(libs.spring.data.jpa)
+
+    // Optional: only the Open-Session-in-View inner configuration uses Spring MVC, and it is gated by
+    // @ConditionalOnClass(WebMvcConfigurer) + @ConditionalOnWebApplication. A servlet web application
+    // brings spring-webmvc transitively; non-web applications never load that configuration.
+    optional("org.springframework:spring-webmvc")
+
+    // Optional: the share bridge borrows the Spring-managed MongoClient and reads MongoConnectionDetails /
+    // MongoProperties for the database name. Gated by @ConditionalOnClass(MongoConnectionDetails), so this is
+    // inert when spring-boot-mongodb is absent.
+    optional("org.springframework.boot:spring-boot-mongodb")
+
+    // Most main dependencies (api/implementation/optional) are inherited by the test classpath, so
+    // only genuinely test-only libraries are declared here.
+    testImplementation(platform(libs.spring.boot.bom))
+    testImplementation(libs.bundles.test.common)
+    testImplementation(libs.spring.boot.test.autoconfigure)
+    testImplementation(libs.mockito.junit.jupiter)
+    // DataSourceAutoConfiguration lives here; on the test classpath so the SQL-JPA precedence test
+    // (mongoEntityManagerFactoryWinsOverSqlWhenDataSourcePresent) can register it and confirm Spring's
+    // SQL JPA backs off behind the @Primary Mongo EntityManagerFactory.
+    testImplementation("org.springframework.boot:spring-boot-jdbc")
+    // Embedded SQL database for the SQL-JPA precedence test: DataSourceAutoConfiguration needs a driver
+    // on the classpath to create a DataSource so HibernateJpaAutoConfiguration is exercised and can back off.
+    testRuntimeOnly("com.h2database:h2")
+    // WebApplicationContextRunner (OSIV test) needs a servlet API on the classpath to build a servlet
+    // web context; spring-webmvc declares it as provided, so it is not pulled in transitively.
+    testImplementation("jakarta.servlet:jakarta.servlet-api")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+
+    integrationTestImplementation(platform(libs.spring.boot.bom))
+    integrationTestImplementation(libs.bundles.test.common)
+    integrationTestImplementation(libs.spring.boot.starter.data.jpa)
+    integrationTestImplementation("org.springframework.boot:spring-boot-mongodb") // provides the MongoClient to borrow
+    integrationTestImplementation(libs.spring.boot.test.autoconfigure) // @SpringBootTest
+    integrationTestRuntimeOnly("org.junit.platform:junit-platform-launcher")
+    integrationTestRuntimeOnly("com.h2database:h2") // in-memory SQL DB for the coexistence test
+}
+
+publishing {
+    publications {
+        create<MavenPublication>("maven") {
+            groupId = "org.mongodb"
+            artifactId = "mongodb-hibernate-spring-boot-autoconfigure"
+            from(components["java"])
+            pom {
+                name = "MongoDB Extension for Hibernate ORM — Spring Boot Auto-Configuration"
+                description = "Spring Boot auto-configuration for the MongoDB Extension for Hibernate ORM"
+                // url, licenses, developers, scm injected by mongo-hibernate-publish plugin
+            }
+        }
+    }
+}

--- a/mongodb-hibernate-spring-boot-autoconfigure/build.gradle.kts
+++ b/mongodb-hibernate-spring-boot-autoconfigure/build.gradle.kts
@@ -22,7 +22,7 @@ plugins {
 
 repositories { mavenCentral() }
 
-// This module ships no module-info.java — like Spring Boot's own autoconfigure jars (which are
+// This module ships no module-info.java. Like Spring Boot's own autoconfigure jars (which are
 // automatic modules), it lives in a Spring ecosystem that is entirely automatic modules, so a full
 // JPMS module descriptor would force an explicit module onto a sea of automatic ones for no benefit
 // (module-path execution is not a tested mode). A stable Automatic-Module-Name is declared instead.
@@ -49,14 +49,14 @@ listOf("compileOnly", "testImplementation").forEach { cfg ->
         }
 
 dependencies {
-    // The Spring Boot BOM — published as a <dependencyManagement> import via api(platform) — manages
+    // The Spring Boot BOM, published as a <dependencyManagement> import via api(platform), manages
     // the versions of the version-less spring-*/jakarta.* entries below.
     api(platform(libs.spring.boot.bom))
 
     // Hard dependencies: required whenever the auto-configuration is active.
     api(project(":")) // mongodb-hibernate: required, and exposes the MongoConfigurationContributor SPI to consumers
     implementation(libs.spring.boot.autoconfigure) // @AutoConfiguration, @ConditionalOn*, AbstractRepositoryConfigurationSourceSupport
-    implementation(libs.spring.boot.persistence) // EntityScanPackages — used unconditionally on the EntityManagerFactory path
+    implementation(libs.spring.boot.persistence) // EntityScanPackages, used unconditionally on the EntityManagerFactory path
     implementation("org.springframework.boot:spring-boot-jpa") // JpaProperties, EntityManagerFactoryBuilder, EntityManagerFactoryBuilderCustomizer
     implementation("org.springframework.boot:spring-boot-hibernate") // HibernateProperties, HibernateSettings, HibernatePropertiesCustomizer
     implementation("org.springframework:spring-orm") // LocalContainerEntityManagerFactoryBean, JpaTransactionManager
@@ -113,7 +113,7 @@ publishing {
             artifactId = "mongodb-hibernate-spring-boot-autoconfigure"
             from(components["java"])
             pom {
-                name = "MongoDB Extension for Hibernate ORM — Spring Boot Auto-Configuration"
+                name = "Spring Boot Auto-Configuration of MongoDB Extension for Hibernate ORM"
                 description = "Spring Boot auto-configuration for the MongoDB Extension for Hibernate ORM"
                 // url, licenses, developers, scm injected by mongo-hibernate-publish plugin
             }

--- a/mongodb-hibernate-spring-boot-autoconfigure/src/integrationTest/java/com/mongodb/hibernate/entityscanit/MongoHibernateEntityScanIntegrationTests.java
+++ b/mongodb-hibernate-spring-boot-autoconfigure/src/integrationTest/java/com/mongodb/hibernate/entityscanit/MongoHibernateEntityScanIntegrationTests.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2025-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.hibernate.entityscanit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.mongodb.hibernate.scannedentities.ScannedBook;
+import jakarta.persistence.EntityManagerFactory;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.persistence.autoconfigure.EntityScan;
+import org.springframework.boot.test.context.SpringBootTest;
+
+// classes = ScanTestApplication pins the context to this config. ScannedBook lives in a separate
+// package (com.mongodb.hibernate.scannedentities), so it is found only because @EntityScan points
+// at it — exercising the EntityScanPackages branch of MongoHibernateAutoConfiguration's package
+// resolution (as opposed to the AutoConfigurationPackages fallback).
+@SpringBootTest(classes = MongoHibernateEntityScanIntegrationTests.ScanTestApplication.class)
+class MongoHibernateEntityScanIntegrationTests {
+
+    @SpringBootApplication
+    @EntityScan(basePackageClasses = ScannedBook.class)
+    static class ScanTestApplication {}
+
+    @Autowired
+    EntityManagerFactory entityManagerFactory;
+
+    @Test
+    void entityFromEntityScanPackageIsMapped() {
+        assertThat(entityManagerFactory.getMetamodel().getEntities())
+                .anyMatch(type -> type.getJavaType().equals(ScannedBook.class));
+    }
+}

--- a/mongodb-hibernate-spring-boot-autoconfigure/src/integrationTest/java/com/mongodb/hibernate/naming/MongoHibernateDefaultNamingIntegrationTests.java
+++ b/mongodb-hibernate-spring-boot-autoconfigure/src/integrationTest/java/com/mongodb/hibernate/naming/MongoHibernateDefaultNamingIntegrationTests.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2025-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.hibernate.naming;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.bson.types.ObjectId;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.orm.jpa.JpaTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+// No spring.jpa.hibernate.naming.* override is set, so the auto-configuration must default to
+// Hibernate's identity physical naming (the Java property name), NOT Spring Boot's snake_case default.
+@SpringBootTest
+class MongoHibernateDefaultNamingIntegrationTests {
+
+    @Autowired
+    NamingBookRepository repository;
+
+    @Autowired
+    JpaTransactionManager transactionManager;
+
+    @Value("${spring.mongodb.uri}")
+    String connectionString;
+
+    @AfterEach
+    void cleanUp() {
+        repository.deleteAll();
+    }
+
+    @Test
+    void unannotatedFieldUsesJavaCamelCaseNameInStoredDocument() {
+        var id = new ObjectId();
+        new TransactionTemplate(transactionManager)
+                .executeWithoutResult(status -> repository.save(new NamingBook(id, "Dune", 1965)));
+
+        var document = NamingTestSupport.readStoredBook(connectionString, id);
+        assertThat(document.containsKey("publishYear")).isTrue();
+        assertThat(document.containsKey("publish_year")).isFalse();
+    }
+}

--- a/mongodb-hibernate-spring-boot-autoconfigure/src/integrationTest/java/com/mongodb/hibernate/naming/MongoHibernateSnakeCaseNamingIntegrationTests.java
+++ b/mongodb-hibernate-spring-boot-autoconfigure/src/integrationTest/java/com/mongodb/hibernate/naming/MongoHibernateSnakeCaseNamingIntegrationTests.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2025-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.hibernate.naming;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.bson.types.ObjectId;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.orm.jpa.JpaTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+// An explicit spring.jpa.hibernate.naming.physical-strategy must be honored end to end: the stored
+// field key becomes snake_case. This proves the default is overridable and not silently dropped.
+@SpringBootTest(
+        properties =
+                "spring.jpa.hibernate.naming.physical-strategy=org.hibernate.boot.model.naming.PhysicalNamingStrategySnakeCaseImpl")
+class MongoHibernateSnakeCaseNamingIntegrationTests {
+
+    @Autowired
+    NamingBookRepository repository;
+
+    @Autowired
+    JpaTransactionManager transactionManager;
+
+    @Value("${spring.mongodb.uri}")
+    String connectionString;
+
+    @AfterEach
+    void cleanUp() {
+        repository.deleteAll();
+    }
+
+    @Test
+    void explicitSnakeCaseStrategyIsHonoredInStoredDocument() {
+        var id = new ObjectId();
+        new TransactionTemplate(transactionManager)
+                .executeWithoutResult(status -> repository.save(new NamingBook(id, "Dune", 1965)));
+
+        var document = NamingTestSupport.readStoredBook(connectionString, id);
+        assertThat(document.containsKey("publish_year")).isTrue();
+        assertThat(document.containsKey("publishYear")).isFalse();
+    }
+}

--- a/mongodb-hibernate-spring-boot-autoconfigure/src/integrationTest/java/com/mongodb/hibernate/naming/NamingBook.java
+++ b/mongodb-hibernate-spring-boot-autoconfigure/src/integrationTest/java/com/mongodb/hibernate/naming/NamingBook.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2025-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.hibernate.naming;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import org.bson.types.ObjectId;
+
+// The collection name is pinned to a lowercase single word so it is stable under both the identity and
+// snake_case physical naming strategies; only the unannotated multi-word field `publishYear` varies
+// (publishYear vs publish_year), which is what the naming tests assert.
+@Entity
+@Table(name = "namingbook")
+public class NamingBook {
+
+    @Id
+    public ObjectId id;
+
+    public String title;
+
+    public int publishYear;
+
+    public NamingBook() {}
+
+    public NamingBook(ObjectId id, String title, int publishYear) {
+        this.id = id;
+        this.title = title;
+        this.publishYear = publishYear;
+    }
+}

--- a/mongodb-hibernate-spring-boot-autoconfigure/src/integrationTest/java/com/mongodb/hibernate/naming/NamingBookRepository.java
+++ b/mongodb-hibernate-spring-boot-autoconfigure/src/integrationTest/java/com/mongodb/hibernate/naming/NamingBookRepository.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2025-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.hibernate.naming;
+
+import org.bson.types.ObjectId;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NamingBookRepository extends JpaRepository<NamingBook, ObjectId> {}

--- a/mongodb-hibernate-spring-boot-autoconfigure/src/integrationTest/java/com/mongodb/hibernate/naming/NamingTestApplication.java
+++ b/mongodb-hibernate-spring-boot-autoconfigure/src/integrationTest/java/com/mongodb/hibernate/naming/NamingTestApplication.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2025-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.hibernate.naming;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+// Lives in this package — NOT com.mongodb.hibernate.autoconfigure — so its component scan does not
+// double-register the production auto-configuration classes. Shared by both naming test classes.
+@SpringBootApplication
+class NamingTestApplication {}

--- a/mongodb-hibernate-spring-boot-autoconfigure/src/integrationTest/java/com/mongodb/hibernate/naming/NamingTestApplication.java
+++ b/mongodb-hibernate-spring-boot-autoconfigure/src/integrationTest/java/com/mongodb/hibernate/naming/NamingTestApplication.java
@@ -18,7 +18,7 @@ package com.mongodb.hibernate.naming;
 
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
-// Lives in this package — NOT com.mongodb.hibernate.autoconfigure — so its component scan does not
+// Lives in this package, not com.mongodb.hibernate.autoconfigure, so its component scan does not
 // double-register the production auto-configuration classes. Shared by both naming test classes.
 @SpringBootApplication
 class NamingTestApplication {}

--- a/mongodb-hibernate-spring-boot-autoconfigure/src/integrationTest/java/com/mongodb/hibernate/naming/NamingTestSupport.java
+++ b/mongodb-hibernate-spring-boot-autoconfigure/src/integrationTest/java/com/mongodb/hibernate/naming/NamingTestSupport.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2025-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.hibernate.naming;
+
+import com.mongodb.ConnectionString;
+import com.mongodb.client.MongoClients;
+import java.util.Objects;
+import org.bson.BsonDocument;
+import org.bson.BsonObjectId;
+import org.bson.types.ObjectId;
+
+final class NamingTestSupport {
+
+    private NamingTestSupport() {}
+
+    // Reads the raw stored document straight from MongoDB (bypassing Hibernate) so the test inspects the
+    // actual persisted field keys rather than the entity's Java property names.
+    static BsonDocument readStoredBook(String connectionString, ObjectId id) {
+        try (var client = MongoClients.create(connectionString)) {
+            var databaseName = Objects.requireNonNull(
+                    new ConnectionString(connectionString).getDatabase(),
+                    "connection string must include a database name");
+            var document = client.getDatabase(databaseName)
+                    .getCollection("namingbook", BsonDocument.class)
+                    .find(new BsonDocument("_id", new BsonObjectId(id)))
+                    .first();
+            return Objects.requireNonNull(document, () -> "no stored document for id " + id);
+        }
+    }
+}

--- a/mongodb-hibernate-spring-boot-autoconfigure/src/integrationTest/java/com/mongodb/hibernate/scannedentities/ScannedBook.java
+++ b/mongodb-hibernate-spring-boot-autoconfigure/src/integrationTest/java/com/mongodb/hibernate/scannedentities/ScannedBook.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2025-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.hibernate.scannedentities;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import org.bson.types.ObjectId;
+
+// Lives outside any test application's package, so it is discoverable only via @EntityScan.
+@Entity
+public class ScannedBook {
+
+    @Id
+    public ObjectId id;
+
+    public String title;
+
+    public ScannedBook() {}
+}

--- a/mongodb-hibernate-spring-boot-autoconfigure/src/integrationTest/java/com/mongodb/hibernate/springboot/BookRepository.java
+++ b/mongodb-hibernate-spring-boot-autoconfigure/src/integrationTest/java/com/mongodb/hibernate/springboot/BookRepository.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2025-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.hibernate.springboot;
+
+import org.bson.types.ObjectId;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BookRepository extends JpaRepository<TestBook, ObjectId> {}

--- a/mongodb-hibernate-spring-boot-autoconfigure/src/integrationTest/java/com/mongodb/hibernate/springboot/DatabaseNameOverrideIntegrationTests.java
+++ b/mongodb-hibernate-spring-boot-autoconfigure/src/integrationTest/java/com/mongodb/hibernate/springboot/DatabaseNameOverrideIntegrationTests.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2025-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.hibernate.springboot;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.model.Filters;
+import org.bson.types.ObjectId;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.orm.jpa.JpaTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+// spring.mongodb.database must override the database embedded in spring.mongodb.uri, mirroring Spring's
+// MongoDatabaseFactoryConfiguration. The entity must land in db_from_property, and db_from_uri must be untouched.
+@SpringBootTest(
+        classes = MongoHibernateSpringBootIntegrationTests.TestApplication.class,
+        properties = {
+            "spring.jpa.database-platform=MongoDB",
+            "spring.mongodb.uri=mongodb://localhost/db_from_uri?directConnection=false",
+            "spring.mongodb.database=db_from_property"
+        })
+class DatabaseNameOverrideIntegrationTests {
+
+    @Autowired
+    BookRepository bookRepository;
+
+    @Autowired
+    MongoClient mongoClient;
+
+    @Autowired
+    JpaTransactionManager transactionManager;
+
+    @AfterEach
+    void cleanUp() {
+        bookRepository.deleteAll();
+    }
+
+    @Test
+    void springMongoDatabaseOverridesUriDatabase() {
+        var id = new ObjectId();
+        new TransactionTemplate(transactionManager)
+                .executeWithoutResult(status -> bookRepository.save(new TestBook(id, "Override")));
+
+        // The document physically lands in the database from spring.mongodb.database (db_from_property),
+        // not the one embedded in spring.mongodb.uri (db_from_uri). Checked with the raw driver against the
+        // TestBook collection (entity name; @Id ObjectId maps to _id).
+        assertThat(mongoClient
+                        .getDatabase("db_from_property")
+                        .getCollection("TestBook")
+                        .countDocuments(Filters.eq("_id", id)))
+                .isEqualTo(1L);
+        assertThat(mongoClient
+                        .getDatabase("db_from_uri")
+                        .getCollection("TestBook")
+                        .countDocuments())
+                .isZero();
+    }
+}

--- a/mongodb-hibernate-spring-boot-autoconfigure/src/integrationTest/java/com/mongodb/hibernate/springboot/MongoHibernateSpringBootIntegrationTests.java
+++ b/mongodb-hibernate-spring-boot-autoconfigure/src/integrationTest/java/com/mongodb/hibernate/springboot/MongoHibernateSpringBootIntegrationTests.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2025-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.hibernate.springboot;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.mongodb.event.CommandListener;
+import com.mongodb.event.CommandStartedEvent;
+import jakarta.persistence.EntityManagerFactory;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import org.bson.types.ObjectId;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.mongodb.autoconfigure.MongoClientSettingsBuilderCustomizer;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.orm.jpa.JpaTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+// The @SpringBootApplication lives in this package — NOT com.mongodb.hibernate.autoconfigure —
+// so its component scan does not pick up the production auto-configuration classes (which would
+// otherwise be registered both by scanning and by the auto-configuration imports). With
+// spring.jpa.database-platform=MongoDB set (in application.properties), the auto-configuration
+// activates and borrows the Spring-managed MongoClient (created from spring.mongodb.uri) to wire
+// the whole stack.
+@SpringBootTest
+class MongoHibernateSpringBootIntegrationTests {
+
+    private static final List<String> COMMAND_NAMES = new CopyOnWriteArrayList<>();
+
+    private static final CommandListener RECORDING_LISTENER = new CommandListener() {
+        @Override
+        public void commandStarted(CommandStartedEvent event) {
+            COMMAND_NAMES.add(event.getCommandName());
+        }
+    };
+
+    @SpringBootApplication
+    static class TestApplication {
+
+        @Bean
+        MongoClientSettingsBuilderCustomizer recordingCommandListenerCustomizer() {
+            return builder -> builder.addCommandListener(RECORDING_LISTENER);
+        }
+    }
+
+    @Autowired
+    EntityManagerFactory entityManagerFactory;
+
+    @Autowired
+    JpaTransactionManager transactionManager;
+
+    @Autowired
+    BookRepository bookRepository;
+
+    @AfterEach
+    void cleanUp() {
+        bookRepository.deleteAll();
+    }
+
+    @Test
+    void entityManagerFactoryAndTransactionManagerAreCreated() {
+        assertThat(entityManagerFactory).isNotNull();
+        assertThat(transactionManager).isNotNull();
+    }
+
+    @Test
+    void entityCanBePersistedAndFound() {
+        var id = new ObjectId();
+        var book = new TestBook(id, "The Hobbit");
+
+        var txTemplate = new TransactionTemplate(transactionManager);
+        txTemplate.executeWithoutResult(status -> bookRepository.save(book));
+
+        var found = bookRepository.findById(id);
+        assertThat(found).isPresent();
+        assertThat(found.get().title).isEqualTo("The Hobbit");
+    }
+
+    @Test
+    void jpaRepositoryBeanIsCreated() {
+        assertThat(bookRepository).isNotNull();
+    }
+
+    @Test
+    void rolledBackTransactionPersistsNothing() {
+        var id = new ObjectId();
+        var txTemplate = new TransactionTemplate(transactionManager);
+        txTemplate.execute(status -> {
+            bookRepository.save(new TestBook(id, "Rolled back"));
+            status.setRollbackOnly();
+            return null;
+        });
+        assertThat(bookRepository.findById(id)).isEmpty();
+    }
+
+    @Test
+    void entityManagerOperationsUseTheBorrowedSpringClient() {
+        // The command listener is registered only on the spring-boot-mongodb client's settings. A Hibernate
+        // operation triggering it proves Hibernate is using that same (borrowed) client, not a second one.
+        COMMAND_NAMES.clear();
+        var txTemplate = new TransactionTemplate(transactionManager);
+        txTemplate.executeWithoutResult(status -> bookRepository.findAll());
+        assertThat(COMMAND_NAMES).contains("aggregate");
+    }
+}

--- a/mongodb-hibernate-spring-boot-autoconfigure/src/integrationTest/java/com/mongodb/hibernate/springboot/MongoHibernateSpringBootIntegrationTests.java
+++ b/mongodb-hibernate-spring-boot-autoconfigure/src/integrationTest/java/com/mongodb/hibernate/springboot/MongoHibernateSpringBootIntegrationTests.java
@@ -61,24 +61,27 @@ class MongoHibernateSpringBootIntegrationTests {
         }
     }
 
-    @Autowired
+    @Autowired(required = false)
     EntityManagerFactory entityManagerFactory;
 
-    @Autowired
+    @Autowired(required = false)
     JpaTransactionManager transactionManager;
 
-    @Autowired
+    @Autowired(required = false)
     BookRepository bookRepository;
 
     @AfterEach
     void cleanUp() {
-        bookRepository.deleteAll();
+        if (bookRepository != null) {
+            bookRepository.deleteAll();
+        }
     }
 
     @Test
-    void entityManagerFactoryAndTransactionManagerAreCreated() {
+    void allBeansCreated() {
         assertThat(entityManagerFactory).isNotNull();
         assertThat(transactionManager).isNotNull();
+        assertThat(bookRepository).isNotNull();
     }
 
     @Test
@@ -92,11 +95,6 @@ class MongoHibernateSpringBootIntegrationTests {
         var found = bookRepository.findById(id);
         assertThat(found).isPresent();
         assertThat(found.get().title).isEqualTo("The Hobbit");
-    }
-
-    @Test
-    void jpaRepositoryBeanIsCreated() {
-        assertThat(bookRepository).isNotNull();
     }
 
     @Test

--- a/mongodb-hibernate-spring-boot-autoconfigure/src/integrationTest/java/com/mongodb/hibernate/springboot/MongoHibernateSpringBootIntegrationTests.java
+++ b/mongodb-hibernate-spring-boot-autoconfigure/src/integrationTest/java/com/mongodb/hibernate/springboot/MongoHibernateSpringBootIntegrationTests.java
@@ -34,7 +34,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.orm.jpa.JpaTransactionManager;
 import org.springframework.transaction.support.TransactionTemplate;
 
-// The @SpringBootApplication lives in this package — NOT com.mongodb.hibernate.autoconfigure —
+// The @SpringBootApplication lives in this package, not com.mongodb.hibernate.autoconfigure,
 // so its component scan does not pick up the production auto-configuration classes (which would
 // otherwise be registered both by scanning and by the auto-configuration imports). With
 // spring.jpa.database-platform=MongoDB set (in application.properties), the auto-configuration

--- a/mongodb-hibernate-spring-boot-autoconfigure/src/integrationTest/java/com/mongodb/hibernate/springboot/TestBook.java
+++ b/mongodb-hibernate-spring-boot-autoconfigure/src/integrationTest/java/com/mongodb/hibernate/springboot/TestBook.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2025-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.hibernate.springboot;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import org.bson.types.ObjectId;
+
+@Entity
+public class TestBook {
+
+    @Id
+    public ObjectId id;
+
+    public String title;
+
+    public TestBook() {}
+
+    public TestBook(ObjectId id, String title) {
+        this.id = id;
+        this.title = title;
+    }
+}

--- a/mongodb-hibernate-spring-boot-autoconfigure/src/integrationTest/java/com/mongodb/hibernate/sqlcoexistence/MongoHibernateSqlCoexistenceIntegrationTests.java
+++ b/mongodb-hibernate-spring-boot-autoconfigure/src/integrationTest/java/com/mongodb/hibernate/sqlcoexistence/MongoHibernateSqlCoexistenceIntegrationTests.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2025-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.hibernate.sqlcoexistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.sql.SQLException;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+// A plain SQL JPA application with this module merely on its classpath. @ActiveProfiles("h2") loads
+// application-h2.properties, which configures an in-memory H2 datasource and overrides the shared
+// spring.jpa.database-platform=MongoDB with a SQL dialect; because OnMongoDatabasePlatformCondition no
+// longer matches, our auto-configurations stay off. A successful boot plus a write that physically lands in
+// H2 proves both that our Spring auto-configuration is inert AND that mongodb-hibernate's Hibernate
+// ServiceContributor does not interfere with a non-MongoDB SessionFactory.
+@SpringBootTest(classes = SqlCoexistenceApplication.class)
+@ActiveProfiles("h2")
+class MongoHibernateSqlCoexistenceIntegrationTests {
+
+    @Autowired
+    DataSource dataSource;
+
+    @Autowired
+    SqlWidgetRepository repository;
+
+    @Test
+    void sqlApplicationIsUnaffectedByMongoHibernateOnClasspath() throws SQLException {
+        var saved = repository.save(new SqlWidget("gadget"));
+
+        // Prove the write physically landed in the H2 SQL database — not MongoDB — by reading it back over a
+        // raw JDBC connection on the autowired DataSource, bypassing JPA entirely. A repository round-trip
+        // alone would pass regardless of which store backs the EntityManagerFactory; querying the SQL table
+        // directly is what confirms Hibernate persisted through the SQL DataSource and that our Mongo
+        // auto-configuration never engaged.
+        try (var connection = dataSource.getConnection();
+                var statement = connection.prepareStatement("select name from sql_widget where id = ?")) {
+            statement.setLong(1, saved.id);
+            try (var resultSet = statement.executeQuery()) {
+                assertThat(resultSet.next()).isTrue();
+                assertThat(resultSet.getString("name")).isEqualTo("gadget");
+                assertThat(resultSet.next()).isFalse();
+            }
+        }
+    }
+}

--- a/mongodb-hibernate-spring-boot-autoconfigure/src/integrationTest/java/com/mongodb/hibernate/sqlcoexistence/MongoHibernateSqlCoexistenceIntegrationTests.java
+++ b/mongodb-hibernate-spring-boot-autoconfigure/src/integrationTest/java/com/mongodb/hibernate/sqlcoexistence/MongoHibernateSqlCoexistenceIntegrationTests.java
@@ -45,7 +45,7 @@ class MongoHibernateSqlCoexistenceIntegrationTests {
     void sqlApplicationIsUnaffectedByMongoHibernateOnClasspath() throws SQLException {
         var saved = repository.save(new SqlWidget("gadget"));
 
-        // Prove the write physically landed in the H2 SQL database — not MongoDB — by reading it back over a
+        // Prove the write physically landed in the H2 SQL database, not MongoDB, by reading it back over a
         // raw JDBC connection on the autowired DataSource, bypassing JPA entirely. A repository round-trip
         // alone would pass regardless of which store backs the EntityManagerFactory; querying the SQL table
         // directly is what confirms Hibernate persisted through the SQL DataSource and that our Mongo

--- a/mongodb-hibernate-spring-boot-autoconfigure/src/integrationTest/java/com/mongodb/hibernate/sqlcoexistence/SqlCoexistenceApplication.java
+++ b/mongodb-hibernate-spring-boot-autoconfigure/src/integrationTest/java/com/mongodb/hibernate/sqlcoexistence/SqlCoexistenceApplication.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2025-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.hibernate.sqlcoexistence;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class SqlCoexistenceApplication {}

--- a/mongodb-hibernate-spring-boot-autoconfigure/src/integrationTest/java/com/mongodb/hibernate/sqlcoexistence/SqlWidget.java
+++ b/mongodb-hibernate-spring-boot-autoconfigure/src/integrationTest/java/com/mongodb/hibernate/sqlcoexistence/SqlWidget.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2025-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.hibernate.sqlcoexistence;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+
+@Entity
+public class SqlWidget {
+
+    @Id
+    @GeneratedValue
+    public Long id;
+
+    public String name;
+
+    public SqlWidget() {}
+
+    public SqlWidget(String name) {
+        this.name = name;
+    }
+}

--- a/mongodb-hibernate-spring-boot-autoconfigure/src/integrationTest/java/com/mongodb/hibernate/sqlcoexistence/SqlWidgetRepository.java
+++ b/mongodb-hibernate-spring-boot-autoconfigure/src/integrationTest/java/com/mongodb/hibernate/sqlcoexistence/SqlWidgetRepository.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2025-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.hibernate.sqlcoexistence;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SqlWidgetRepository extends JpaRepository<SqlWidget, Long> {}

--- a/mongodb-hibernate-spring-boot-autoconfigure/src/integrationTest/resources/application-h2.properties
+++ b/mongodb-hibernate-spring-boot-autoconfigure/src/integrationTest/resources/application-h2.properties
@@ -1,0 +1,6 @@
+# Override the shared application.properties' spring.jpa.database-platform=MongoDB with a SQL dialect so
+# OnMongoDatabasePlatformCondition does not match and the MongoDB auto-configuration stays inert; this models
+# a plain SQL JPA application that merely has mongodb-hibernate on its classpath.
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+spring.datasource.url=jdbc:h2:mem:coexistence;DB_CLOSE_DELAY=-1
+spring.jpa.hibernate.ddl-auto=create-drop

--- a/mongodb-hibernate-spring-boot-autoconfigure/src/integrationTest/resources/application.properties
+++ b/mongodb-hibernate-spring-boot-autoconfigure/src/integrationTest/resources/application.properties
@@ -1,0 +1,2 @@
+spring.jpa.database-platform=MongoDB
+spring.mongodb.uri=mongodb://localhost/mongo-hibernate-test?directConnection=false

--- a/mongodb-hibernate-spring-boot-autoconfigure/src/main/java/com/mongodb/hibernate/autoconfigure/MongoHibernateAutoConfiguration.java
+++ b/mongodb-hibernate-spring-boot-autoconfigure/src/main/java/com/mongodb/hibernate/autoconfigure/MongoHibernateAutoConfiguration.java
@@ -320,6 +320,11 @@ public class MongoHibernateAutoConfiguration {
             this.jpaProperties = jpaProperties;
         }
 
+        /**
+         * Registers an {@link OpenEntityManagerInViewInterceptor} for MongoDB-backed JPA.
+         *
+         * @return the interceptor
+         */
         @Bean
         public OpenEntityManagerInViewInterceptor openEntityManagerInViewInterceptor() {
             if (jpaProperties.getOpenInView() == null) {
@@ -330,6 +335,12 @@ public class MongoHibernateAutoConfiguration {
             return new OpenEntityManagerInViewInterceptor();
         }
 
+        /**
+         * Registers the {@link OpenEntityManagerInViewInterceptor} as a Spring MVC interceptor.
+         *
+         * @param interceptor the interceptor to register
+         * @return a {@link WebMvcConfigurer} that adds the interceptor
+         */
         @Bean
         public WebMvcConfigurer mongoOpenEntityManagerInViewInterceptorConfigurer(
                 OpenEntityManagerInViewInterceptor interceptor) {

--- a/mongodb-hibernate-spring-boot-autoconfigure/src/main/java/com/mongodb/hibernate/autoconfigure/MongoHibernateAutoConfiguration.java
+++ b/mongodb-hibernate-spring-boot-autoconfigure/src/main/java/com/mongodb/hibernate/autoconfigure/MongoHibernateAutoConfiguration.java
@@ -75,8 +75,8 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
  * <p>Activated when {@link MongoConfigurationContributor} is on the classpath and {@code spring.jpa.database-platform}
  * is {@code MongoDB}. It reuses Spring Boot's own JPA property machinery ({@link JpaProperties},
  * {@link HibernateProperties}, {@link EntityManagerFactoryBuilder}) so the full {@code spring.jpa.*} surface is honored
- * — {@code ddl-auto}, {@code show-sql}, naming strategies, {@link HibernatePropertiesCustomizer} and
- * {@link EntityManagerFactoryBuilderCustomizer} beans — rather than only the raw {@code spring.jpa.properties.*}
+ * - {@code ddl-auto}, {@code show-sql}, naming strategies, {@link HibernatePropertiesCustomizer} and
+ * {@link EntityManagerFactoryBuilderCustomizer} beans - rather than only the raw {@code spring.jpa.properties.*}
  * passthrough. Spring Boot's {@code HibernateJpaAutoConfiguration} cannot be reused directly because it requires a
  * {@code DataSource}; this module has none (Hibernate connects to MongoDB via {@code jakarta.persistence.jdbc.url}).
  *
@@ -193,7 +193,7 @@ public class MongoHibernateAutoConfiguration {
         // default. putIfAbsent means an explicit spring.jpa.hibernate.naming.* (which Spring Boot applies
         // with put) or a raw spring.jpa.properties.hibernate.*_naming_strategy still wins; only the unset
         // case falls back to Hibernate's identity (camelCase) mapping. A schemaless store must not
-        // silently reshape field names — see the design spec.
+        // silently reshape field names.
         var base = new HashMap<>(jpaProperties.getProperties());
         base.putIfAbsent(
                 MappingSettings.IMPLICIT_NAMING_STRATEGY, ImplicitNamingStrategyJpaCompliantImpl.class.getName());
@@ -229,7 +229,7 @@ public class MongoHibernateAutoConfiguration {
     @Primary
     @ConditionalOnMissingBean({LocalContainerEntityManagerFactoryBean.class, EntityManagerFactory.class})
     // EntityManagerFactoryBuilder only exposes build() via dataSource(...), but MongoDB has no JDBC
-    // DataSource — Hibernate connects through jakarta.persistence.jdbc.url. null is the correct
+    // DataSource. Hibernate connects through jakarta.persistence.jdbc.url. null is the correct
     // "no DataSource" value (LocalContainerEntityManagerFactoryBean tolerates it); NullAway cannot see
     // that the builder's parameter is effectively nullable.
     @SuppressWarnings("NullAway")

--- a/mongodb-hibernate-spring-boot-autoconfigure/src/main/java/com/mongodb/hibernate/autoconfigure/MongoHibernateAutoConfiguration.java
+++ b/mongodb-hibernate-spring-boot-autoconfigure/src/main/java/com/mongodb/hibernate/autoconfigure/MongoHibernateAutoConfiguration.java
@@ -1,0 +1,364 @@
+/*
+ * Copyright 2025-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.hibernate.autoconfigure;
+
+import com.mongodb.client.MongoClient;
+import com.mongodb.hibernate.cfg.spi.MongoConfigurationContributor;
+import jakarta.persistence.EntityManagerFactory;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.hibernate.boot.model.naming.ImplicitNamingStrategyJpaCompliantImpl;
+import org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl;
+import org.hibernate.cfg.MappingSettings;
+import org.jspecify.annotations.Nullable;
+import org.springframework.aot.hint.MemberCategory;
+import org.springframework.aot.hint.RuntimeHints;
+import org.springframework.aot.hint.RuntimeHintsRegistrar;
+import org.springframework.aot.hint.TypeReference;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfigurationPackages;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBooleanProperty;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.hibernate.autoconfigure.HibernateProperties;
+import org.springframework.boot.hibernate.autoconfigure.HibernatePropertiesCustomizer;
+import org.springframework.boot.hibernate.autoconfigure.HibernateSettings;
+import org.springframework.boot.jpa.EntityManagerFactoryBuilder;
+import org.springframework.boot.jpa.autoconfigure.EntityManagerFactoryBuilderCustomizer;
+import org.springframework.boot.jpa.autoconfigure.JpaProperties;
+import org.springframework.boot.mongodb.autoconfigure.MongoConnectionDetails;
+import org.springframework.boot.mongodb.autoconfigure.MongoProperties;
+import org.springframework.boot.persistence.autoconfigure.EntityScanPackages;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.ImportRuntimeHints;
+import org.springframework.context.annotation.Primary;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.orm.jpa.JpaTransactionManager;
+import org.springframework.orm.jpa.JpaVendorAdapter;
+import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
+import org.springframework.orm.jpa.support.OpenEntityManagerInViewInterceptor;
+import org.springframework.orm.jpa.vendor.HibernateJpaVendorAdapter;
+import org.springframework.transaction.TransactionManager;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+/**
+ * Spring Boot {@link AutoConfiguration auto-configuration} for MongoDB-backed JPA via the MongoDB Extension for
+ * Hibernate ORM.
+ *
+ * <p>Activated when {@link MongoConfigurationContributor} is on the classpath and {@code spring.jpa.database-platform}
+ * is {@code MongoDB}. It reuses Spring Boot's own JPA property machinery ({@link JpaProperties},
+ * {@link HibernateProperties}, {@link EntityManagerFactoryBuilder}) so the full {@code spring.jpa.*} surface is honored
+ * — {@code ddl-auto}, {@code show-sql}, naming strategies, {@link HibernatePropertiesCustomizer} and
+ * {@link EntityManagerFactoryBuilderCustomizer} beans — rather than only the raw {@code spring.jpa.properties.*}
+ * passthrough. Spring Boot's {@code HibernateJpaAutoConfiguration} cannot be reused directly because it requires a
+ * {@code DataSource}; this module has none (Hibernate connects to MongoDB via {@code jakarta.persistence.jdbc.url}).
+ *
+ * <p>Unlike Spring Boot, the default physical naming strategy is left as Hibernate's own identity mapping (the Java
+ * property name) rather than {@code snake_case}: MongoDB is schemaless, so a divergent naming default would silently
+ * fork field names across documents instead of erroring as a relational schema would. An explicit
+ * {@code spring.jpa.hibernate.naming.*} is still honored.
+ *
+ * <p>Any {@link MongoConfigurationContributor} beans are aggregated into a composite contributor (applied in
+ * {@link org.springframework.core.annotation.Order @Order} order, last wins) and forwarded to Hibernate through the JPA
+ * properties map.
+ */
+// afterName (string) for MongoAutoConfiguration because spring-boot-mongodb is optional and may be absent at
+// runtime; ordering after it ensures the MongoClient bean is registered before this configuration's bean
+// conditions are evaluated. before uses the HibernateJpaAutoConfiguration class directly because
+// spring-boot-hibernate is a non-optional implementation dependency; this lets the @Primary Mongo
+// EntityManagerFactory win and Spring's SQL JPA back off when a stray DataSource is present.
+@AutoConfiguration(
+        afterName = "org.springframework.boot.mongodb.autoconfigure.MongoAutoConfiguration",
+        before = org.springframework.boot.hibernate.autoconfigure.HibernateJpaAutoConfiguration.class)
+@ConditionalOnClass(MongoConfigurationContributor.class)
+// Activate only for MongoDB-backed applications: OnMongoDatabasePlatformCondition matches when
+// spring.jpa.database-platform is MongoDB, so this module stays inert in a SQL application even when it is on
+// the classpath.
+@Conditional(OnMongoDatabasePlatformCondition.class)
+@EnableConfigurationProperties({JpaProperties.class, HibernateProperties.class})
+@ImportRuntimeHints(MongoHibernateAutoConfiguration.MongoHibernateRuntimeHints.class)
+public class MongoHibernateAutoConfiguration {
+
+    // Same string as MongoConstants.MONGO_CONFIGURATION_CONTRIBUTOR_KEY in the core module.
+    // Duplicated here because MongoConstants is in an unexported internal package.
+    private static final String CONFIGURATION_CONTRIBUTOR_KEY =
+            "com.mongodb.hibernate.configurationContributor";
+
+    /** Creates a new {@code MongoHibernateAutoConfiguration}. */
+    public MongoHibernateAutoConfiguration() {}
+
+    /**
+     * Fails fast with an actionable message when the integration is active but there is no {@link MongoClient} bean to
+     * borrow (for example {@code spring-boot-mongodb} is absent and the application defines no {@code MongoClient}).
+     * Without this, bootstrap fails later in Hibernate with a cryptic "jakarta.persistence.jdbc.url is required" error.
+     *
+     * <p>The guard is registered as an eagerly-instantiated {@link BeanFactoryPostProcessor} so it runs before any
+     * regular singleton (in particular the {@code entityManagerFactory}), making the actionable message the surfaced
+     * failure rather than a downstream symptom.
+     */
+    @Bean
+    @ConditionalOnMissingBean({MongoClient.class, MongoConfigurationContributor.class})
+    static BeanFactoryPostProcessor mongoClientRequired() {
+        throw new IllegalStateException(
+                "spring.jpa.database-platform=MongoDB is set but no MongoClient bean is available to borrow. "
+                        + "Add the spring-boot-mongodb dependency and configure spring.mongodb.*, define a "
+                        + "MongoClient @Bean, or configure JPA manually instead of using this auto-configuration.");
+    }
+
+    /**
+     * Creates the JPA vendor adapter, applying the {@code spring.jpa.*} settings Spring Boot's
+     * {@code JpaBaseConfiguration} applies to its own adapter.
+     *
+     * @param jpaProperties the bound {@code spring.jpa.*} properties
+     * @return the configured vendor adapter
+     */
+    @Bean
+    @ConditionalOnMissingBean
+    public JpaVendorAdapter jpaVendorAdapter(JpaProperties jpaProperties) {
+        var adapter = new HibernateJpaVendorAdapter();
+        adapter.setShowSql(jpaProperties.isShowSql());
+        if (jpaProperties.getDatabase() != null) {
+            adapter.setDatabase(jpaProperties.getDatabase());
+        }
+        if (jpaProperties.getDatabasePlatform() != null) {
+            adapter.setDatabasePlatform(jpaProperties.getDatabasePlatform());
+        }
+        adapter.setGenerateDdl(jpaProperties.isGenerateDdl());
+        return adapter;
+    }
+
+    /**
+     * Creates the {@link EntityManagerFactoryBuilder}, wired with a JPA-properties factory that ignores its
+     * {@code DataSource} argument (MongoDB has none). {@link EntityManagerFactoryBuilderCustomizer} beans are applied in
+     * {@code @Order} order.
+     *
+     * @param jpaVendorAdapter the vendor adapter
+     * @param jpaProperties the bound {@code spring.jpa.*} properties
+     * @param hibernateProperties the bound {@code spring.jpa.hibernate.*} properties
+     * @param contributors the {@link MongoConfigurationContributor} beans to aggregate
+     * @param hibernateCustomizers the {@link HibernatePropertiesCustomizer} beans to apply
+     * @param builderCustomizers the {@link EntityManagerFactoryBuilderCustomizer} beans to apply
+     * @return the configured builder
+     */
+    @Bean
+    @ConditionalOnMissingBean
+    public EntityManagerFactoryBuilder mongoEntityManagerFactoryBuilder(
+            JpaVendorAdapter jpaVendorAdapter,
+            JpaProperties jpaProperties,
+            HibernateProperties hibernateProperties,
+            ObjectProvider<MongoConfigurationContributor> contributors,
+            ObjectProvider<HibernatePropertiesCustomizer> hibernateCustomizers,
+            ObjectProvider<EntityManagerFactoryBuilderCustomizer> builderCustomizers) {
+        var builder = new EntityManagerFactoryBuilder(
+                jpaVendorAdapter,
+                dataSource -> buildJpaProperties(jpaProperties, hibernateProperties, contributors, hibernateCustomizers),
+                null);
+        builderCustomizers.orderedStream().forEach(customizer -> customizer.customize(builder));
+        return builder;
+    }
+
+    private Map<String, Object> buildJpaProperties(
+            JpaProperties jpaProperties,
+            HibernateProperties hibernateProperties,
+            ObjectProvider<MongoConfigurationContributor> contributors,
+            ObjectProvider<HibernatePropertiesCustomizer> hibernateCustomizers) {
+        // Seed Hibernate's own default naming strategies so we do NOT inherit Spring Boot's snake_case
+        // default. putIfAbsent means an explicit spring.jpa.hibernate.naming.* (which Spring Boot applies
+        // with put) or a raw spring.jpa.properties.hibernate.*_naming_strategy still wins; only the unset
+        // case falls back to Hibernate's identity (camelCase) mapping. A schemaless store must not
+        // silently reshape field names — see the design spec.
+        var base = new HashMap<>(jpaProperties.getProperties());
+        base.putIfAbsent(
+                MappingSettings.IMPLICIT_NAMING_STRATEGY, ImplicitNamingStrategyJpaCompliantImpl.class.getName());
+        base.putIfAbsent(MappingSettings.PHYSICAL_NAMING_STRATEGY, PhysicalNamingStrategyStandardImpl.class.getName());
+
+        var settings = new HibernateSettings()
+                // MongoDB has no embedded-database notion, so Spring Boot's DataSource-dependent
+                // HibernateDefaultDdlAutoProvider is not used; default ddl-auto to "none".
+                .ddlAuto(() -> "none")
+                .hibernatePropertiesCustomizers(
+                        hibernateCustomizers.orderedStream().toList());
+
+        var properties = new HashMap<>(hibernateProperties.determineHibernateProperties(base, settings));
+
+        var contributorList = contributors.orderedStream().toList();
+        if (!contributorList.isEmpty()) {
+            MongoConfigurationContributor composite = cfg -> contributorList.forEach(c -> c.configure(cfg));
+            properties.put(CONFIGURATION_CONTRIBUTOR_KEY, composite);
+        }
+        return properties;
+    }
+
+    /**
+     * Creates the {@link LocalContainerEntityManagerFactoryBean} for MongoDB-backed JPA. Marked {@link Primary} to
+     * match Spring Boot and avoid ambiguity if a second {@link EntityManagerFactory} is present (a single persistence
+     * unit is the supported model).
+     *
+     * @param factoryBuilder the entity-manager-factory builder
+     * @param applicationContext the application context, used to resolve entity-scan packages
+     * @return the configured factory bean
+     */
+    @Bean
+    @Primary
+    @ConditionalOnMissingBean({LocalContainerEntityManagerFactoryBean.class, EntityManagerFactory.class})
+    // EntityManagerFactoryBuilder only exposes build() via dataSource(...), but MongoDB has no JDBC
+    // DataSource — Hibernate connects through jakarta.persistence.jdbc.url. null is the correct
+    // "no DataSource" value (LocalContainerEntityManagerFactoryBean tolerates it); NullAway cannot see
+    // that the builder's parameter is effectively nullable.
+    @SuppressWarnings("NullAway")
+    public LocalContainerEntityManagerFactoryBean entityManagerFactory(
+            EntityManagerFactoryBuilder factoryBuilder, ApplicationContext applicationContext) {
+        // Prefer packages registered via @EntityScan; fall back to the main @SpringBootApplication
+        // package (AutoConfigurationPackages) so entities are still discovered without @EntityScan.
+        var packages = EntityScanPackages.get(applicationContext).getPackageNames();
+        if (packages.isEmpty()) {
+            packages = AutoConfigurationPackages.get(applicationContext);
+        }
+        return factoryBuilder
+                .dataSource(null)
+                .packages(packages.toArray(String[]::new))
+                .build();
+    }
+
+    /**
+     * Creates a {@link JpaTransactionManager} bound to the {@link EntityManagerFactory}.
+     *
+     * @param entityManagerFactory the entity manager factory to manage transactions for
+     * @return the configured transaction manager
+     */
+    @Bean
+    @ConditionalOnMissingBean(TransactionManager.class)
+    public JpaTransactionManager transactionManager(EntityManagerFactory entityManagerFactory) {
+        return new JpaTransactionManager(entityManagerFactory);
+    }
+
+    /**
+     * Borrows the Spring-managed {@link MongoClient} and hands it to Hibernate via a
+     * {@link MongoConfigurationContributor}. Gated by {@code @ConditionalOnClass(MongoConnectionDetails.class)} so it is
+     * inert without {@code spring-boot-mongodb}, and by {@code @ConditionalOnBean(MongoClient.class)} so it borrows only
+     * an existing client.
+     */
+    @Configuration(proxyBeanMethods = false)
+    @ConditionalOnClass(MongoConnectionDetails.class)
+    @ConditionalOnBean(MongoClient.class)
+    @ConditionalOnMissingBean(MongoConfigurationContributor.class)
+    static class MongoClientBridgeConfiguration {
+
+        MongoClientBridgeConfiguration() {}
+
+        /**
+         * Ordered {@link Ordered#HIGHEST_PRECEDENCE} so it is applied first in the contributor composite, letting a user
+         * {@link MongoConfigurationContributor} (default order) override the supplied database name.
+         *
+         * @param mongoClient the Spring-managed client to borrow
+         * @param connectionDetails the connection details used to resolve the database name from the connection string
+         * @param mongoProperties the bound {@code spring.mongodb.*} properties used to resolve the database name
+         * @return a contributor that hands Hibernate the borrowed client and resolved database name
+         */
+        @Bean
+        @Order(Ordered.HIGHEST_PRECEDENCE)
+        MongoConfigurationContributor mongoClientConfigurationContributor(
+                MongoClient mongoClient, MongoConnectionDetails connectionDetails, MongoProperties mongoProperties) {
+            var resolved = mongoProperties.getDatabase();
+            if (resolved == null) {
+                resolved = connectionDetails.getConnectionString().getDatabase();
+            }
+            if (resolved == null) {
+                throw new IllegalStateException(
+                        "A MongoDB database name is required for spring.jpa.database-platform=MongoDB but none was found. "
+                                + "Put it in the connection string (spring.mongodb.uri=mongodb://host/<db>), set "
+                                + "spring.mongodb.database, or set it via MongoConfigurationContributor.databaseName(...).");
+            }
+            var databaseName = resolved;
+            return configurator -> configurator.mongoClient(mongoClient).databaseName(databaseName);
+        }
+    }
+
+    /**
+     * Registers an {@link OpenEntityManagerInViewInterceptor} in servlet web applications, mirroring Spring Boot's
+     * Open-Session-in-View support so {@code spring.jpa.open-in-view} behaves identically here.
+     */
+    @Configuration(proxyBeanMethods = false)
+    @ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.SERVLET)
+    @ConditionalOnClass(WebMvcConfigurer.class)
+    @ConditionalOnMissingBean(OpenEntityManagerInViewInterceptor.class)
+    @ConditionalOnBooleanProperty(name = "spring.jpa.open-in-view", matchIfMissing = true)
+    public static class MongoJpaWebConfiguration {
+
+        private static final Log logger = LogFactory.getLog(MongoJpaWebConfiguration.class);
+
+        private final JpaProperties jpaProperties;
+
+        MongoJpaWebConfiguration(JpaProperties jpaProperties) {
+            this.jpaProperties = jpaProperties;
+        }
+
+        @Bean
+        public OpenEntityManagerInViewInterceptor openEntityManagerInViewInterceptor() {
+            if (jpaProperties.getOpenInView() == null) {
+                logger.warn("spring.jpa.open-in-view is enabled by default. Therefore, database queries may be "
+                        + "performed during view rendering. Explicitly configure spring.jpa.open-in-view to disable "
+                        + "this warning");
+            }
+            return new OpenEntityManagerInViewInterceptor();
+        }
+
+        @Bean
+        public WebMvcConfigurer mongoOpenEntityManagerInViewInterceptorConfigurer(
+                OpenEntityManagerInViewInterceptor interceptor) {
+            return new WebMvcConfigurer() {
+                @Override
+                public void addInterceptors(InterceptorRegistry registry) {
+                    registry.addWebRequestInterceptor(interceptor);
+                }
+            };
+        }
+    }
+
+    /**
+     * Registers reflection hints for the naming-strategy and {@code NoJtaPlatform} types Hibernate instantiates
+     * reflectively, mirroring Spring Boot's {@code HibernateRuntimeHints} so this configuration works in a native image.
+     */
+    static class MongoHibernateRuntimeHints implements RuntimeHintsRegistrar {
+        @Override
+        public void registerHints(RuntimeHints hints, @Nullable ClassLoader classLoader) {
+            hints.reflection()
+                    .registerType(PhysicalNamingStrategyStandardImpl.class, MemberCategory.INVOKE_DECLARED_CONSTRUCTORS)
+                    .registerType(
+                            ImplicitNamingStrategyJpaCompliantImpl.class, MemberCategory.INVOKE_DECLARED_CONSTRUCTORS);
+            for (var noJtaPlatform : List.of(
+                    "org.hibernate.engine.transaction.jta.platform.internal.NoJtaPlatform",
+                    "org.hibernate.service.jta.platform.internal.NoJtaPlatform")) {
+                hints.reflection()
+                        .registerType(TypeReference.of(noJtaPlatform), MemberCategory.INVOKE_DECLARED_CONSTRUCTORS);
+            }
+        }
+    }
+}

--- a/mongodb-hibernate-spring-boot-autoconfigure/src/main/java/com/mongodb/hibernate/autoconfigure/MongoJpaRepositoriesAutoConfiguration.java
+++ b/mongodb-hibernate-spring-boot-autoconfigure/src/main/java/com/mongodb/hibernate/autoconfigure/MongoJpaRepositoriesAutoConfiguration.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2025-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.hibernate.autoconfigure;
+
+import java.lang.annotation.Annotation;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBooleanProperty;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.data.AbstractRepositoryConfigurationSourceSupport;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.data.jpa.repository.config.JpaRepositoryConfigExtension;
+import org.springframework.data.jpa.repository.support.JpaRepositoryFactoryBean;
+import org.springframework.data.repository.config.RepositoryConfigurationExtension;
+
+/**
+ * Spring Boot {@link AutoConfiguration auto-configuration} that enables Spring Data JPA repository scanning for
+ * MongoDB-backed persistence.
+ *
+ * <p>Spring Boot's own {@code DataJpaRepositoriesAutoConfiguration} only activates when a {@code DataSource} bean is
+ * present. This module provides no {@code DataSource}, so that auto-configuration never fires; this class is an
+ * equivalent that drops the {@code DataSource} requirement. It activates when {@link JpaRepository} is on the
+ * classpath, {@code spring.jpa.database-platform} is {@code MongoDB}, and no {@link JpaRepositoryFactoryBean} has already
+ * been defined, so a user who declares {@code @EnableJpaRepositories} themselves takes precedence.
+ */
+@AutoConfiguration(
+        after = MongoHibernateAutoConfiguration.class,
+        beforeName = "org.springframework.boot.data.jpa.autoconfigure.JpaRepositoriesAutoConfiguration")
+@ConditionalOnClass(JpaRepository.class)
+// Same gate as MongoHibernateAutoConfiguration: activate only when spring.jpa.database-platform=MongoDB,
+// so a SQL application with this module on its classpath is unaffected.
+@Conditional(OnMongoDatabasePlatformCondition.class)
+@ConditionalOnMissingBean({JpaRepositoryFactoryBean.class, JpaRepositoryConfigExtension.class})
+@ConditionalOnBooleanProperty(name = "spring.data.jpa.repositories.enabled", matchIfMissing = true)
+@Import(MongoJpaRepositoriesAutoConfiguration.RepositoriesRegistrar.class)
+public class MongoJpaRepositoriesAutoConfiguration {
+
+    /** Creates a new {@code MongoJpaRepositoriesAutoConfiguration}. */
+    public MongoJpaRepositoriesAutoConfiguration() {}
+
+    /**
+     * Registers the Spring Data JPA repository infrastructure. {@link AbstractRepositoryConfigurationSourceSupport} is
+     * the Spring Boot base class that wires {@code @EnableJpaRepositories} using {@code AutoConfigurationPackages} (the
+     * main application package) for the scan base, rather than the package of the annotated class.
+     */
+    static final class RepositoriesRegistrar extends AbstractRepositoryConfigurationSourceSupport {
+
+        RepositoriesRegistrar() {}
+
+        @Override
+        protected Class<? extends Annotation> getAnnotation() {
+            return EnableJpaRepositories.class;
+        }
+
+        @Override
+        protected Class<?> getConfiguration() {
+            return EnableJpaRepositoriesConfiguration.class;
+        }
+
+        @Override
+        protected RepositoryConfigurationExtension getRepositoryConfigurationExtension() {
+            return new JpaRepositoryConfigExtension();
+        }
+    }
+
+    @EnableJpaRepositories
+    private static class EnableJpaRepositoriesConfiguration {}
+}

--- a/mongodb-hibernate-spring-boot-autoconfigure/src/main/java/com/mongodb/hibernate/autoconfigure/OnMongoDatabasePlatformCondition.java
+++ b/mongodb-hibernate-spring-boot-autoconfigure/src/main/java/com/mongodb/hibernate/autoconfigure/OnMongoDatabasePlatformCondition.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2025-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.hibernate.autoconfigure;
+
+import org.springframework.boot.autoconfigure.condition.ConditionMessage;
+import org.springframework.boot.autoconfigure.condition.ConditionOutcome;
+import org.springframework.boot.autoconfigure.condition.SpringBootCondition;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+
+/**
+ * Matches when {@code spring.jpa.database-platform} is {@code MongoDB} (the MongoDB dialect short name). Gates the
+ * MongoDB JPA auto-configurations so they activate only when the application has declared MongoDB as its JPA platform,
+ * leaving a SQL-backed application untouched even when this module is on its classpath.
+ */
+final class OnMongoDatabasePlatformCondition extends SpringBootCondition {
+
+    // The MongoDB dialect short name (MongoConstants.MONGO_DIALECT_SHORT_NAME in the core module). Duplicated here
+    // because that constant is in an unexported internal package.
+    private static final String MONGO_DATABASE_PLATFORM = "MongoDB";
+
+    private static final String DATABASE_PLATFORM_PROPERTY = "spring.jpa.database-platform";
+
+    OnMongoDatabasePlatformCondition() {}
+
+    @Override
+    public ConditionOutcome getMatchOutcome(ConditionContext context, AnnotatedTypeMetadata metadata) {
+        var message = ConditionMessage.forCondition("MongoDB JPA platform");
+        var platform = context.getEnvironment().getProperty(DATABASE_PLATFORM_PROPERTY);
+        return MONGO_DATABASE_PLATFORM.equals(platform)
+                ? ConditionOutcome.match(message.foundExactly(DATABASE_PLATFORM_PROPERTY + "=" + MONGO_DATABASE_PLATFORM))
+                : ConditionOutcome.noMatch(
+                        message.didNotFind(DATABASE_PLATFORM_PROPERTY + "=" + MONGO_DATABASE_PLATFORM).atAll());
+    }
+}

--- a/mongodb-hibernate-spring-boot-autoconfigure/src/main/java/com/mongodb/hibernate/autoconfigure/package-info.java
+++ b/mongodb-hibernate-spring-boot-autoconfigure/src/main/java/com/mongodb/hibernate/autoconfigure/package-info.java
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+/** Spring Boot auto-configuration for the MongoDB Extension for Hibernate ORM. */
 @NullMarked
 package com.mongodb.hibernate.autoconfigure;
 

--- a/mongodb-hibernate-spring-boot-autoconfigure/src/main/java/com/mongodb/hibernate/autoconfigure/package-info.java
+++ b/mongodb-hibernate-spring-boot-autoconfigure/src/main/java/com/mongodb/hibernate/autoconfigure/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024-present MongoDB, Inc.
+ * Copyright 2025-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
-rootProject.name = "mongo-hibernate"
+@NullMarked
+package com.mongodb.hibernate.autoconfigure;
 
-include("mongodb-hibernate-spring-boot-autoconfigure")
+import org.jspecify.annotations.NullMarked;

--- a/mongodb-hibernate-spring-boot-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/mongodb-hibernate-spring-boot-autoconfigure/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,2 @@
+com.mongodb.hibernate.autoconfigure.MongoHibernateAutoConfiguration
+com.mongodb.hibernate.autoconfigure.MongoJpaRepositoriesAutoConfiguration

--- a/mongodb-hibernate-spring-boot-autoconfigure/src/test/java/com/mongodb/hibernate/autoconfigure/MongoHibernateAutoConfigurationTests.java
+++ b/mongodb-hibernate-spring-boot-autoconfigure/src/test/java/com/mongodb/hibernate/autoconfigure/MongoHibernateAutoConfigurationTests.java
@@ -1,0 +1,290 @@
+/*
+ * Copyright 2025-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.hibernate.autoconfigure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import com.mongodb.ConnectionString;
+import com.mongodb.client.MongoClient;
+import com.mongodb.hibernate.cfg.spi.MongoConfigurationContributor;
+import jakarta.persistence.EntityManagerFactory;
+import java.util.Map;
+import org.hibernate.boot.model.naming.ImplicitNamingStrategyComponentPathImpl;
+import org.hibernate.boot.model.naming.ImplicitNamingStrategyJpaCompliantImpl;
+import org.hibernate.boot.model.naming.PhysicalNamingStrategySnakeCaseImpl;
+import org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.hibernate.autoconfigure.HibernatePropertiesCustomizer;
+import org.springframework.boot.jpa.EntityManagerFactoryBuilder;
+import org.springframework.boot.mongodb.autoconfigure.MongoConnectionDetails;
+import org.springframework.boot.mongodb.autoconfigure.MongoProperties;
+import org.springframework.boot.test.context.FilteredClassLoader;
+import org.springframework.boot.test.context.assertj.AssertableApplicationContext;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
+import org.springframework.orm.jpa.JpaTransactionManager;
+import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
+import org.springframework.orm.jpa.support.OpenEntityManagerInViewInterceptor;
+
+class MongoHibernateAutoConfigurationTests {
+
+    private static final String PHYSICAL_NAMING_STRATEGY = "hibernate.physical_naming_strategy";
+    private static final String IMPLICIT_NAMING_STRATEGY = "hibernate.implicit_naming_strategy";
+
+    private static final String ACTIVATE = "spring.jpa.database-platform=MongoDB";
+
+    // Register as an auto-configuration (not withUserConfiguration) so Spring processes it AFTER
+    // user-supplied beans. @ConditionalOnMissingBean is only ordering-reliable for auto-configs.
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(MongoHibernateAutoConfiguration.class));
+
+    // Registers a stub MongoConnectionDetails (returning a connection string with a database), a mock
+    // MongoClient, and a MongoProperties bean, and sets the activation property — so the bridge resolves and
+    // the no-client guard backs off. Generic over the runner type so both the plain and web runners qualify.
+    private static <SELF extends org.springframework.boot.test.context.runner.AbstractApplicationContextRunner<
+                            SELF, C, A>,
+                    C extends org.springframework.context.ConfigurableApplicationContext,
+                    A extends org.springframework.boot.test.context.assertj.ApplicationContextAssertProvider<C>>
+            SELF withMongoClient(SELF runner) {
+        return runner.withPropertyValues(ACTIVATE)
+                .withBean(MongoClient.class, () -> mock(MongoClient.class))
+                .withBean(MongoProperties.class, MongoProperties::new)
+                .withBean(MongoConnectionDetails.class, () -> (MongoConnectionDetails)
+                        () -> new ConnectionString("mongodb://localhost/test"));
+    }
+
+    @Test
+    void backsOffIfEntityManagerFactoryAlreadyDefined() {
+        // With the integration active and a client to borrow, this isolates the @ConditionalOnMissingBean
+        // back-off rather than the activation gate. A user-supplied EntityManagerFactory must suppress ours.
+        withMongoClient(contextRunner)
+                .withBean(EntityManagerFactory.class, () -> mock(EntityManagerFactory.class))
+                .run(context -> {
+                    assertThat(context).doesNotHaveBean(LocalContainerEntityManagerFactoryBean.class);
+                    assertThat(context).hasSingleBean(EntityManagerFactory.class);
+                });
+    }
+
+    @Test
+    void doesNotActivateForNonMongoPlatform() {
+        // A SQL application that happens to have this module on its classpath must be left alone:
+        // OnMongoDatabasePlatformCondition does not match a non-MongoDB platform, so nothing is contributed.
+        contextRunner
+                .withPropertyValues("spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect")
+                .run(context -> {
+                    assertThat(context).doesNotHaveBean(LocalContainerEntityManagerFactoryBean.class);
+                    assertThat(context).doesNotHaveBean(EntityManagerFactoryBuilder.class);
+                    assertThat(context).doesNotHaveBean(JpaTransactionManager.class);
+                });
+    }
+
+    @Test
+    void doesNotActivateWithoutDatabasePlatform() {
+        contextRunner.run(context -> {
+            assertThat(context).doesNotHaveBean(LocalContainerEntityManagerFactoryBean.class);
+            assertThat(context).doesNotHaveBean(JpaTransactionManager.class);
+        });
+    }
+
+    @Test
+    void staysInertWhenMongoClientPresentButPlatformUnset() {
+        // The no-hijack case: a Spring Data MongoDB app has a MongoClient but has not opted into Mongo JPA.
+        contextRunner
+                .withBean(MongoClient.class, () -> mock(MongoClient.class))
+                .run(context -> assertThat(context).doesNotHaveBean(LocalContainerEntityManagerFactoryBean.class));
+    }
+
+    @Test
+    void failsFastWhenActivatedWithoutMongoClient() {
+        contextRunner
+                .withPropertyValues(ACTIVATE)
+                .run(context -> assertThat(context)
+                        .hasFailed()
+                        .getFailure()
+                        .hasMessageContaining("no MongoClient bean is available"));
+    }
+
+    @Test
+    void failsFastWhenNoDatabaseResolvedFromAnySource() {
+        // MongoClient present (guard passes), but neither spring.mongodb.database nor the connection string
+        // carries a database, so the bridge cannot resolve one.
+        contextRunner
+                .withPropertyValues(ACTIVATE)
+                .withBean(MongoClient.class, () -> mock(MongoClient.class))
+                .withBean(MongoProperties.class, MongoProperties::new) // getDatabase() == null
+                .withBean(MongoConnectionDetails.class, () -> (MongoConnectionDetails)
+                        () -> new ConnectionString("mongodb://localhost")) // no database in the connection string
+                .withBean(EntityManagerFactory.class, () -> mock(EntityManagerFactory.class))
+                .run(context -> assertThat(context)
+                        .hasFailed()
+                        .getFailure()
+                        .hasMessageContaining("database name is required"));
+    }
+
+    @Test
+    void userContributorTakesOverAndBridgeAndGuardBackOff() {
+        // A user MongoConfigurationContributor signals "I supply the connection myself": the bridge and the
+        // no-client guard both defer to it.
+        MongoConfigurationContributor userContributor = configurator -> {};
+        contextRunner
+                .withPropertyValues(ACTIVATE)
+                .withBean(MongoConfigurationContributor.class, () -> userContributor)
+                .withBean(EntityManagerFactory.class, () -> mock(EntityManagerFactory.class))
+                .run(context -> {
+                    assertThat(context).hasNotFailed();
+                    // No MongoClient to borrow — this is exactly the setup failsFastWhenActivatedWithoutMongoClient
+                    // proves would throw; the user contributor is what suppresses the guard.
+                    assertThat(context).doesNotHaveBean(MongoClient.class);
+                    // The user's contributor took over: it is the only MongoConfigurationContributor in play, so the
+                    // bridge (itself a MongoConfigurationContributor, named mongoClientConfigurationContributor)
+                    // registered no competing bean.
+                    assertThat(context).hasSingleBean(MongoConfigurationContributor.class);
+                    assertThat(context).getBean(MongoConfigurationContributor.class).isSameAs(userContributor);
+                    assertThat(context).doesNotHaveBean("mongoClientConfigurationContributor");
+                });
+    }
+
+    @Test
+    void bridgeContributorIsRegisteredWhenClientPresent() {
+        withMongoClient(contextRunner)
+                .withBean(EntityManagerFactory.class, () -> mock(EntityManagerFactory.class))
+                .run(context -> assertThat(context).hasBean("mongoClientConfigurationContributor"));
+    }
+
+    @Test
+    void doesNotRegisterBridgeWhenSpringBootMongodbAbsent() {
+        // When MongoConnectionDetails is filtered out, the no-client guard still sees the MongoClient bean from
+        // withMongoClient, so the context does not fail; the bridge simply is not registered.
+        withMongoClient(contextRunner)
+                .withClassLoader(new FilteredClassLoader(MongoConnectionDetails.class))
+                .withBean(EntityManagerFactory.class, () -> mock(EntityManagerFactory.class))
+                .run(context -> assertThat(context).doesNotHaveBean("mongoClientConfigurationContributor"));
+    }
+
+    @Test
+    void mongoEntityManagerFactoryWinsOverSqlWhenDataSourcePresent() {
+        // Verifies the dropped EnvironmentPostProcessor exclusion is correctly replaced by before-ordering:
+        // with a stray DataSource present, only the @Primary Mongo EntityManagerFactory exists and Spring's
+        // SQL JPA backs off.
+        new ApplicationContextRunner()
+                .withConfiguration(AutoConfigurations.of(
+                        org.springframework.boot.jdbc.autoconfigure.DataSourceAutoConfiguration.class,
+                        org.springframework.boot.hibernate.autoconfigure.HibernateJpaAutoConfiguration.class,
+                        MongoHibernateAutoConfiguration.class))
+                .withPropertyValues(ACTIVATE)
+                .withBean(MongoClient.class, () -> mock(MongoClient.class))
+                .withBean(MongoProperties.class, MongoProperties::new)
+                .withBean(MongoConnectionDetails.class, () -> (MongoConnectionDetails)
+                        () -> new ConnectionString("mongodb://localhost/test"))
+                .withBean(EntityManagerFactory.class, () -> mock(EntityManagerFactory.class))
+                .run(context -> assertThat(context).hasSingleBean(EntityManagerFactory.class));
+    }
+
+    @Test
+    void honorsDdlAutoAndDefaultsToHibernateCamelCaseNaming() {
+        withMongoClient(contextRunner)
+                .withPropertyValues("spring.jpa.hibernate.ddl-auto=update")
+                .withBean(EntityManagerFactory.class, () -> mock(EntityManagerFactory.class))
+                .run(context -> {
+                    var properties = assembledJpaProperties(context);
+                    assertThat(properties).containsEntry("hibernate.hbm2ddl.auto", "update");
+                    // The default physical naming strategy is Hibernate's identity mapping (camelCase),
+                    // NOT Spring Boot's snake_case default.
+                    assertThat(properties)
+                            .containsEntry(
+                                    PHYSICAL_NAMING_STRATEGY, PhysicalNamingStrategyStandardImpl.class.getName());
+                    // The default implicit naming strategy is Hibernate's JPA-compliant one (matching the
+                    // standalone extension), NOT Spring Boot's SpringImplicitNamingStrategy.
+                    assertThat(properties)
+                            .containsEntry(
+                                    IMPLICIT_NAMING_STRATEGY, ImplicitNamingStrategyJpaCompliantImpl.class.getName());
+                });
+    }
+
+    @Test
+    void honorsExplicitImplicitNamingStrategyOverride() {
+        // As with the physical strategy, an explicit spring.jpa.hibernate.naming.implicit-strategy must win
+        // over the seeded default (putIfAbsent does not clobber it).
+        withMongoClient(contextRunner)
+                .withPropertyValues("spring.jpa.hibernate.naming.implicit-strategy="
+                        + ImplicitNamingStrategyComponentPathImpl.class.getName())
+                .withBean(EntityManagerFactory.class, () -> mock(EntityManagerFactory.class))
+                .run(context -> assertThat(assembledJpaProperties(context))
+                        .containsEntry(
+                                IMPLICIT_NAMING_STRATEGY, ImplicitNamingStrategyComponentPathImpl.class.getName()));
+    }
+
+    @Test
+    void honorsExplicitPhysicalNamingStrategyOverride() {
+        // A user who explicitly asks for snake_case gets it — the default is changed by *presence* of
+        // the property, never by comparing its value, so even requesting Spring Boot's own default works.
+        withMongoClient(contextRunner)
+                .withPropertyValues("spring.jpa.hibernate.naming.physical-strategy="
+                        + PhysicalNamingStrategySnakeCaseImpl.class.getName())
+                .withBean(EntityManagerFactory.class, () -> mock(EntityManagerFactory.class))
+                .run(context -> assertThat(assembledJpaProperties(context))
+                        .containsEntry(PHYSICAL_NAMING_STRATEGY, PhysicalNamingStrategySnakeCaseImpl.class.getName()));
+    }
+
+    @Test
+    void appliesHibernatePropertiesCustomizerBeans() {
+        withMongoClient(contextRunner)
+                .withBean(EntityManagerFactory.class, () -> mock(EntityManagerFactory.class))
+                .withBean(
+                        HibernatePropertiesCustomizer.class,
+                        () -> (HibernatePropertiesCustomizer) properties -> properties.put("custom.key", "custom.value"))
+                .run(context -> assertThat(assembledJpaProperties(context))
+                        .containsEntry("custom.key", "custom.value"));
+    }
+
+    @Test
+    void registersOpenEntityManagerInViewInterceptorByDefaultInServletWebApp() {
+        withMongoClient(webContextRunner())
+                .withBean(EntityManagerFactory.class, () -> mock(EntityManagerFactory.class))
+                .run(context -> assertThat(context).hasSingleBean(OpenEntityManagerInViewInterceptor.class));
+    }
+
+    @Test
+    void omitsOpenEntityManagerInViewInterceptorWhenOpenInViewDisabled() {
+        withMongoClient(webContextRunner())
+                .withPropertyValues("spring.jpa.open-in-view=false")
+                .withBean(EntityManagerFactory.class, () -> mock(EntityManagerFactory.class))
+                .run(context -> assertThat(context).doesNotHaveBean(OpenEntityManagerInViewInterceptor.class));
+    }
+
+    private static WebApplicationContextRunner webContextRunner() {
+        return new WebApplicationContextRunner()
+                .withConfiguration(AutoConfigurations.of(MongoHibernateAutoConfiguration.class));
+    }
+
+    // Drives property assembly without bootstrapping Hibernate: a user EntityManagerFactory makes our
+    // entityManagerFactory bean back off (so nothing connects), but the EntityManagerFactoryBuilder bean
+    // is still created. EntityManagerFactoryBuilder.build() only *configures* the factory bean — it does
+    // not call afterPropertiesSet() — so getJpaPropertyMap() exposes the assembled properties with no
+    // database. The builder is the public seam; no production visibility is widened for the test.
+    @SuppressWarnings("NullAway") // MongoDB has no DataSource; null is the correct argument (see production code).
+    private static Map<String, Object> assembledJpaProperties(AssertableApplicationContext context) {
+        assertThat(context).doesNotHaveBean(LocalContainerEntityManagerFactoryBean.class);
+        var builder = context.getBean(EntityManagerFactoryBuilder.class);
+        return builder.dataSource(null)
+                .packages("com.mongodb.hibernate.autoconfigure")
+                .build()
+                .getJpaPropertyMap();
+    }
+}

--- a/mongodb-hibernate-spring-boot-autoconfigure/src/test/java/com/mongodb/hibernate/autoconfigure/MongoJpaRepositoriesAutoConfigurationTests.java
+++ b/mongodb-hibernate-spring-boot-autoconfigure/src/test/java/com/mongodb/hibernate/autoconfigure/MongoJpaRepositoriesAutoConfigurationTests.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2025-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.hibernate.autoconfigure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.FilteredClassLoader;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.config.JpaRepositoryConfigExtension;
+
+class MongoJpaRepositoriesAutoConfigurationTests {
+
+    // Register as an auto-configuration (not withUserConfiguration) so @ConditionalOnMissingBean
+    // orders after user-supplied beans — same requirement as MongoHibernateAutoConfigurationTests.
+    // Each test observes whether the auto-configuration fired by the presence of its own
+    // @Configuration bean, which works without any repository interfaces or an EntityManagerFactory
+    // (the positive path — repositories actually created — needs MongoDB and lives in the
+    // integration test).
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(MongoJpaRepositoriesAutoConfiguration.class));
+
+    @Test
+    void backsOffIfRepositoryConfigurationAlreadyDefined() {
+        // A user who declares their own @EnableJpaRepositories yields a JpaRepositoryConfigExtension
+        // (and JpaRepositoryFactoryBean); our auto-configuration must defer to them. The MongoDB platform
+        // makes OnMongoDatabasePlatformCondition match, so this isolates the @ConditionalOnMissingBean
+        // back-off.
+        contextRunner
+                .withPropertyValues("spring.jpa.database-platform=MongoDB")
+                .withBean(JpaRepositoryConfigExtension.class, () -> mock(JpaRepositoryConfigExtension.class))
+                .run(context -> assertThat(context).doesNotHaveBean(MongoJpaRepositoriesAutoConfiguration.class));
+    }
+
+    @Test
+    void doesNotActivateWhenSpringDataJpaAbsentFromClasspath() {
+        // FilteredClassLoader simulates Spring Data JPA being absent without changing the build.
+        contextRunner
+                .withPropertyValues("spring.jpa.database-platform=MongoDB")
+                .withClassLoader(new FilteredClassLoader(JpaRepository.class))
+                .run(context -> assertThat(context).doesNotHaveBean(MongoJpaRepositoriesAutoConfiguration.class));
+    }
+
+    @Test
+    void doesNotActivateForNonMongoPlatform() {
+        // A SQL application with this module on its classpath must be left alone.
+        contextRunner
+                .withPropertyValues("spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect")
+                .run(context -> assertThat(context).doesNotHaveBean(MongoJpaRepositoriesAutoConfiguration.class));
+    }
+}

--- a/mongodb-hibernate-spring-boot-starter/build.gradle.kts
+++ b/mongodb-hibernate-spring-boot-starter/build.gradle.kts
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2025-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins {
+    id("java-library")
+    id("mongo-hibernate-publish")
+}
+
+repositories { mavenCentral() }
+
+// No source code — just dependency aggregation following the Spring Boot starter convention:
+// https://docs.spring.io/spring-boot/reference/features/developing-auto-configuration.html#features.developing-auto-configuration.custom-starter
+
+dependencies {
+    api(project(":"))
+    api(project(":mongodb-hibernate-spring-boot-autoconfigure"))
+    api(platform(libs.spring.boot.bom))
+    // Spring Data JPA + Hibernate ORM + spring-orm, but deliberately NOT spring-boot-starter-data-jpa: that
+    // starter also drags in spring-boot-starter-jdbc -> HikariCP, a SQL connection pool a MongoDB-backed app
+    // does not want. With a pooled DataSource on the classpath but no spring.datasource.url, Spring Boot's
+    // DataSourceAutoConfiguration fails fast at startup ("'url' attribute is not specified"). Depending on the
+    // granular spring-boot-data-jpa module (which still brings spring-boot-jdbc's auto-config classes, inert
+    // without a pool) gives the full JPA stack without that pool. A user who genuinely wants SQL alongside
+    // MongoDB adds HikariCP + a url themselves, and Spring behaves normally.
+    //
+    // No dependency on the base spring-boot-starter: a feature starter should not impose a logging backend or
+    // other application foundation — the application's primary starter (spring-boot-starter-web, or plain
+    // spring-boot-starter) provides that. spring-boot-data-jpa already brings the auto-configure engine.
+    api("org.springframework.boot:spring-boot-data-jpa")
+    api("org.springframework.boot:spring-boot-mongodb") // the MongoClient infrastructure the integration borrows
+}
+
+publishing {
+    publications {
+        create<MavenPublication>("maven") {
+            groupId = "org.mongodb"
+            artifactId = "mongodb-hibernate-spring-boot-starter"
+            from(components["java"])
+            pom {
+                name = "MongoDB Extension for Hibernate ORM — Spring Boot Starter"
+                description = "Spring Boot starter for the MongoDB Extension for Hibernate ORM"
+                // url, licenses, developers, scm injected by mongo-hibernate-publish plugin
+            }
+        }
+    }
+}
+
+// Regression guard for the deliberate omission of a SQL connection pool (see the dependencies block). If a
+// pool implementation (HikariCP, etc.) or spring-boot-starter-jdbc ever reappears on the runtime classpath,
+// a MongoDB-backed application would fail to start: Spring Boot's DataSourceAutoConfiguration would try to
+// build a SQL DataSource and fail with "'url' attribute is not specified". Fail the build here instead.
+val verifyNoSqlConnectionPool by
+        tasks.registering {
+            val componentIds =
+                    configurations.named("runtimeClasspath").map { configuration ->
+                        configuration.incoming.resolutionResult.allComponents.map { it.id.displayName }
+                    }
+            doLast {
+                val poolMarkers =
+                        listOf("HikariCP", "tomcat-jdbc", "commons-dbcp", "c3p0", "vibur", "oracle-ucp", "spring-boot-starter-jdbc")
+                val offenders =
+                        componentIds.get().filter { id -> poolMarkers.any { id.contains(it, ignoreCase = true) } }
+                require(offenders.isEmpty()) {
+                    "mongodb-hibernate-spring-boot-starter must not bring a SQL connection pool on its runtime " +
+                            "classpath (Spring Boot's DataSourceAutoConfiguration would fail fast at startup): $offenders"
+                }
+            }
+        }
+
+tasks.named("check") { dependsOn(verifyNoSqlConnectionPool) }

--- a/mongodb-hibernate-spring-boot-starter/build.gradle.kts
+++ b/mongodb-hibernate-spring-boot-starter/build.gradle.kts
@@ -21,7 +21,7 @@ plugins {
 
 repositories { mavenCentral() }
 
-// No source code — just dependency aggregation following the Spring Boot starter convention:
+// No source code, just dependency aggregation following the Spring Boot starter convention:
 // https://docs.spring.io/spring-boot/reference/features/developing-auto-configuration.html#features.developing-auto-configuration.custom-starter
 
 dependencies {
@@ -37,7 +37,7 @@ dependencies {
     // MongoDB adds HikariCP + a url themselves, and Spring behaves normally.
     //
     // No dependency on the base spring-boot-starter: a feature starter should not impose a logging backend or
-    // other application foundation — the application's primary starter (spring-boot-starter-web, or plain
+    // other application foundation. The application's primary starter (spring-boot-starter-web, or plain
     // spring-boot-starter) provides that. spring-boot-data-jpa already brings the auto-configure engine.
     api("org.springframework.boot:spring-boot-data-jpa")
     api("org.springframework.boot:spring-boot-mongodb") // the MongoClient infrastructure the integration borrows
@@ -50,7 +50,7 @@ publishing {
             artifactId = "mongodb-hibernate-spring-boot-starter"
             from(components["java"])
             pom {
-                name = "MongoDB Extension for Hibernate ORM — Spring Boot Starter"
+                name = "Spring Boot Starter of MongoDB Extension for Hibernate ORM"
                 description = "Spring Boot starter for the MongoDB Extension for Hibernate ORM"
                 // url, licenses, developers, scm injected by mongo-hibernate-publish plugin
             }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -17,3 +17,5 @@
 rootProject.name = "mongo-hibernate"
 
 include("mongodb-hibernate-spring-boot-autoconfigure")
+
+include("mongodb-hibernate-spring-boot-starter")

--- a/src/main/java/com/mongodb/hibernate/cfg/MongoConfigurator.java
+++ b/src/main/java/com/mongodb/hibernate/cfg/MongoConfigurator.java
@@ -18,6 +18,7 @@ package com.mongodb.hibernate.cfg;
 
 import com.mongodb.ConnectionString;
 import com.mongodb.MongoClientSettings;
+import com.mongodb.client.MongoClient;
 import com.mongodb.hibernate.cfg.spi.MongoConfigurationContributor;
 import com.mongodb.hibernate.internal.cfg.MongoConfigurationBuilder;
 import java.util.Map;
@@ -74,6 +75,17 @@ import org.hibernate.service.spi.Configurable;
  *             if {@linkplain ConnectionString#getDatabase() configured};
  *             otherwise a value must be configured via {@link MongoConfigurator#databaseName(String)}.</td>
  *         </tr>
+ *         <tr>
+ *             <td>{@link #mongoClient(MongoClient)}</td>
+ *             <td>✓</td>
+ *             <td>&mdash;</td>
+ *             <td>&mdash;</td>
+ *             <td>No externally managed client; the extension creates one from the configured
+ *             {@link MongoClientSettings}. When a client is supplied, it is used as-is and not closed, and
+ *             {@link #applyToMongoClientSettings(Consumer)} and the {@value AvailableSettings#JAKARTA_JDBC_URL}
+ *             connection string are not used to build a connection (the database name must still be configured via
+ *             {@link #databaseName(String)} or come from {@value AvailableSettings#JAKARTA_JDBC_URL}).</td>
+ *         </tr>
  *     </tbody>
  * </table>
  *
@@ -88,6 +100,8 @@ public sealed interface MongoConfigurator permits MongoConfigurationBuilder {
      * must configure the database name via {@link MongoConfigurator#databaseName(String)}, as there is no way for that
      * to happen automatically.
      *
+     * <p>These settings are not used if an externally managed client is supplied via {@link #mongoClient(MongoClient)}.
+     *
      * @param configurator The {@link Consumer} of the {@link MongoClientSettings.Builder}.
      * @return {@code this}.
      */
@@ -100,4 +114,15 @@ public sealed interface MongoConfigurator permits MongoConfigurationBuilder {
      * @return {@code this}.
      */
     MongoConfigurator databaseName(String databaseName);
+
+    /**
+     * Supplies an externally managed {@link MongoClient} to use instead of creating one from the configured
+     * {@link MongoClientSettings}. When supplied, the client's lifecycle is owned by the caller: the extension uses it
+     * as-is and does not close it, and {@link #applyToMongoClientSettings(Consumer)} and the
+     * {@value AvailableSettings#JAKARTA_JDBC_URL} connection string are not used to build a connection.
+     *
+     * @param mongoClient the externally managed client to use.
+     * @return {@code this}.
+     */
+    MongoConfigurator mongoClient(MongoClient mongoClient);
 }

--- a/src/main/java/com/mongodb/hibernate/internal/MongoConstants.java
+++ b/src/main/java/com/mongodb/hibernate/internal/MongoConstants.java
@@ -33,4 +33,12 @@ public final class MongoConstants {
     public static final String ID_FIELD_NAME = "_id";
 
     public static final String MONGO_DIALECT_SHORT_NAME = "MongoDB";
+
+    /**
+     * JPA property key used to pass a {@code MongoConfigurationContributor} object via the JPA properties map. Read by
+     * {@code StandardServiceRegistryScopedState}, written by {@code MongoHibernateAutoConfiguration} in the Spring Boot
+     * autoconfigure module (which duplicates this string as a private constant since it cannot access this internal
+     * class).
+     */
+    public static final String MONGO_CONFIGURATION_CONTRIBUTOR_KEY = "com.mongodb.hibernate.configurationContributor";
 }

--- a/src/main/java/com/mongodb/hibernate/internal/cfg/MongoConfiguration.java
+++ b/src/main/java/com/mongodb/hibernate/internal/cfg/MongoConfiguration.java
@@ -17,15 +17,36 @@
 package com.mongodb.hibernate.internal.cfg;
 
 import com.mongodb.MongoClientSettings;
+import com.mongodb.client.MongoClient;
 import com.mongodb.hibernate.cfg.MongoConfigurator;
-import java.util.function.Consumer;
+import org.jspecify.annotations.Nullable;
 
 /**
  * The configuration of the MongoDB Extension for Hibernate ORM.
  *
- * @param mongoClientSettings {@link MongoConfigurator#applyToMongoClientSettings(Consumer)}.
+ * @param mongoClientSettings settings to create a client from, or {@code null} when {@code mongoClient} is supplied.
+ * @param mongoClient an externally supplied {@link MongoClient} to use as-is (the provider does not own or close it),
+ *     or {@code null} when {@code mongoClientSettings} is supplied.
  * @param databaseName {@link MongoConfigurator#databaseName(String)}.
  * @see MongoConfigurationBuilder#build()
  * @hidden
  */
-public record MongoConfiguration(MongoClientSettings mongoClientSettings, String databaseName) {}
+public record MongoConfiguration(
+        @Nullable MongoClientSettings mongoClientSettings,
+        @Nullable MongoClient mongoClient,
+        String databaseName) {
+
+    public MongoConfiguration {
+        if ((mongoClientSettings == null) == (mongoClient == null)) {
+            throw new IllegalArgumentException("Exactly one of mongoClientSettings and mongoClient must be non-null");
+        }
+    }
+
+    public MongoConfiguration(MongoClientSettings mongoClientSettings, String databaseName) {
+        this(mongoClientSettings, null, databaseName);
+    }
+
+    public MongoConfiguration(MongoClient mongoClient, String databaseName) {
+        this(null, mongoClient, databaseName);
+    }
+}

--- a/src/main/java/com/mongodb/hibernate/internal/cfg/MongoConfigurationBuilder.java
+++ b/src/main/java/com/mongodb/hibernate/internal/cfg/MongoConfigurationBuilder.java
@@ -23,6 +23,7 @@ import static org.hibernate.cfg.AvailableSettings.JAKARTA_JDBC_URL;
 
 import com.mongodb.ConnectionString;
 import com.mongodb.MongoClientSettings;
+import com.mongodb.client.MongoClient;
 import com.mongodb.hibernate.cfg.MongoConfigurator;
 import com.mongodb.hibernate.internal.VisibleForTesting;
 import java.lang.reflect.Type;
@@ -38,6 +39,7 @@ import org.jspecify.annotations.Nullable;
 public final class MongoConfigurationBuilder implements MongoConfigurator {
     private final MongoClientSettings.Builder mongoClientSettingsBuilder;
     private @Nullable String databaseName;
+    private @Nullable MongoClient mongoClient;
 
     public MongoConfigurationBuilder(Map<String, Object> configurationValues) {
         mongoClientSettingsBuilder = MongoClientSettings.builder();
@@ -66,8 +68,17 @@ public final class MongoConfigurationBuilder implements MongoConfigurator {
         return this;
     }
 
+    @Override
+    public MongoConfigurationBuilder mongoClient(MongoClient mongoClient) {
+        this.mongoClient = notNull("mongoClient", mongoClient);
+        return this;
+    }
+
     public MongoConfiguration build() {
-        return new MongoConfiguration(mongoClientSettingsBuilder.build(), notNull("databaseName", databaseName));
+        var db = notNull("databaseName", databaseName);
+        return mongoClient != null
+                ? new MongoConfiguration(mongoClient, db)
+                : new MongoConfiguration(mongoClientSettingsBuilder.build(), db);
     }
 
     private static final class ConfigPropertiesParser {

--- a/src/main/java/com/mongodb/hibernate/internal/jdbc/MongoConnectionProvider.java
+++ b/src/main/java/com/mongodb/hibernate/internal/jdbc/MongoConnectionProvider.java
@@ -56,6 +56,7 @@ public final class MongoConnectionProvider implements ConnectionProvider, Stoppa
 
     private @Nullable StandardServiceRegistryScopedState standardServiceRegistryScopedState;
     private transient @Nullable MongoClient mongoClient;
+    private transient boolean ownsMongoClient;
 
     public MongoConnectionProvider() {}
 
@@ -103,7 +104,7 @@ public final class MongoConnectionProvider implements ConnectionProvider, Stoppa
 
     @Override
     public void stop() {
-        if (mongoClient != null) {
+        if (ownsMongoClient && mongoClient != null) {
             mongoClient.close();
         }
     }
@@ -112,13 +113,25 @@ public final class MongoConnectionProvider implements ConnectionProvider, Stoppa
     public void injectStandardServiceRegistryScopedState(
             StandardServiceRegistryScopedState standardServiceRegistryScopedState) {
         this.standardServiceRegistryScopedState = standardServiceRegistryScopedState;
-        var mongoClientSettings =
-                standardServiceRegistryScopedState.getConfiguration().mongoClientSettings();
+        var configuration = standardServiceRegistryScopedState.getConfiguration();
         var driverInfo = MongoDriverInformation.builder()
                 .driverName(assertNotNull(BuildConfig.NAME))
                 .driverVersion(assertNotNull(BuildConfig.VERSION))
                 .build();
-        mongoClient = MongoClients.create(mongoClientSettings, driverInfo);
+        var suppliedClient = configuration.mongoClient();
+        if (suppliedClient != null) {
+            // We borrowed this client rather than creating it; append our driver metadata so telemetry still
+            // attributes connections to mongo-hibernate.
+            suppliedClient.appendMetadata(driverInfo);
+            this.mongoClient = suppliedClient;
+            this.ownsMongoClient = false;
+        } else {
+            // XOR invariant: when mongoClient() is null, mongoClientSettings() is non-null. NullAway cannot
+            // see the invariant, so assert it.
+            var mongoClientSettings = assertNotNull(configuration.mongoClientSettings());
+            this.mongoClient = MongoClients.create(mongoClientSettings, driverInfo);
+            this.ownsMongoClient = true;
+        }
     }
 
     @Serial
@@ -142,8 +155,9 @@ public final class MongoConnectionProvider implements ConnectionProvider, Stoppa
         }
 
         @Override
-        public String getJdbcUrl() {
-            return configuration.mongoClientSettings().toString();
+        public @Nullable String getJdbcUrl() {
+            var settings = configuration.mongoClientSettings();
+            return settings != null ? settings.toString() : null;
         }
 
         @Override
@@ -167,19 +181,15 @@ public final class MongoConnectionProvider implements ConnectionProvider, Stoppa
         }
 
         @Override
-        public Integer getPoolMinSize() {
-            return configuration
-                    .mongoClientSettings()
-                    .getConnectionPoolSettings()
-                    .getMinSize();
+        public @Nullable Integer getPoolMinSize() {
+            var settings = configuration.mongoClientSettings();
+            return settings != null ? settings.getConnectionPoolSettings().getMinSize() : null;
         }
 
         @Override
-        public Integer getPoolMaxSize() {
-            return configuration
-                    .mongoClientSettings()
-                    .getConnectionPoolSettings()
-                    .getMaxSize();
+        public @Nullable Integer getPoolMaxSize() {
+            var settings = configuration.mongoClientSettings();
+            return settings != null ? settings.getConnectionPoolSettings().getMaxSize() : null;
         }
 
         @Override

--- a/src/main/java/com/mongodb/hibernate/internal/service/StandardServiceRegistryScopedState.java
+++ b/src/main/java/com/mongodb/hibernate/internal/service/StandardServiceRegistryScopedState.java
@@ -16,6 +16,7 @@
 
 package com.mongodb.hibernate.internal.service;
 
+import static com.mongodb.hibernate.internal.MongoConstants.MONGO_CONFIGURATION_CONTRIBUTOR_KEY;
 import static com.mongodb.hibernate.internal.MongoConstants.MONGO_DIALECT_SHORT_NAME;
 import static com.mongodb.hibernate.internal.VisibleForTesting.AccessModifier.PRIVATE;
 import static java.lang.String.format;
@@ -168,7 +169,7 @@ public final class StandardServiceRegistryScopedState implements Service {
         private static MongoConfiguration createMongoConfiguration(
                 Map<String, Object> configurationValues, ServiceRegistryImplementor serviceRegistry) {
             var jdbcUrl = configurationValues.get(JAKARTA_JDBC_URL);
-            var mongoConfigurationContributor = getMongoConfigurationContributor(serviceRegistry);
+            var mongoConfigurationContributor = getMongoConfigurationContributor(configurationValues, serviceRegistry);
             if (jdbcUrl == null && mongoConfigurationContributor == null) {
                 throw new HibernateException(format(
                         "Configuration property [%s] is required unless %s is provided",
@@ -183,7 +184,13 @@ public final class StandardServiceRegistryScopedState implements Service {
         }
 
         private static @Nullable MongoConfigurationContributor getMongoConfigurationContributor(
-                ServiceRegistryImplementor serviceRegistry) {
+                Map<String, Object> configurationValues, ServiceRegistryImplementor serviceRegistry) {
+            // The JPA properties map is checked first — before the service registry —
+            // so Spring Boot auto-configuration can bridge a contributor without touching Hibernate internals.
+            if (configurationValues.get(MONGO_CONFIGURATION_CONTRIBUTOR_KEY)
+                    instanceof MongoConfigurationContributor contributor) {
+                return contributor;
+            }
             MongoConfigurationContributor result = null;
             try {
                 result = serviceRegistry.getService(MongoConfigurationContributor.class);

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -114,7 +114,7 @@ module com.mongodb.hibernate {
     requires transitive org.hibernate.orm.core;
     requires org.mongodb.bson;
     requires transitive org.mongodb.driver.core;
-    requires org.mongodb.driver.sync.client;
+    requires transitive org.mongodb.driver.sync.client;
     requires org.jspecify;
 
     provides ServiceContributor with

--- a/src/test/java/com/mongodb/hibernate/internal/cfg/MongoConfigurationBuilderTests.java
+++ b/src/test/java/com/mongodb/hibernate/internal/cfg/MongoConfigurationBuilderTests.java
@@ -16,13 +16,16 @@
 
 package com.mongodb.hibernate.internal.cfg;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hibernate.cfg.AvailableSettings.JAKARTA_JDBC_URL;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
 
 import com.mongodb.ConnectionString;
 import com.mongodb.MongoClientSettings;
+import com.mongodb.client.MongoClient;
 import java.util.Map;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -65,6 +68,17 @@ class MongoConfigurationBuilderTests {
                 "testReplicaSetName",
                 config.mongoClientSettings().getClusterSettings().getRequiredReplicaSetName());
         assertEquals("testDbName2", config.databaseName());
+    }
+
+    @Test
+    void suppliedMongoClientIsCarriedIntoConfiguration() {
+        var client = mock(MongoClient.class);
+        var config = new MongoConfigurationBuilder()
+                .databaseName("db")
+                .mongoClient(client)
+                .build();
+        assertThat(config.mongoClient()).isSameAs(client);
+        assertThat(config.mongoClientSettings()).isNull();
     }
 
     @Nested

--- a/src/test/java/com/mongodb/hibernate/internal/cfg/MongoConfigurationTests.java
+++ b/src/test/java/com/mongodb/hibernate/internal/cfg/MongoConfigurationTests.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2024-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.hibernate.internal.cfg;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+
+import com.mongodb.MongoClientSettings;
+import com.mongodb.client.MongoClient;
+import org.junit.jupiter.api.Test;
+
+class MongoConfigurationTests {
+
+    @Test
+    void rejectsBothSettingsAndClient() {
+        var settings = MongoClientSettings.builder().build();
+        var client = mock(MongoClient.class);
+        assertThatThrownBy(() -> new MongoConfiguration(settings, client, "db"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Exactly one");
+    }
+
+    @Test
+    void rejectsNeitherSettingsNorClient() {
+        assertThatThrownBy(() -> new MongoConfiguration(null, null, "db"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Exactly one");
+    }
+}

--- a/src/test/java/com/mongodb/hibernate/internal/jdbc/MongoConnectionProviderTests.java
+++ b/src/test/java/com/mongodb/hibernate/internal/jdbc/MongoConnectionProviderTests.java
@@ -16,11 +16,17 @@
 
 package com.mongodb.hibernate.internal.jdbc;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 import com.mongodb.ConnectionString;
 import com.mongodb.MongoClientSettings;
+import com.mongodb.client.MongoClient;
 import com.mongodb.client.internal.MongoClientImpl;
 import com.mongodb.hibernate.internal.BuildConfig;
 import com.mongodb.hibernate.internal.cfg.MongoConfiguration;
@@ -57,6 +63,47 @@ class MongoConnectionProviderTests {
         assertAll(
                 () -> assertTrue(driverInformation.getDriverNames().contains(BuildConfig.NAME)),
                 () -> assertTrue(driverInformation.getDriverVersions().contains(BuildConfig.VERSION)));
+    }
+
+    @Test
+    void usesSuppliedClientAndDoesNotCloseItOnStop() {
+        var suppliedClient = mock(MongoClient.class);
+        var config = new MongoConfiguration(suppliedClient, "db"); // borrow variant: settings is null
+        var provider = new MongoConnectionProvider();
+        provider.injectStandardServiceRegistryScopedState(new StandardServiceRegistryScopedState(config));
+
+        assertThat(provider.getMongoClient()).isSameAs(suppliedClient);
+
+        provider.stop();
+        verify(suppliedClient, never()).close();
+    }
+
+    @Test
+    void appendsDriverMetadataToBorrowedClient() {
+        // Borrowing must not lose the extension's MongoDB telemetry attribution: the provider appends
+        // mongo-hibernate's driver name/version to the borrowed client's handshake metadata.
+        var suppliedClient = mock(MongoClient.class);
+        var config = new MongoConfiguration(suppliedClient, "db");
+        var provider = new MongoConnectionProvider();
+        provider.injectStandardServiceRegistryScopedState(new StandardServiceRegistryScopedState(config));
+
+        verify(suppliedClient)
+                .appendMetadata(argThat(info -> info.getDriverNames().contains(BuildConfig.NAME)
+                        && info.getDriverVersions().contains(BuildConfig.VERSION)));
+    }
+
+    @Test
+    void closesSelfCreatedClientOnStop() {
+        var config = new MongoConfiguration(
+                MongoClientSettings.builder()
+                        .applyConnectionString(new ConnectionString("mongodb://host"))
+                        .build(),
+                "db"); // no supplied client -> provider creates and owns one
+        var provider = new MongoConnectionProvider();
+        provider.injectStandardServiceRegistryScopedState(new StandardServiceRegistryScopedState(config));
+        assertThat(provider.getMongoClient()).isNotNull();
+
+        provider.stop(); // owned path goes through close(); a real client tolerates close()
     }
 
     private MongoConnectionProvider createMongoConnectionProvider() {

--- a/src/test/java/com/mongodb/hibernate/internal/service/StandardServiceRegistryScopedStateTests.java
+++ b/src/test/java/com/mongodb/hibernate/internal/service/StandardServiceRegistryScopedStateTests.java
@@ -16,6 +16,7 @@
 
 package com.mongodb.hibernate.internal.service;
 
+import static com.mongodb.hibernate.internal.MongoConstants.MONGO_CONFIGURATION_CONTRIBUTOR_KEY;
 import static com.mongodb.hibernate.internal.MongoConstants.MONGO_DIALECT_SHORT_NAME;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -24,7 +25,9 @@ import static org.hibernate.cfg.AvailableSettings.DIALECT;
 import static org.hibernate.cfg.AvailableSettings.JAKARTA_JDBC_URL;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 
+import com.mongodb.hibernate.cfg.spi.MongoConfigurationContributor;
 import com.mongodb.hibernate.internal.jdbc.MongoConnectionProvider;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.hibernate.boot.registry.BootstrapServiceRegistryBuilder;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.junit.jupiter.api.Test;
@@ -95,6 +98,25 @@ class StandardServiceRegistryScopedStateTests {
             assertThatThrownBy(() -> standardServiceRegistry.requireService(StandardServiceRegistryScopedState.class))
                     .hasRootCauseMessage("[hibernate.dialect] must be set to [MongoDB]");
         }
+    }
+
+    @Test
+    void contributorFromConfigurationValuesIsInvoked() {
+        var called = new AtomicBoolean(false);
+        MongoConfigurationContributor contributor = cfg -> called.set(true);
+
+        var builder = new StandardServiceRegistryBuilder()
+                .clearSettings()
+                .applySetting(JAKARTA_JDBC_URL, "mongodb://localhost/db")
+                .applySetting(DIALECT, MONGO_DIALECT_SHORT_NAME);
+        new StandardServiceRegistryScopedState.ServiceContributor().contribute(builder);
+        // Simulate what MongoHibernateAutoConfiguration does: put the contributor in settings
+        builder.applySetting(MONGO_CONFIGURATION_CONTRIBUTOR_KEY, contributor);
+
+        try (var registry = builder.build()) {
+            registry.requireService(StandardServiceRegistryScopedState.class);
+        }
+        assertThat(called).isTrue();
     }
 
     @Test


### PR DESCRIPTION
## Summary

Adds Spring Boot support for MongoDB-backed JPA via this extension: a starter, an
auto-configuration module, and a small core-module change letting Hibernate borrow
a Spring-managed `MongoClient` instead of creating its own.

In a Spring Boot app, setting `spring.jpa.database-platform=MongoDB` (plus
`spring-boot-mongodb` config) creates a JPA `EntityManagerFactory`,
`JpaTransactionManager`, and Spring Data JPA repository with no `DataSource`.

Design spec: `docs/superpowers/specs/2026-06-07-hibernate-172-design.md`

Spring app that uses this starter module: https://github.com/jyemin/spring-data-with-mongo-hibernate-test-app/tree/with-auto-configuration

