### PR TITLE
HIBERNATE-183: require com.mongodb.hibernate.semantics.nulls=MQL at bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,13 @@ declare MongoDB as the JPA platform, and configure the connection with Spring Bo
 ```properties
 spring.jpa.database-platform=MongoDB
 spring.mongodb.uri=mongodb://localhost/mydb
+spring.jpa.properties.com.mongodb.hibernate.semantics.nulls=MQL
 ```
+
+`com.mongodb.hibernate.semantics.nulls` is required and must be `MQL`: it declares that
+null-comparison semantics follow whatever MongoDB's query language actually does, which is
+not part of the contract and may change release to release. A future release may add a
+`SQL`-semantics option.
 
 When `spring.jpa.database-platform` is `MongoDB`, the starter auto-configures a JPA
 `EntityManagerFactory`, a `JpaTransactionManager`, and Spring Data JPA repositories backed by MongoDB.

--- a/docs/superpowers/specs/2026-07-01-hibernate-183-null-semantics-config-design.md
+++ b/docs/superpowers/specs/2026-07-01-hibernate-183-null-semantics-config-design.md
@@ -1,0 +1,160 @@
+# HIBERNATE-183: Required null-semantics configuration property
+
+## Context
+
+MongoDB's null-comparison behavior varies by expression and pipeline stage, and does not
+match SQL's three-valued logic. Rather than pick a default now, this ticket adds a
+required configuration property that forces every user to declare their expectation.
+Only one value is supported today (`MQL`); a future release may add `SQL` semantics and
+possibly change the default, but users who declared `MQL` today keep getting the actual
+MQL behavior, not a silently-changed default.
+
+The value is intentionally named `MQL`, not `binary` or `twoValued`: it does not assert a
+coherent two-valued semantics exists. It documents that null semantics are "whatever MQL's
+translation happens to do," which is not part of the contract and may change release to
+release.
+
+## Property
+
+- **Key:** `com.mongodb.hibernate.semantics.nulls` (string literal, see "Naming" below)
+- **Value:** `String`, only `"MQL"` is accepted (exact, case-sensitive match)
+- **Default:** none — the property is required
+- **Storage:** not threaded into `MongoConfiguration` or anywhere else. This ticket is a
+  pure bootstrap-time gate; nothing consumes the value yet. A future ticket that adds
+  `SQL` semantics will introduce the plumbing to read and act on it.
+
+### Naming
+
+`semantics` is a deliberate namespace, not a flattened `nullSemantics` key, anticipating a
+family of MQL-vs-SQL behavioral divergences that may eventually get their own properties,
+e.g.:
+
+- `semantics.arrayEquality` — MongoDB fields can hold arrays; comparing a field to a
+  scalar matches if *any* array element matches, which SQL has no analog for
+- `semantics.typeComparison` — cross-BSON-type comparisons follow BSON's type-ordering
+  rules, not SQL's coercion/error rules
+- `semantics.nullOrdering` — where nulls/missing fields land in `$sort` vs SQL's
+  `NULLS FIRST/LAST`
+- `semantics.collation` — string comparison case-sensitivity/locale, since MQL has an
+  explicit `collation` option SQL dialects handle differently
+- `semantics.aggregateNulls` — whether aggregates skip nulls/missing fields the way SQL
+  aggregates do
+- `semantics.joinMissingMatch` — `LEFT JOIN` unmatched-is-null vs `$lookup`
+  unmatched-is-empty-array semantics
+
+None of these are being added now (YAGNI) — this is just the reasoning for keeping
+`semantics` as a namespace prefix.
+
+The key uses plural `nulls`, not singular `null`: technically `null` would be legal here
+(it's a string literal property key, not a Java identifier, so the language-keyword
+restriction doesn't apply), but plural sidesteps the awkwardness of a bare `null` segment
+and reads naturally as a noun ("null semantics"), consistent with the other candidate
+names above.
+
+No public constant is introduced for the key or value, following the existing precedent of
+`MongoConstants.MONGO_CONFIGURATION_CONTRIBUTOR_KEY`: it stays an internal string literal,
+documented via javadoc and exception text, not a symbol users import.
+
+## Validation
+
+Add a new private static method to `StandardServiceRegistryScopedState.ServiceContributor`
+(`/Users/jeff/git/m/mongo-hibernate/src/main/java/com/mongodb/hibernate/internal/service/StandardServiceRegistryScopedState.java`),
+sibling to the existing `forbidTemporalConfiguration`:
+
+```java
+private static void checkNullSemantics(Map<String, Object> configurationValues) {
+    var value = configurationValues.get("com.mongodb.hibernate.semantics.nulls");
+    if (value == null) {
+        throw new HibernateException(
+                "Configuration property [com.mongodb.hibernate.semantics.nulls] is required");
+    }
+    if (!"MQL".equals(value)) {
+        throw new HibernateException(format(
+                "Configuration property [com.mongodb.hibernate.semantics.nulls] with value [%s] must be [MQL]",
+                value));
+    }
+}
+```
+
+Called from `createMongoConfiguration(...)` alongside `forbidTemporalConfiguration(...)`,
+so it runs unconditionally whenever the Mongo-specific service is actually initiated —
+i.e., only for genuine Mongo bootstraps. It does not run for non-Mongo dialect bootstraps
+(e.g. `NativeBootstrappingTests`), because `StandardServiceRegistryScopedState` is never
+requested in that path; `checkMongoDialectIsPluggedIn` would reject before reaching here
+if a Mongo bootstrap were misconfigured, but that's a separate, already-existing check.
+
+Unlike `JAKARTA_JDBC_URL`, this check is **not** waived when a `MongoConfigurationContributor`
+is present — there is no builder-method equivalent for this property, so a contributor
+can't supply it.
+
+## Documentation
+
+Add a row to the "Supported configuration properties" table in
+`MongoConfigurator`'s class javadoc
+(`/Users/jeff/git/m/mongo-hibernate/src/main/java/com/mongodb/hibernate/cfg/MongoConfigurator.java`):
+
+| Method | Has default | Property name | Supported value types | Value |
+|---|---|---|---|---|
+| — | ✗ | `com.mongodb.hibernate.semantics.nulls` | `String` | Must be `"MQL"` (the only supported value). Declares that null-comparison semantics are whatever MQL's translation produces, which is not part of the contract and may change release to release. A future release may add `"SQL"` semantics. |
+
+## Tests
+
+All in
+`/Users/jeff/git/m/mongo-hibernate/src/test/java/com/mongodb/hibernate/internal/service/StandardServiceRegistryScopedStateTests.java`:
+
+| Test | Covers |
+|---|---|
+| `testNullSemanticsRequired` (new) | Property absent → `HibernateException` with the "is required" message |
+| `testNullSemanticsUnsupportedValue` (new) | Property present but not `"MQL"` → `HibernateException` with the "must be [MQL]" message, including the actual value |
+| `testNullSemanticsMql` (new) | Property present and `"MQL"` → no exception |
+| `contributorFromConfigurationValuesIsInvoked` (existing) | Update: this test explicitly clears settings and applies only `JAKARTA_JDBC_URL`/`DIALECT`, so it needs an explicit `.applySetting("com.mongodb.hibernate.semantics.nulls", "MQL")` added or it will start failing |
+
+Service initiation is lazy: `StandardServiceRegistryBuilder#build()` alone does not run
+`initiateService()`. Each new test must call
+`registry.requireService(StandardServiceRegistryScopedState.class)` after building (inside
+a try-with-resources on the registry), matching the pattern already used by
+`testMongoDialectNotPluggedIn` and `contributorFromConfigurationValuesIsInvoked`.
+
+## Blast radius: existing bootstrap sites that must add the property
+
+Because the property is required, every existing place that bootstraps a real Mongo
+Hibernate registry needs `com.mongodb.hibernate.semantics.nulls=MQL` added, or it will
+start failing:
+
+1. `src/test/resources/hibernate.properties` — add the property (covers unit tests that
+   rely on classpath defaults, including `differentStandardServiceRegistriesHaveDifferentStates`
+   and all of `MongoConfigurationContributorTests`)
+2. `src/integrationTest/resources/hibernate.properties` — add the property
+3. `mongodb-hibernate-spring-boot-autoconfigure/src/integrationTest/resources/application.properties`
+   — add `spring.jpa.properties.com.mongodb.hibernate.semantics.nulls=MQL`
+4. `example-module/src/main/java/com/mongodb/hibernate/example/AppWithMongoConfiguratorContributorAddedDirectly.java`
+   — add `.applySetting("com.mongodb.hibernate.semantics.nulls", "MQL")`
+5. `example-module/src/main/java/com/mongodb/hibernate/example/AppWithMongoConfiguratorContributorAddedViaServiceContributor.java`
+   — same
+6. `example-module/src/smokeTest/java/com/mongodb/hibernate/example/test/MongoAdditionalMappingContributorTests.java`
+   — same, defensively (uses `buildMetadata`, which may or may not trigger service
+   initiation; add it regardless since it's cheap insurance)
+7. `README.md` Spring Boot config snippet (currently `spring.jpa.database-platform` /
+   `spring.mongodb.uri`) — add
+   `spring.jpa.properties.com.mongodb.hibernate.semantics.nulls=MQL` plus a one-sentence
+   explanation
+
+### Explicitly NOT changed (verified the check never fires there)
+
+- `mongodb-hibernate-spring-boot-autoconfigure/src/integrationTest/resources/application-h2.properties`
+  — non-Mongo dialect
+- `src/test/java/com/mongodb/hibernate/boot/NativeBootstrappingTests.java` — non-Mongo
+  dialect, `clearSettings()` + H2
+- `src/integrationTest/java/com/mongodb/hibernate/TestServiceContributor.java` — doesn't
+  set Hibernate settings, only registers services
+- Spring Boot starter's `MongoHibernateAutoConfiguration` — deliberately does **not**
+  auto-default this property (decided explicitly): the whole point is forcing every user,
+  including Spring Boot users, to consciously declare null semantics before an alternative
+  exists. Auto-defaulting would silently exempt Spring Boot users from that decision.
+
+## Out of scope
+
+- Actually consuming the value anywhere (translator, dialect). This ticket only gates
+  bootstrap.
+- Adding `SQL` as a second supported value, or any of the other `semantics.*` properties
+  brainstormed under "Naming" above.

--- a/docs/superpowers/specs/2026-07-01-hibernate-183-null-semantics-config-design.md
+++ b/docs/superpowers/specs/2026-07-01-hibernate-183-null-semantics-config-design.md
@@ -58,7 +58,7 @@ documented via javadoc and exception text, not a symbol users import.
 ## Validation
 
 Add a new private static method to `StandardServiceRegistryScopedState.ServiceContributor`
-(`/Users/jeff/git/m/mongo-hibernate/src/main/java/com/mongodb/hibernate/internal/service/StandardServiceRegistryScopedState.java`),
+(`src/main/java/com/mongodb/hibernate/internal/service/StandardServiceRegistryScopedState.java`),
 sibling to the existing `forbidTemporalConfiguration`:
 
 ```java
@@ -91,7 +91,7 @@ can't supply it.
 
 Add a row to the "Supported configuration properties" table in
 `MongoConfigurator`'s class javadoc
-(`/Users/jeff/git/m/mongo-hibernate/src/main/java/com/mongodb/hibernate/cfg/MongoConfigurator.java`):
+(`src/main/java/com/mongodb/hibernate/cfg/MongoConfigurator.java`):
 
 | Method | Has default | Property name | Supported value types | Value |
 |---|---|---|---|---|
@@ -100,7 +100,7 @@ Add a row to the "Supported configuration properties" table in
 ## Tests
 
 All in
-`/Users/jeff/git/m/mongo-hibernate/src/test/java/com/mongodb/hibernate/internal/service/StandardServiceRegistryScopedStateTests.java`:
+`src/test/java/com/mongodb/hibernate/internal/service/StandardServiceRegistryScopedStateTests.java`:
 
 | Test | Covers |
 |---|---|

--- a/example-module/src/main/java/com/mongodb/hibernate/example/AppWithMongoConfiguratorContributorAddedDirectly.java
+++ b/example-module/src/main/java/com/mongodb/hibernate/example/AppWithMongoConfiguratorContributorAddedDirectly.java
@@ -53,6 +53,7 @@ public final class AppWithMongoConfiguratorContributorAddedDirectly {
                 .getMetadataBuilder(new StandardServiceRegistryBuilder()
                         .applySetting(AvailableSettings.DIALECT, "MongoDB")
                         .applySetting(AvailableSettings.STATEMENT_BATCH_SIZE, 2)
+                        .applySetting("com.mongodb.hibernate.semantics.nulls", "MQL")
                         .addService(MongoConfigurationContributor.class, configurator ->
                                 configurator.applyToMongoClientSettings(mongoClientSettings -> mongoClientSettings
                                                 .applyToClusterSettings(clusterSettings -> clusterSettings

--- a/example-module/src/main/java/com/mongodb/hibernate/example/AppWithMongoConfiguratorContributorAddedViaServiceContributor.java
+++ b/example-module/src/main/java/com/mongodb/hibernate/example/AppWithMongoConfiguratorContributorAddedViaServiceContributor.java
@@ -44,6 +44,7 @@ public final class AppWithMongoConfiguratorContributorAddedViaServiceContributor
                 .getMetadataBuilder(new StandardServiceRegistryBuilder()
                         .applySetting(AvailableSettings.DIALECT, "MongoDB")
                         .applySetting(AvailableSettings.STATEMENT_BATCH_SIZE, 2)
+                        .applySetting("com.mongodb.hibernate.semantics.nulls", "MQL")
                         .build())
                 .build()
                 .buildSessionFactory()) {

--- a/example-module/src/smokeTest/java/com/mongodb/hibernate/example/test/MongoAdditionalMappingContributorTests.java
+++ b/example-module/src/smokeTest/java/com/mongodb/hibernate/example/test/MongoAdditionalMappingContributorTests.java
@@ -35,6 +35,7 @@ class MongoAdditionalMappingContributorTests {
                 .buildMetadata(new StandardServiceRegistryBuilder()
                         .applySetting(AvailableSettings.ALLOW_METADATA_ON_BOOT, false)
                         .applySetting(AvailableSettings.JAKARTA_JDBC_URL, "mongodb://host/db")
+                        .applySetting("com.mongodb.hibernate.semantics.nulls", "MQL")
                         .build()))
                 .hasMessageContaining("does not support primary key spanning multiple columns");
     }

--- a/mongodb-hibernate-spring-boot-autoconfigure/src/integrationTest/resources/application.properties
+++ b/mongodb-hibernate-spring-boot-autoconfigure/src/integrationTest/resources/application.properties
@@ -1,2 +1,3 @@
 spring.jpa.database-platform=MongoDB
 spring.mongodb.uri=mongodb://localhost/mongo-hibernate-test?directConnection=false
+spring.jpa.properties.com.mongodb.hibernate.semantics.nulls=MQL

--- a/src/integrationTest/resources/hibernate.properties
+++ b/src/integrationTest/resources/hibernate.properties
@@ -1,2 +1,3 @@
 jakarta.persistence.jdbc.url=mongodb://localhost/mongo-hibernate-test?directConnection=false
 hibernate.query.plan_cache_enabled=false #make tests more isolated from each other
+com.mongodb.hibernate.semantics.nulls=MQL

--- a/src/main/java/com/mongodb/hibernate/cfg/MongoConfigurator.java
+++ b/src/main/java/com/mongodb/hibernate/cfg/MongoConfigurator.java
@@ -86,6 +86,21 @@ import org.hibernate.service.spi.Configurable;
  *             connection string are not used to build a connection (the database name must still be configured via
  *             {@link #databaseName(String)} or come from {@value AvailableSettings#JAKARTA_JDBC_URL}).</td>
  *         </tr>
+ *         <tr>
+ *             <td>&mdash;</td>
+ *             <td>✗</td>
+ *             <td>{@code com.mongodb.hibernate.semantics.nulls}</td>
+ *             <td>
+ *                 <ul>
+ *                     <li>{@link String}</li>
+ *                 </ul>
+ *             </td>
+ *             <td>
+ *                 Must be {@code "MQL"} (the only supported value). Declares that null-comparison semantics are
+ *                 whatever MQL's translation produces, which is not part of the contract and may change release
+ *                 to release. A future release may add {@code "SQL"} semantics.
+ *             </td>
+ *         </tr>
  *     </tbody>
  * </table>
  *

--- a/src/main/java/com/mongodb/hibernate/internal/service/StandardServiceRegistryScopedState.java
+++ b/src/main/java/com/mongodb/hibernate/internal/service/StandardServiceRegistryScopedState.java
@@ -176,6 +176,7 @@ public final class StandardServiceRegistryScopedState implements Service {
                         JAKARTA_JDBC_URL, MongoConfigurationContributor.class.getName()));
             }
             forbidTemporalConfiguration(configurationValues);
+            checkNullSemantics(configurationValues);
             var mongoConfigurationBuilder = new MongoConfigurationBuilder(configurationValues);
             if (mongoConfigurationContributor != null) {
                 mongoConfigurationContributor.configure(mongoConfigurationBuilder);
@@ -210,6 +211,19 @@ public final class StandardServiceRegistryScopedState implements Service {
                     throw new HibernateException(
                             format("Configuration property [%s] is not supported", JAVA_TIME_USE_DIRECT_JDBC));
                 }
+            }
+        }
+
+        private static void checkNullSemantics(Map<String, Object> configurationValues) {
+            var nullSemantics = configurationValues.get("com.mongodb.hibernate.semantics.nulls");
+            if (nullSemantics == null) {
+                throw new HibernateException(
+                        "Configuration property [com.mongodb.hibernate.semantics.nulls] is required");
+            }
+            if (!"MQL".equals(nullSemantics)) {
+                throw new HibernateException(format(
+                        "Configuration property [com.mongodb.hibernate.semantics.nulls] with value [%s] must be [MQL]",
+                        nullSemantics));
             }
         }
     }

--- a/src/test/java/com/mongodb/hibernate/internal/service/StandardServiceRegistryScopedStateTests.java
+++ b/src/test/java/com/mongodb/hibernate/internal/service/StandardServiceRegistryScopedStateTests.java
@@ -101,6 +101,45 @@ class StandardServiceRegistryScopedStateTests {
     }
 
     @Test
+    void testNullSemanticsRequired() {
+        var standardServiceRegistryBuilder = new StandardServiceRegistryBuilder()
+                .clearSettings()
+                .applySetting(DIALECT, MONGO_DIALECT_SHORT_NAME)
+                .applySetting(JAKARTA_JDBC_URL, "mongodb://host/db");
+        try (var standardServiceRegistry = standardServiceRegistryBuilder.build()) {
+            assertThatThrownBy(() -> standardServiceRegistry.requireService(StandardServiceRegistryScopedState.class))
+                    .hasRootCauseMessage("Configuration property [com.mongodb.hibernate.semantics.nulls] is required");
+        }
+    }
+
+    @Test
+    void testNullSemanticsUnsupportedValue() {
+        var standardServiceRegistryBuilder = new StandardServiceRegistryBuilder()
+                .clearSettings()
+                .applySetting(DIALECT, MONGO_DIALECT_SHORT_NAME)
+                .applySetting(JAKARTA_JDBC_URL, "mongodb://host/db")
+                .applySetting("com.mongodb.hibernate.semantics.nulls", "SQL");
+        try (var standardServiceRegistry = standardServiceRegistryBuilder.build()) {
+            assertThatThrownBy(() -> standardServiceRegistry.requireService(StandardServiceRegistryScopedState.class))
+                    .hasRootCauseMessage(
+                            "Configuration property [com.mongodb.hibernate.semantics.nulls] with value [SQL] must be [MQL]");
+        }
+    }
+
+    @Test
+    void testNullSemanticsMql() {
+        var standardServiceRegistryBuilder = new StandardServiceRegistryBuilder()
+                .clearSettings()
+                .applySetting(DIALECT, MONGO_DIALECT_SHORT_NAME)
+                .applySetting(JAKARTA_JDBC_URL, "mongodb://host/db")
+                .applySetting("com.mongodb.hibernate.semantics.nulls", "MQL");
+        try (var standardServiceRegistry = standardServiceRegistryBuilder.build()) {
+            assertThat(standardServiceRegistry.requireService(StandardServiceRegistryScopedState.class))
+                    .isNotNull();
+        }
+    }
+
+    @Test
     void contributorFromConfigurationValuesIsInvoked() {
         var called = new AtomicBoolean(false);
         MongoConfigurationContributor contributor = cfg -> called.set(true);
@@ -108,7 +147,8 @@ class StandardServiceRegistryScopedStateTests {
         var builder = new StandardServiceRegistryBuilder()
                 .clearSettings()
                 .applySetting(JAKARTA_JDBC_URL, "mongodb://localhost/db")
-                .applySetting(DIALECT, MONGO_DIALECT_SHORT_NAME);
+                .applySetting(DIALECT, MONGO_DIALECT_SHORT_NAME)
+                .applySetting("com.mongodb.hibernate.semantics.nulls", "MQL");
         new StandardServiceRegistryScopedState.ServiceContributor().contribute(builder);
         // Simulate what MongoHibernateAutoConfiguration does: put the contributor in settings
         builder.applySetting(MONGO_CONFIGURATION_CONTRIBUTOR_KEY, contributor);

--- a/src/test/resources/hibernate.properties
+++ b/src/test/resources/hibernate.properties
@@ -1,2 +1,3 @@
 hibernate.boot.allow_jdbc_metadata_access=false
 jakarta.persistence.jdbc.url=mongodb://host/db
+com.mongodb.hibernate.semantics.nulls=MQL


### PR DESCRIPTION
Adds a required Hibernate bootstrap configuration property, `com.mongodb.hibernate.semantics.nulls`, with `MQL` as the only supported value for now. This defers the decision on SQL vs. MQL null-comparison semantics without picking a silent default — every user must declare their expectation explicitly.

Wires the new requirement through every existing bootstrap site so nothing else breaks: unit test fixtures, integration test fixtures, the Spring Boot autoconfigure module's integration test fixture, the example-module apps/smoke test, and the README's Spring Boot config snippet.