### PR TITLE
HIBERNATE-56: throw when @Id column is explicitly mapped to a name other than _id

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -146,8 +146,9 @@ dependencies {
     errorprone(libs.nullaway)
     errorprone(libs.google.errorprone.core)
 
+    implementation(platform(libs.hibernate.platform))
     api(libs.hibernate.core)
-    implementation("org.hibernate.models:hibernate-models")
+    implementation(libs.hibernate.models)
     api(libs.mongo.java.driver.sync)
     // We need the `libs.findbugs.jsr` dependency to stop `javadoc` from emitting
     // `warning: unknown enum constant When.MAYBE`

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -147,6 +147,7 @@ dependencies {
     errorprone(libs.google.errorprone.core)
 
     api(libs.hibernate.core)
+    implementation("org.hibernate.models:hibernate-models")
     api(libs.mongo.java.driver.sync)
     // We need the `libs.findbugs.jsr` dependency to stop `javadoc` from emitting
     // `warning: unknown enum constant When.MAYBE`

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -51,8 +51,10 @@ assertj = { module = "org.assertj:assertj-core", version.ref = "assertj" }
 nullaway = { module = "com.uber.nullaway:nullaway", version.ref = "nullaway" }
 jspecify = { module = "org.jspecify:jspecify", version.ref = "jspecify" }
 google-errorprone-core = { module = "com.google.errorprone:error_prone_core", version.ref = "google-errorprone-core" }
-hibernate-core = { module = "org.hibernate.orm:hibernate-core", version.ref = "hibernate-orm" }
-hibernate-testing = { module = "org.hibernate.orm:hibernate-testing", version.ref = "hibernate-orm" }
+hibernate-platform = { module = "org.hibernate.orm:hibernate-platform", version.ref = "hibernate-orm" }
+hibernate-core = { module = "org.hibernate.orm:hibernate-core" }
+hibernate-models = { module = "org.hibernate.models:hibernate-models" }
+hibernate-testing = { module = "org.hibernate.orm:hibernate-testing" }
 mongo-java-driver-sync = { module = "org.mongodb:mongodb-driver-sync", version.ref = "mongo-java-driver-sync" }
 findbugs-jsr = { module = "com.google.code.findbugs:jsr305", version.ref = "findbugs-jsr" }
 sl4j-api = { module = "org.slf4j:slf4j-api", version.ref = "slf4j-api" }

--- a/src/integrationTest/java/com/mongodb/hibernate/id/MongoIdFieldNameIntegrationTests.java
+++ b/src/integrationTest/java/com/mongodb/hibernate/id/MongoIdFieldNameIntegrationTests.java
@@ -18,8 +18,10 @@ package com.mongodb.hibernate.id;
 
 import static com.mongodb.hibernate.internal.MongoConstants.ID_FIELD_NAME;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.mongodb.client.MongoCollection;
+import com.mongodb.hibernate.internal.FeatureNotSupportedException;
 import com.mongodb.hibernate.junit.InjectMongoCollection;
 import com.mongodb.hibernate.junit.MongoExtension;
 import com.mongodb.hibernate.junit.MongoServiceRegistryProducer;
@@ -28,9 +30,11 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import org.bson.BsonDocument;
+import org.hibernate.boot.MetadataSources;
 import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.hibernate.testing.orm.junit.SessionFactoryScope;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -39,8 +43,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
         annotatedClasses = {
             MongoIdFieldNameIntegrationTests.EntityWithoutIdColumnAnnotation.class,
             MongoIdFieldNameIntegrationTests.EntityWithIdColumnAnnotationWithoutNameElement.class,
-            MongoIdFieldNameIntegrationTests.EntityWithIdColumnAnnotationWithValidNameElement.class,
-            MongoIdFieldNameIntegrationTests.EntityWithIdColumnAnnotationWithInvalidNameElement.class
+            MongoIdFieldNameIntegrationTests.EntityWithIdColumnAnnotationWithValidNameElement.class
         })
 @ExtendWith(MongoExtension.class)
 class MongoIdFieldNameIntegrationTests implements MongoServiceRegistryProducer {
@@ -79,16 +82,6 @@ class MongoIdFieldNameIntegrationTests implements MongoServiceRegistryProducer {
         assertCollectionContainsExactly(BsonDocument.parse("{_id: 1}"));
     }
 
-    @Test
-    void testEntityWithIdColumnAnnotationWithInvalidNameElement(SessionFactoryScope scope) {
-        scope.inTransaction(session -> {
-            var movie = new EntityWithIdColumnAnnotationWithInvalidNameElement();
-            movie.id = 1;
-            session.persist(movie);
-        });
-        assertCollectionContainsExactly(BsonDocument.parse("{_id: 1}"));
-    }
-
     private static void assertCollectionContainsExactly(BsonDocument expectedDoc) {
         assertThat(mongoCollection.find()).containsExactly(expectedDoc);
     }
@@ -116,11 +109,44 @@ class MongoIdFieldNameIntegrationTests implements MongoServiceRegistryProducer {
         int id;
     }
 
-    @Entity
-    @Table(name = COLLECTION_NAME)
-    static class EntityWithIdColumnAnnotationWithInvalidNameElement {
-        @Id
-        @Column(name = "silentlyReplaced")
-        int id;
+    @Nested
+    class Unsupported implements MongoServiceRegistryProducer {
+        @Test
+        void testEntityWithIdColumnAnnotationWithInvalidNameElement() {
+            assertThatThrownBy(() -> new MetadataSources()
+                            .addAnnotatedClass(EntityWithIdColumnAnnotationWithInvalidNameElement.class)
+                            .buildMetadata()
+                            .buildSessionFactory()
+                            .close())
+                    .isInstanceOf(FeatureNotSupportedException.class)
+                    .hasMessageContaining("customId");
+        }
+
+        @Test
+        void testExplicitNonIdColumnNameViaOrmXml() {
+            assertThatThrownBy(() -> new MetadataSources()
+                            .addAnnotatedClass(EntityWithOrmXmlIdColumnOverride.class)
+                            .addResource("com/mongodb/hibernate/id/id-column-orm-override.xml")
+                            .buildMetadata()
+                            .buildSessionFactory()
+                            .close())
+                    .isInstanceOf(FeatureNotSupportedException.class)
+                    .hasMessageContaining("ormOverriddenId");
+        }
+
+        @Entity
+        @Table(name = COLLECTION_NAME)
+        static class EntityWithIdColumnAnnotationWithInvalidNameElement {
+            @Id
+            @Column(name = "customId")
+            int id;
+        }
+
+        @Entity
+        @Table(name = COLLECTION_NAME)
+        static class EntityWithOrmXmlIdColumnOverride {
+            @Id
+            int id;
+        }
     }
 }

--- a/src/integrationTest/resources/com/mongodb/hibernate/id/id-column-orm-override.xml
+++ b/src/integrationTest/resources/com/mongodb/hibernate/id/id-column-orm-override.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entity-mappings xmlns="https://jakarta.ee/xml/ns/persistence/orm"
+                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 version="3.0">
+    <entity class="com.mongodb.hibernate.id.MongoIdFieldNameIntegrationTests$Unsupported$EntityWithOrmXmlIdColumnOverride">
+        <attributes>
+            <id name="id">
+                <column name="ormOverriddenId"/>
+            </id>
+        </attributes>
+    </entity>
+</entity-mappings>

--- a/src/main/java/com/mongodb/hibernate/internal/boot/MongoAdditionalMappingContributor.java
+++ b/src/main/java/com/mongodb/hibernate/internal/boot/MongoAdditionalMappingContributor.java
@@ -25,6 +25,7 @@ import static java.lang.String.format;
 
 import com.mongodb.hibernate.internal.FeatureNotSupportedException;
 import com.mongodb.hibernate.internal.dialect.MongoDialect;
+import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import java.sql.Time;
 import java.sql.Timestamp;
@@ -51,6 +52,7 @@ import org.hibernate.mapping.AggregateColumn;
 import org.hibernate.mapping.Component;
 import org.hibernate.mapping.PersistentClass;
 import org.hibernate.mapping.Property;
+import org.hibernate.mapping.SimpleValue;
 import org.hibernate.type.BasicPluralType;
 import org.hibernate.type.ComponentType;
 
@@ -203,6 +205,19 @@ public final class MongoAdditionalMappingContributor implements AdditionalMappin
         }
         assertTrue(idColumns.size() == 1);
         var idColumn = idColumns.get(0);
+        if (!ID_FIELD_NAME.equals(idColumn.getName()) && identifier instanceof SimpleValue simpleValue) {
+            var memberDetails = simpleValue.getMemberDetails();
+            if (memberDetails != null) {
+                var columnAnnotation = memberDetails.getDirectAnnotationUsage(Column.class);
+                if (columnAnnotation != null && !columnAnnotation.name().isBlank()) {
+                    throw new FeatureNotSupportedException(format(
+                            "%s: the @Id column name cannot be overridden to [%s];"
+                                    + " MongoDB requires the primary key field to be named [%s]"
+                                    + " — remove @Column(name = \"%s\") or change it to @Column(name = \"%s\")",
+                            persistentClass, idColumn.getName(), ID_FIELD_NAME, idColumn.getName(), ID_FIELD_NAME));
+                }
+            }
+        }
         idColumn.setName(ID_FIELD_NAME);
     }
 }

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -112,6 +112,7 @@ module com.mongodb.hibernate {
     requires java.sql;
     requires jakarta.persistence;
     requires transitive org.hibernate.orm.core;
+    requires org.hibernate.models;
     requires org.mongodb.bson;
     requires transitive org.mongodb.driver.core;
     requires transitive org.mongodb.driver.sync.client;


### PR DESCRIPTION
MongoDB requires the primary key field to be named `_id`. Previously, any explicitly-set `@Id` column name was silently overridden. This change detects the misconfiguration at bootstrap and throws `FeatureNotSupportedException` with an actionable message.

## Scope

| Mapping style | Covered |
|---|---|
| `@Column(name = "<anything but _id>")` on `@Id` field | ✅ |
| JPA orm.xml `<column name="..."/>` override | ✅ (Hibernate merges orm.xml into the same annotation model before bootstrap validation runs) |
| Legacy HBM XML | ❌ — deprecated, removed in Hibernate 8.0; `MemberDetails` is null for HBM-sourced mappings so there is no clean detection mechanism |

## Implementation

Guard added in `MongoAdditionalMappingContributor.setIdentifierColumnName`. Before the unconditional rename to `_id`, if the column name differs and the identifier is a `SimpleValue` with non-null `MemberDetails` carrying a `@Column` annotation with a non-blank name, it throws:

```
EntityWithBadId: the @Id column name cannot be overridden to [customId];
MongoDB requires the primary key field to be named [_id]
— remove @Column(name = "customId") or change it to @Column(name = "_id")
```

`hibernate-models` is added as an explicit `implementation` dependency (it was already a transitive dep via `hibernate-core`; no version pin needed) and `requires org.hibernate.models` added to `module-info.java`.