### PR TITLE
HIBERNATE-77: Support HQL in / not in

### DIFF
--- a/src/integrationTest/java/com/mongodb/hibernate/query/select/SimpleSelectQueryIntegrationTests.java
+++ b/src/integrationTest/java/com/mongodb/hibernate/query/select/SimpleSelectQueryIntegrationTests.java
@@ -279,6 +279,71 @@ class SimpleSelectQueryIntegrationTests extends AbstractQueryIntegrationTests {
                     Set.of(Contact.COLLECTION_NAME));
         }
 
+        @ParameterizedTest
+        @ValueSource(booleans = {false, true})
+        void testComparisonByIn(boolean negated) {
+            assertSelectionQuery(
+                    "from Contact where age %s in (?1, :foo, 7)".formatted(negated ? "not" : ""),
+                    Contact.class,
+                    q -> q.setParameter(1, 18).setParameter("foo", 35),
+                    """
+                    {
+                      "aggregate": "contacts",
+                      "pipeline": [
+                        {
+                          "$match": {
+                            "age": {
+                              "$%s": [18, 35, 7]
+                            }
+                          }
+                        },
+                        {
+                          "$project": {
+                            "_id": true,
+                            "age": true,
+                            "country": true,
+                            "name": true
+                          }
+                        }
+                      ]
+                    }"""
+                            .formatted(negated ? "nin" : "in"),
+                    negated ? getTestingContacts(4, 5) : getTestingContacts(1, 2, 3),
+                    Set.of(Contact.COLLECTION_NAME));
+        }
+
+        @ParameterizedTest
+        @ValueSource(booleans = {false, true})
+        void testComparisonByInEmpty(boolean negated) {
+            assertSelectionQuery(
+                    "from Contact where age %s in ()".formatted(negated ? "not" : ""),
+                    Contact.class,
+                    """
+                    {
+                      "aggregate": "contacts",
+                      "pipeline": [
+                        {
+                          "$match": {
+                            "age": {
+                              "$%s": []
+                            }
+                          }
+                        },
+                        {
+                          "$project": {
+                            "_id": true,
+                            "age": true,
+                            "country": true,
+                            "name": true
+                          }
+                        }
+                      ]
+                    }"""
+                            .formatted(negated ? "nin" : "in"),
+                    negated ? testingContacts : List.of(),
+                    Set.of(Contact.COLLECTION_NAME));
+        }
+
         @Test
         void testAndFilter() {
             assertSelectionQuery(

--- a/src/main/java/com/mongodb/hibernate/internal/translate/AbstractMqlTranslator.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/AbstractMqlTranslator.java
@@ -44,6 +44,8 @@ import static com.mongodb.hibernate.internal.translate.mongoast.filter.AstCompar
 import static com.mongodb.hibernate.internal.translate.mongoast.filter.AstComparisonFilterOperator.LT;
 import static com.mongodb.hibernate.internal.translate.mongoast.filter.AstComparisonFilterOperator.LTE;
 import static com.mongodb.hibernate.internal.translate.mongoast.filter.AstComparisonFilterOperator.NE;
+import static com.mongodb.hibernate.internal.translate.mongoast.filter.AstListComparisonFilterOperator.IN;
+import static com.mongodb.hibernate.internal.translate.mongoast.filter.AstListComparisonFilterOperator.NIN;
 import static com.mongodb.hibernate.internal.translate.mongoast.filter.AstLogicalFilterOperator.AND;
 import static com.mongodb.hibernate.internal.translate.mongoast.filter.AstLogicalFilterOperator.NOR;
 import static com.mongodb.hibernate.internal.translate.mongoast.filter.AstLogicalFilterOperator.OR;
@@ -82,6 +84,7 @@ import com.mongodb.hibernate.internal.translate.mongoast.filter.AstElemMatchFilt
 import com.mongodb.hibernate.internal.translate.mongoast.filter.AstEmptyFilter;
 import com.mongodb.hibernate.internal.translate.mongoast.filter.AstFieldOperationFilter;
 import com.mongodb.hibernate.internal.translate.mongoast.filter.AstFilter;
+import com.mongodb.hibernate.internal.translate.mongoast.filter.AstListComparisonFilterOperation;
 import com.mongodb.hibernate.internal.translate.mongoast.filter.AstLogicalFilter;
 import com.mongodb.hibernate.internal.type.ValueConversions;
 import jakarta.persistence.criteria.Nulls;
@@ -1046,7 +1049,19 @@ public abstract class AbstractMqlTranslator<T extends JdbcOperation> implements 
 
     @Override
     public void visitInListPredicate(InListPredicate inListPredicate) {
-        throw new FeatureNotSupportedException();
+        var expression = inListPredicate.getTestExpression();
+        if (!isFieldPathExpression(expression)) {
+            throw new FeatureNotSupportedException(
+                    "Only the following list predicates are supported: field in [not] (...)");
+        }
+        var fieldPath = acceptAndYield(expression, FIELD_PATH);
+        var operator = inListPredicate.isNegated() ? NIN : IN;
+        var operation = new AstListComparisonFilterOperation(
+                operator,
+                inListPredicate.getListExpressions().stream()
+                        .map(item -> acceptAndYield(item, VALUE))
+                        .toList());
+        astVisitorValueHolder.yield(FILTER, new AstFieldOperationFilter(fieldPath, operation));
     }
 
     @Override

--- a/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/filter/AstListComparisonFilterOperation.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/filter/AstListComparisonFilterOperation.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2025-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.hibernate.internal.translate.mongoast.filter;
+
+import com.mongodb.hibernate.internal.translate.mongoast.AstValue;
+import java.util.List;
+import org.bson.BsonWriter;
+
+/**
+ * See <a href="https://www.mongodb.com/docs/manual/reference/operator/query/in/">Query and Projection Operators. Query
+ * Selectors. Comparison</a>.
+ *
+ * @hidden
+ */
+public record AstListComparisonFilterOperation(AstListComparisonFilterOperator operator, List<AstValue> values)
+        implements AstFilterOperation {
+    @Override
+    public void render(BsonWriter writer) {
+        writer.writeStartDocument();
+        {
+            writer.writeName(operator.getOperatorName());
+            writer.writeStartArray();
+            for (final var value : values) {
+                value.render(writer);
+            }
+            writer.writeEndArray();
+        }
+        writer.writeEndDocument();
+    }
+}

--- a/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/filter/AstListComparisonFilterOperator.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/filter/AstListComparisonFilterOperator.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2025-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.hibernate.internal.translate.mongoast.filter;
+
+/**
+ * @see AstComparisonFilterOperation
+ * @hidden
+ */
+@SuppressWarnings("MissingSummary")
+public enum AstListComparisonFilterOperator {
+    /** See <a href="https://www.mongodb.com/docs/manual/reference/operator/query/in/">{@code $in}</a>. */
+    IN("$in"),
+    /** See <a href="https://www.mongodb.com/docs/manual/reference/operator/query/nin/">{@code $nin}</a>. */
+    NIN("$nin");
+
+    private final String operatorName;
+
+    AstListComparisonFilterOperator(String operatorName) {
+        this.operatorName = operatorName;
+    }
+
+    String getOperatorName() {
+        return operatorName;
+    }
+}

--- a/src/test/java/com/mongodb/hibernate/internal/translate/mongoast/filter/AstListComparisonFilterOperationTests.java
+++ b/src/test/java/com/mongodb/hibernate/internal/translate/mongoast/filter/AstListComparisonFilterOperationTests.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2025-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.hibernate.internal.translate.mongoast.filter;
+
+import static com.mongodb.hibernate.internal.translate.mongoast.AstNodeAssertions.assertRendering;
+
+import com.mongodb.hibernate.internal.translate.mongoast.AstLiteral;
+import java.util.List;
+import org.bson.BsonString;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+class AstListComparisonFilterOperationTests {
+
+    @ParameterizedTest
+    @EnumSource(AstListComparisonFilterOperator.class)
+    void testRendering(AstListComparisonFilterOperator operator) {
+        var operation = new AstListComparisonFilterOperation(
+                operator, List.of(new AstLiteral(new BsonString("a")), new AstLiteral(new BsonString("b"))));
+
+        var expectedJson = """
+                           {"%s": ["a", "b"]}\
+                           """
+                .formatted(operator.getOperatorName());
+        assertRendering(expectedJson, operation);
+    }
+}


### PR DESCRIPTION
Adds HQL support for `in` and `not in` list comparisons.