### PR TITLE
docs: require repo-relative paths in checked-in docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,3 +92,6 @@ curl -s -X PUT \
   through the testing framework must implement MongoServiceRegistryProducer (in com.mongodb.hibernate.junit). It strips the 
   SharedDriverManagerConnectionProvider that Hibernate's test framework injects, which would otherwise trip the 
   auto-configured connection provider.
+- **Checked-in docs:** Use repo-relative paths, not developer-local absolute paths (e.g. `/Users/name/...`),
+  when referencing files in design specs, plans, or other markdown committed to the repo — these are read
+  on GitHub by people whose checkouts differ from yours.


### PR DESCRIPTION
## Summary
- Adds a code-style convention to AGENTS.md: use repo-relative paths, not developer-local absolute paths, in design specs/plans/other markdown committed to the repo.
- Prompted by a Copilot PR review comment on #174, which flagged `/Users/...` paths in a design spec as meaningless to other readers on GitHub.