### PR TITLE
HIBERNATE-76 Add support for HQL's `like`

### DIFF
--- a/src/integrationTest/java/com/mongodb/hibernate/query/select/RegularExpressionIntegrationTests.java
+++ b/src/integrationTest/java/com/mongodb/hibernate/query/select/RegularExpressionIntegrationTests.java
@@ -1,0 +1,246 @@
+/*
+ * Copyright 2026-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.hibernate.query.select;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.mongodb.hibernate.internal.FeatureNotSupportedException;
+import com.mongodb.hibernate.query.AbstractQueryIntegrationTests;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Stream;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+@DomainModel(annotatedClasses = {RegularExpressionIntegrationTests.ItemWithString.class})
+class RegularExpressionIntegrationTests extends AbstractQueryIntegrationTests {
+
+    private static final ItemWithString ITEM1 = new ItemWithString(1, "ab .");
+    private static final ItemWithString ITEM2 = new ItemWithString(2, "AB .");
+    private static final ItemWithString ITEM3 = new ItemWithString(3, "zz%");
+
+    @BeforeEach
+    void beforeEach() {
+        getSessionFactoryScope()
+                .inTransaction(session -> Stream.of(ITEM1, ITEM2, ITEM3).forEach(session::persist));
+        getTestCommandListener().clear();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", "i"})
+    void testLikeMatchesNegated(String options) {
+        runBasicNegatedTest(
+                "from Item where str not %slike '%%ab%% .'".formatted(options),
+                "/^.*ab.* \\.$/" + options,
+                options.equals("i") ? List.of(ITEM3) : List.of(ITEM2, ITEM3));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", "i"})
+    void testLikeMatches(String options) {
+        runBasicTest(
+                "from Item where str %slike '%%ab%% .'".formatted(options),
+                "/^.*ab.* \\.$/" + options,
+                options.equals("i") ? List.of(ITEM1, ITEM2) : List.of(ITEM1));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", "i"})
+    void testLikeMatchSingle(String options) {
+        runBasicTest(
+                "from Item where str %slike 'a_ .'".formatted(options),
+                "/^a. \\.$/" + options,
+                options.equals("i") ? List.of(ITEM1, ITEM2) : List.of(ITEM1));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", "i"})
+    void testLikeMatchSingleNegated(String options) {
+        runBasicNegatedTest(
+                "from Item where str not %slike 'a_ .'".formatted(options),
+                "/^a. \\.$/" + options,
+                options.equals("i") ? List.of(ITEM3) : List.of(ITEM2, ITEM3));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", "i"})
+    void testLikeMatchesWithEscape(String options) {
+        runBasicTest(
+                "from Item where str %slike 'z%%!%%' escape '!'".formatted(options),
+                "/^z.*%$/" + options,
+                List.of(ITEM3));
+    }
+
+    private void runBasicTest(String query, String regex, List<ItemWithString> results) {
+        assertSelectionQuery(
+                query,
+                ItemWithString.class,
+                """
+                {
+                  "aggregate": "items",
+                  "pipeline": [
+                    {
+                      "$match": {
+                        "str": {
+                          "$regex": %ss
+                        }
+                      }
+                    },
+                    {
+                      "$project": {
+                        "_id": true,
+                        "str": true
+                      }
+                    }
+                  ]
+                }"""
+                        .formatted(regex),
+                results,
+                Set.of(ItemWithString.COLLECTION_NAME));
+    }
+
+    private void runBasicNegatedTest(String query, String regex, List<ItemWithString> results) {
+        assertSelectionQuery(
+                query,
+                ItemWithString.class,
+                """
+                {
+                  "aggregate": "items",
+                  "pipeline": [
+                    {
+                      "$match": {
+                        "$nor": [
+                          { "str": { "$regex": %ss } }
+                        ]
+                      }
+                    },
+                    {
+                      "$project": {
+                        "_id": true,
+                        "str": true
+                      }
+                    }
+                  ]
+                }"""
+                        .formatted(regex),
+                results,
+                Set.of(ItemWithString.COLLECTION_NAME));
+    }
+
+    @Test
+    void testLikeDoesNotTreatPlusAsRegexQuantifier() {
+        var exactMatch = new ItemWithString(4, "a+b");
+        var shouldNotMatch = new ItemWithString(5, "ab");
+        getSessionFactoryScope().inTransaction(session -> {
+            session.persist(exactMatch);
+            session.persist(shouldNotMatch);
+        });
+
+        var results = getSessionFactoryScope().fromTransaction(session -> session.createSelectionQuery(
+                        "from Item where str like 'a+b'", ItemWithString.class)
+                .getResultList());
+
+        // '+' in a LIKE pattern is a literal character, not a regex quantifier: only the item whose
+        // value is exactly "a+b" should match "a+b", not "ab".
+        assertThat(results).containsExactly(exactMatch);
+    }
+
+    @Test
+    void testLikeDoesNotMatchAcrossEmbeddedNewlines() {
+        var itemWithEmbeddedNewline = new ItemWithString(4, "abc\ndef");
+        getSessionFactoryScope().inTransaction(session -> session.persist(itemWithEmbeddedNewline));
+
+        var results = getSessionFactoryScope().fromTransaction(session -> session.createSelectionQuery(
+                        "from Item where str like 'def%'", ItemWithString.class)
+                .getResultList());
+
+        // The whole value "abc\ndef" does not start with "def", so LIKE 'def%' must not match it, even
+        // though the value's second line does.
+        assertThat(results).isEmpty();
+    }
+
+    @Test
+    void testNonLiteralPattern() {
+        assertSelectQueryFailure(
+                "from Item where 'value' like str",
+                ItemWithString.class,
+                FeatureNotSupportedException.class,
+                "Expression must be a literal String in pattern in LIKE, but other expression was found.");
+        // We cannot test using an expression since the HQL parser rejects something like "from Item where str like
+        // 'abcd' escape str"
+    }
+
+    @Test
+    void testTrailingEscapingPattern() {
+        assertSelectQueryFailure(
+                "from Item where str like 'foo!' escape '!'",
+                ItemWithString.class,
+                IllegalArgumentException.class,
+                "Escape character ! found at end of LIKE pattern: foo!");
+    }
+
+    @Test
+    void testBadEscapingPattern() {
+        assertSelectQueryFailure(
+                "from Item where str like 'foo!$' escape '!'",
+                ItemWithString.class,
+                IllegalArgumentException.class,
+                "Character $ is escaped by !, but only %%, _, and ! should be escaped");
+    }
+
+    @Entity(name = "Item")
+    @Table(name = ItemWithString.COLLECTION_NAME)
+    static final class ItemWithString {
+        public static final String COLLECTION_NAME = "items";
+
+        @Id
+        int id;
+
+        String str;
+
+        public ItemWithString() {}
+
+        public ItemWithString(int id, String str) {
+            this.id = id;
+            this.str = str;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (o == null || getClass() != o.getClass()) return false;
+            ItemWithString that = (ItemWithString) o;
+            return id == that.id && Objects.equals(str, that.str);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(id, str);
+        }
+
+        @Override
+        public String toString() {
+            return "ItemWithString{" + "id=" + id + ", str='" + str + '\'' + '}';
+        }
+    }
+}

--- a/src/main/java/com/mongodb/hibernate/internal/translate/AbstractMqlTranslator.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/AbstractMqlTranslator.java
@@ -49,6 +49,7 @@ import static com.mongodb.hibernate.internal.translate.mongoast.filter.AstListCo
 import static com.mongodb.hibernate.internal.translate.mongoast.filter.AstLogicalFilterOperator.AND;
 import static com.mongodb.hibernate.internal.translate.mongoast.filter.AstLogicalFilterOperator.NOR;
 import static com.mongodb.hibernate.internal.translate.mongoast.filter.AstLogicalFilterOperator.OR;
+import static com.mongodb.hibernate.internal.translate.mongoast.filter.AstRegularExpressionFilterOperation.quoteMeta;
 import static java.lang.String.format;
 import static org.hibernate.query.common.FetchClauseType.ROWS_ONLY;
 
@@ -86,6 +87,7 @@ import com.mongodb.hibernate.internal.translate.mongoast.filter.AstFieldOperatio
 import com.mongodb.hibernate.internal.translate.mongoast.filter.AstFilter;
 import com.mongodb.hibernate.internal.translate.mongoast.filter.AstListComparisonFilterOperation;
 import com.mongodb.hibernate.internal.translate.mongoast.filter.AstLogicalFilter;
+import com.mongodb.hibernate.internal.translate.mongoast.filter.AstRegularExpressionFilterOperation;
 import com.mongodb.hibernate.internal.type.ValueConversions;
 import jakarta.persistence.criteria.Nulls;
 import java.io.IOException;
@@ -1148,7 +1150,19 @@ public abstract class AbstractMqlTranslator<T extends JdbcOperation> implements 
 
     @Override
     public void visitLikePredicate(LikePredicate likePredicate) {
-        throw new FeatureNotSupportedException();
+        Character escape = null;
+        if (likePredicate.getEscapeCharacter() != null) {
+            escape = extractLiteral(likePredicate.getEscapeCharacter(), Character.class, "escape character in LIKE");
+        }
+        var pattern = extractLiteral(likePredicate.getPattern(), String.class, "pattern in LIKE");
+
+        var fieldPath = acceptAndYield(likePredicate.getMatchExpression(), FIELD_PATH);
+        final var filter = new AstFieldOperationFilter(
+                fieldPath,
+                new AstRegularExpressionFilterOperation(
+                        quoteMeta(pattern, escape), likePredicate.isCaseSensitive() ? "s" : "is"));
+        astVisitorValueHolder.yield(
+                FILTER, likePredicate.isNegated() ? new AstLogicalFilter(NOR, List.of(filter)) : filter);
     }
 
     @Override
@@ -1357,6 +1371,17 @@ public abstract class AbstractMqlTranslator<T extends JdbcOperation> implements 
                 throw new FeatureNotSupportedException("Only single table from clause is supported");
             }
         }
+    }
+
+    private static <T> T extractLiteral(Expression expression, Class<T> type, String context) {
+        if (expression instanceof Literal literal) {
+            if (type.isInstance(literal.getLiteralValue())) {
+                return type.cast(literal.getLiteralValue());
+            }
+        }
+        throw new FeatureNotSupportedException(String.format(
+                "Expression must be a literal %s in %s, but other expression was found.",
+                type.getSimpleName(), context));
     }
 
     private record EquijoinFields(String localField, String foreignField) {}

--- a/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/filter/AstRegularExpressionFilterOperation.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/filter/AstRegularExpressionFilterOperation.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2025-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.hibernate.internal.translate.mongoast.filter;
+
+import org.bson.BsonRegularExpression;
+import org.bson.BsonWriter;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * See <a href="https://www.mongodb.com/docs/manual/reference/operator/query/regex/#mongodb-query-op.-regex">regular
+ * expression query predicate</a>, <a href="https://www.mongodb.com/docs/manual/tutorial/query-documents/">Query
+ * Documents</a>.
+ *
+ * @hidden
+ */
+public record AstRegularExpressionFilterOperation(String pattern, String options) implements AstFilterOperation {
+    private static final String REGEX_METACHAR = "[]()|^-+*?{}$\\.";
+    /**
+     * Converts a SQL LIKE pattern to a regular expression
+     *
+     * @param pattern the pattern to convert to an equivalent regular expression
+     * @param escape the escape character, if any
+     * @return a string builder that will hold the regular expression that matches the supplied text
+     */
+    public static String quoteMeta(String pattern, @Nullable Character escape) {
+        var result = new StringBuilder(pattern.length());
+        result.append("^");
+        for (var index = 0; index < pattern.length(); index++) {
+            var current = pattern.charAt(index);
+            if (escape != null && current == escape) {
+                if (index == pattern.length() - 1) {
+                    throw new IllegalArgumentException(
+                            "Escape character %s found at end of LIKE pattern: %s".formatted(escape, pattern));
+                }
+                var next = pattern.charAt(index + 1);
+                if (next == '_') {
+                    result.append("_");
+                } else if (next == '%') {
+                    result.append("%");
+                } else if (next == escape) {
+                    if (REGEX_METACHAR.indexOf(escape) != -1) {
+                        result.append("\\");
+                    }
+                    result.append(escape);
+                } else {
+                    throw new IllegalArgumentException(
+                            "Character %1$s is escaped by %2$s, but only %%, _, and %2$s should be escaped"
+                                    .formatted(next, escape));
+                }
+                index++;
+            } else if (current == '_') {
+                result.append(".");
+            } else if (current == '%') {
+                result.append(".*");
+            } else {
+                if (REGEX_METACHAR.indexOf(current) != -1) {
+                    result.append("\\");
+                }
+                result.append(current);
+            }
+        }
+        result.append("$");
+        return result.toString();
+    }
+
+    @Override
+    public void render(BsonWriter writer) {
+        writer.writeStartDocument();
+        {
+            writer.writeName("$regex");
+            writer.writeRegularExpression(new BsonRegularExpression(pattern, options));
+        }
+        writer.writeEndDocument();
+    }
+}

--- a/src/test/java/com/mongodb/hibernate/internal/translate/mongoast/filter/AstRegularExpressionOperationTests.java
+++ b/src/test/java/com/mongodb/hibernate/internal/translate/mongoast/filter/AstRegularExpressionOperationTests.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2025-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.hibernate.internal.translate.mongoast.filter;
+
+import static com.mongodb.hibernate.internal.translate.mongoast.AstNodeAssertions.assertRendering;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class AstRegularExpressionOperationTests {
+    @Test
+    void testRendering() {
+        var operation = new AstRegularExpressionFilterOperation("pa[t]t?ern*", "i");
+        var expectedJson =
+                """
+                {"$regex": {"$regularExpression": {"pattern": "pa[t]t?ern*", "options": "i"}}}\
+                """;
+        assertRendering(expectedJson, operation);
+    }
+
+    @Test
+    void testQuote() {
+        assertEquals("^$", AstRegularExpressionFilterOperation.quoteMeta("", null));
+        assertEquals("^.*$", AstRegularExpressionFilterOperation.quoteMeta("%", null));
+        assertEquals("^.$", AstRegularExpressionFilterOperation.quoteMeta("_", null));
+        assertEquals("^x.*x$", AstRegularExpressionFilterOperation.quoteMeta("x%x", null));
+        assertEquals("^.*\\.\\*\\+\\\\\\[\\]\\|$", AstRegularExpressionFilterOperation.quoteMeta("%.*+\\[]|", null));
+    }
+
+    @Test
+    void testQuoteEscaped() {
+        assertEquals("^$", AstRegularExpressionFilterOperation.quoteMeta("", 'y'));
+        assertEquals("^.*$", AstRegularExpressionFilterOperation.quoteMeta("%", 'y'));
+        assertEquals("^%$", AstRegularExpressionFilterOperation.quoteMeta("y%", 'y'));
+        assertEquals("^.$", AstRegularExpressionFilterOperation.quoteMeta("_", 'y'));
+        assertEquals("^_$", AstRegularExpressionFilterOperation.quoteMeta("y_", 'y'));
+        assertEquals("^x.*x%$", AstRegularExpressionFilterOperation.quoteMeta("x%xy%", 'y'));
+        assertEquals("^.*y$", AstRegularExpressionFilterOperation.quoteMeta("%yy", 'y'));
+        assertEquals("^.*\\.\\*\\+\\\\\\[\\]\\|$", AstRegularExpressionFilterOperation.quoteMeta("%.*+\\[]|", 'y'));
+    }
+
+    @Test
+    void testQuoteEscapedSlash() {
+        assertEquals("^$", AstRegularExpressionFilterOperation.quoteMeta("", '\\'));
+        assertEquals("^.*$", AstRegularExpressionFilterOperation.quoteMeta("%", '\\'));
+        assertEquals("^%$", AstRegularExpressionFilterOperation.quoteMeta("\\%", '\\'));
+        assertEquals("^.$", AstRegularExpressionFilterOperation.quoteMeta("_", '\\'));
+        assertEquals("^_$", AstRegularExpressionFilterOperation.quoteMeta("\\_", '\\'));
+        assertEquals("^\\\\.*$", AstRegularExpressionFilterOperation.quoteMeta("\\\\%", '\\'));
+    }
+}


### PR DESCRIPTION
This adds a filter for regular expressions to allow the `like` operator in HSQL to be bound to an MQL regular expression.

HIBERNATE-76: Support HQL pattern matching