### PR TITLE
HIBERNATE-69: Support mapped superclasses and single-table inheritance

### DIFF
--- a/src/integrationTest/java/com/mongodb/hibernate/boot/NativeBootstrappingIntegrationTests.java
+++ b/src/integrationTest/java/com/mongodb/hibernate/boot/NativeBootstrappingIntegrationTests.java
@@ -19,15 +19,31 @@ package com.mongodb.hibernate.boot;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.mongodb.client.MongoClient;
+import com.mongodb.hibernate.internal.FeatureNotSupportedException;
 import com.mongodb.hibernate.junit.InjectMongoClient;
 import com.mongodb.hibernate.junit.MongoExtension;
+import com.mongodb.hibernate.junit.MongoServiceRegistryProducer;
+import com.mongodb.hibernate.query.AbstractQueryIntegrationTests;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.Version;
+import java.time.Instant;
 import org.bson.BsonDocument;
+import org.hibernate.annotations.CurrentTimestamp;
+import org.hibernate.annotations.Generated;
+import org.hibernate.annotations.GeneratedColumn;
+import org.hibernate.annotations.SourceType;
 import org.hibernate.boot.MetadataSources;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(MongoExtension.class)
-class NativeBootstrappingIntegrationTests {
+class NativeBootstrappingIntegrationTests extends AbstractQueryIntegrationTests
+        implements MongoServiceRegistryProducer {
     @InjectMongoClient
     private static MongoClient mongoClient;
 
@@ -52,5 +68,105 @@ class NativeBootstrappingIntegrationTests {
                 })
                 .hasRootCauseMessage(
                         "Could not instantiate [com.mongodb.hibernate.internal.dialect.MongoDialect], see the earlier exceptions to find out why");
+    }
+
+    @Nested
+    class Unsupported implements MongoServiceRegistryProducer {
+
+        @Entity(name = "ItemWithDbTimestamp")
+        @Table(name = "ItemWithDbTimestamp")
+        static class ItemWithDbTimestamp {
+            @Id
+            int id;
+
+            String string;
+
+            @Version
+            @CurrentTimestamp(source = SourceType.DB)
+            Instant version;
+        }
+
+        @Entity(name = "ItemWithGenerated")
+        @Table(name = "ItemWithGenerated")
+        static class ItemWithGenerated {
+            @Id
+            int id;
+
+            String string;
+
+            @Version
+            @Generated(sql = "does not matter")
+            Instant version;
+        }
+
+        @Entity(name = "ItemWithGeneratedColumn")
+        @Table(name = "ItemWithGeneratedColumn")
+        static class ItemWithGeneratedColumn {
+            @Id
+            int id;
+
+            String string;
+
+            @Version
+            @GeneratedColumn(value = "does not matter")
+            Instant version;
+        }
+
+        @Entity(name = "ItemWithGeneratedValue")
+        @Table(name = "ItemWithGeneratedValue")
+        static class ItemWithGeneratedValue {
+            @Id
+            @GeneratedValue
+            int id;
+
+            String string;
+        }
+
+        @Test
+        void testForbidCurrentTimestampSourceDbAnnotation() {
+            assertBootstrapThrows(() -> new MetadataSources()
+                            .addAnnotatedClass(
+                                    NativeBootstrappingIntegrationTests.Unsupported.ItemWithDbTimestamp.class)
+                            .buildMetadata(new StandardServiceRegistryBuilder().build())
+                            .buildSessionFactory())
+                    .isInstanceOf(FeatureNotSupportedException.class)
+                    .hasMessage(
+                            "Field version of class com.mongodb.hibernate.boot.NativeBootstrappingIntegrationTests.Unsupported.ItemWithDbTimestamp is not supported: Annotation @CurrentTimestamp(source=DB) is forbidden");
+        }
+
+        @Test
+        void testForbidGeneratedAnnotation() {
+            assertBootstrapThrows(() -> new MetadataSources()
+                            .addAnnotatedClass(NativeBootstrappingIntegrationTests.Unsupported.ItemWithGenerated.class)
+                            .buildMetadata(new StandardServiceRegistryBuilder().build())
+                            .buildSessionFactory())
+                    .isInstanceOf(FeatureNotSupportedException.class)
+                    .hasMessage(
+                            "Field version of class com.mongodb.hibernate.boot.NativeBootstrappingIntegrationTests.Unsupported.ItemWithGenerated is not supported: Annotation org.hibernate.annotations.Generated is forbidden");
+        }
+
+        @Test
+        void testForbidGeneratedValueAnnotation() {
+            assertBootstrapThrows(() -> new MetadataSources()
+                            .addAnnotatedClass(
+                                    NativeBootstrappingIntegrationTests.Unsupported.ItemWithGeneratedValue.class)
+                            .buildMetadata(new StandardServiceRegistryBuilder().build())
+                            .buildSessionFactory())
+                    .isInstanceOf(FeatureNotSupportedException.class)
+                    .hasMessage(
+                            "Field id of class com.mongodb.hibernate.boot.NativeBootstrappingIntegrationTests.Unsupported.ItemWithGeneratedValue is not supported: Annotation jakarta.persistence.GeneratedValue is forbidden");
+        }
+
+        @Test
+        void testForbidGeneratedColumnAnnotation() {
+            assertBootstrapThrows(() -> new MetadataSources()
+                            .addAnnotatedClass(
+                                    NativeBootstrappingIntegrationTests.Unsupported.ItemWithGeneratedColumn.class)
+                            .buildMetadata(new StandardServiceRegistryBuilder().build())
+                            .buildSessionFactory())
+                    .isInstanceOf(FeatureNotSupportedException.class)
+                    .hasMessage(
+                            "Field version of class com.mongodb.hibernate.boot.NativeBootstrappingIntegrationTests.Unsupported.ItemWithGeneratedColumn is not supported: Annotation org.hibernate.annotations.GeneratedColumn is forbidden");
+        }
     }
 }

--- a/src/integrationTest/java/com/mongodb/hibernate/locking/OptimisticLockingIntegrationTests.java
+++ b/src/integrationTest/java/com/mongodb/hibernate/locking/OptimisticLockingIntegrationTests.java
@@ -524,18 +524,6 @@ class OptimisticLockingIntegrationTests extends AbstractQueryIntegrationTests im
 
     @Nested
     class Unsupported implements MongoServiceRegistryProducer {
-
-        @Test
-        void testVersionWithCurrentTimestampSourceDbThrows() {
-            assertBootstrapThrows(() -> new MetadataSources()
-                            .addAnnotatedClass(ItemWithDbTimestamp.class)
-                            .buildMetadata(new StandardServiceRegistryBuilder().build())
-                            .buildSessionFactory())
-                    .isInstanceOf(FeatureNotSupportedException.class)
-                    .hasMessage(
-                            "@CurrentTimestamp(source=DB), @Generated, and @ColumnTransformer write expressions are not supported");
-        }
-
         @Test
         void testSecondaryTableThrows() {
             assertBootstrapThrows(() -> new MetadataSources()
@@ -557,19 +545,6 @@ class OptimisticLockingIntegrationTests extends AbstractQueryIntegrationTests im
                     .isInstanceOf(FeatureNotSupportedException.class)
                     .hasMessage(
                             "TODO-HIBERNATE-69 https://jira.mongodb.org/browse/HIBERNATE-69 JOINED inheritance is not supported");
-        }
-
-        @Entity(name = "ItemWithDbTimestamp")
-        @Table(name = "ItemWithDbTimestamp")
-        static class ItemWithDbTimestamp {
-            @Id
-            int id;
-
-            String string;
-
-            @Version
-            @CurrentTimestamp(source = SourceType.DB)
-            Instant version;
         }
 
         @Entity(name = "ItemWithSecondaryTable")

--- a/src/integrationTest/java/com/mongodb/hibernate/query/mutation/UpdatingIntegrationTests.java
+++ b/src/integrationTest/java/com/mongodb/hibernate/query/mutation/UpdatingIntegrationTests.java
@@ -468,8 +468,7 @@ class UpdatingIntegrationTests extends AbstractQueryIntegrationTests {
                         .buildMetadata(new StandardServiceRegistryBuilder().build())
                         .buildSessionFactory())
                 .isInstanceOf(FeatureNotSupportedException.class)
-                .hasMessage(
-                        "@CurrentTimestamp(source=DB), @Generated, and @ColumnTransformer write expressions are not supported");
+                .hasMessage("@ColumnTransformer expressions are not supported");
     }
 
     @Entity(name = "ItemWithColumnTransformer")

--- a/src/integrationTest/java/com/mongodb/hibernate/query/select/InheritanceIntegrationTests.java
+++ b/src/integrationTest/java/com/mongodb/hibernate/query/select/InheritanceIntegrationTests.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2026-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.hibernate.query.select;
+
+import com.mongodb.hibernate.query.AbstractQueryIntegrationTests;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
+import java.util.List;
+import java.util.Set;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+@DomainModel(annotatedClasses = {InheritanceIntegrationTests.MappedA.class})
+public class InheritanceIntegrationTests extends AbstractQueryIntegrationTests {
+    static final List<MappedA> MAPPED_A = List.of(new MappedA(1, "A", 65), new MappedA(2, "B", 66));
+
+    @BeforeEach
+    void beforeEach() {
+
+        getSessionFactoryScope().inTransaction(session -> {
+            MAPPED_A.forEach(session::persist);
+        });
+        getTestCommandListener().clear();
+    }
+
+    @Test
+    void testReadMapped() {
+        assertSelectionQuery(
+                "from MappedA where uniqueOnA > 64",
+                MappedA.class,
+                """
+                {
+                  "aggregate": "MappedA",
+                  "pipeline": [
+                    {
+                      "$match": {
+                        "uniqueOnA": {"$gt": 64}
+                      }
+                    },
+                    {
+                      "$project": {
+                        "_id": true,
+                        "commonField": true,
+                        "uniqueOnA": true,
+                      }
+                    }
+                  ]
+                }""",
+                MAPPED_A,
+                Set.of("MappedA"));
+    }
+
+    @MappedSuperclass
+    abstract static class MappedSuper {
+        @Id
+        int id;
+
+        String commonField;
+
+        public MappedSuper(int id, String commonField) {
+            this.id = id;
+            this.commonField = commonField;
+        }
+
+        public String getCommonField() {
+            return commonField;
+        }
+
+        public void setCommonField(String commonField) {
+            this.commonField = commonField;
+        }
+
+        public int getId() {
+            return id;
+        }
+
+        public void setId(int id) {
+            this.id = id;
+        }
+    }
+
+    @Entity(name = "MappedA")
+    static class MappedA extends MappedSuper {
+        int uniqueOnA;
+
+        public MappedA() {
+            this(0, null, 0);
+        }
+
+        public MappedA(int id, String commonField, int uniqueOnA) {
+            super(id, commonField);
+            this.uniqueOnA = uniqueOnA;
+        }
+
+        public int getUniqueOnA() {
+            return uniqueOnA;
+        }
+
+        public void setUniqueOnA(int uniqueOnA) {
+            this.uniqueOnA = uniqueOnA;
+        }
+    }
+}

--- a/src/integrationTest/java/com/mongodb/hibernate/query/select/InheritanceIntegrationTests.java
+++ b/src/integrationTest/java/com/mongodb/hibernate/query/select/InheritanceIntegrationTests.java
@@ -16,25 +16,55 @@
 
 package com.mongodb.hibernate.query.select;
 
+import com.mongodb.hibernate.junit.MongoServiceRegistryProducer;
 import com.mongodb.hibernate.query.AbstractQueryIntegrationTests;
+import jakarta.persistence.DiscriminatorColumn;
+import jakarta.persistence.DiscriminatorType;
+import jakarta.persistence.DiscriminatorValue;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.InheritanceType;
 import jakarta.persistence.MappedSuperclass;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
+import org.hibernate.annotations.DiscriminatorOptions;
 import org.hibernate.testing.orm.junit.DomainModel;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-@DomainModel(annotatedClasses = {InheritanceIntegrationTests.MappedA.class})
+@DomainModel(
+        annotatedClasses = {
+            InheritanceIntegrationTests.MappedA.class,
+            InheritanceIntegrationTests.SingleIntA.class,
+            InheritanceIntegrationTests.SingleIntB.class,
+            InheritanceIntegrationTests.SingleCharA.class,
+            InheritanceIntegrationTests.SingleCharB.class,
+            InheritanceIntegrationTests.SingleStrA.class,
+            InheritanceIntegrationTests.SingleStrB.class
+        })
 public class InheritanceIntegrationTests extends AbstractQueryIntegrationTests {
     static final List<MappedA> MAPPED_A = List.of(new MappedA(1, "A", 65), new MappedA(2, "B", 66));
+    static final SingleCharA SINGLE_CHAR_A = new SingleCharA(1, "A", 65);
+    static final SingleCharB SINGLE_CHAR_B = new SingleCharB(2, "B", 66);
+    static final SingleIntA SINGLE_INT_A = new SingleIntA(1, "A", 65);
+    static final SingleIntB SINGLE_INT_B = new SingleIntB(2, "B", 66);
+    static final SingleStrA SINGLE_STR_A = new SingleStrA(1, "A", 65);
+    static final SingleStrB SINGLE_STR_B = new SingleStrB(2, "B", 66);
 
     @BeforeEach
     void beforeEach() {
 
         getSessionFactoryScope().inTransaction(session -> {
             MAPPED_A.forEach(session::persist);
+            session.persist(SINGLE_CHAR_A);
+            session.persist(SINGLE_CHAR_B);
+            session.persist(SINGLE_INT_A);
+            session.persist(SINGLE_INT_B);
+            session.persist(SINGLE_STR_A);
+            session.persist(SINGLE_STR_B);
         });
         getTestCommandListener().clear();
     }
@@ -57,13 +87,156 @@ public class InheritanceIntegrationTests extends AbstractQueryIntegrationTests {
                       "$project": {
                         "_id": true,
                         "commonField": true,
-                        "uniqueOnA": true,
+                        "uniqueOnA": true
                       }
                     }
                   ]
                 }""",
                 MAPPED_A,
                 Set.of("MappedA"));
+    }
+
+    @Nested
+    class SingleInheritanceTests implements MongoServiceRegistryProducer {
+
+        @Test
+        void testReadSingleChar() {
+            assertSelectionQuery(
+                    "from SingleCharA",
+                    SingleCharA.class,
+                    """
+                    {
+                      "aggregate": "SingleChar",
+                      "pipeline": [
+                        {
+                          "$match": {
+                            "dtype": {"$eq": "a"}
+                          }
+                        },
+                        {
+                          "$project": {
+                            "_id": true,
+                            "commonField": true,
+                            "uniqueOnA": true
+                          }
+                        }
+                      ]
+                    }""",
+                    List.of(SINGLE_CHAR_A),
+                    Set.of("SingleChar"));
+        }
+
+        @Test
+        void testReadSingleCharSuper() {
+            assertSelectionQuery(
+                    "from SingleChar",
+                    SingleCharSuper.class,
+                    """
+                    {
+                      "aggregate": "SingleChar",
+                      "pipeline": [
+                        {
+                          "$match": {
+                            "dtype": {"$in": ["a", "b"]}
+                          }
+                        },
+                        {
+                          "$project": {
+                            "_id": true,
+                            "dtype": true,
+                            "commonField": true,
+                            "uniqueOnA": true,
+                            "uniqueOnB": true
+                          }
+                        }
+                      ]
+                    }""",
+                    List.of(SINGLE_CHAR_A, SINGLE_CHAR_B),
+                    Set.of("SingleChar"));
+        }
+
+        @Test
+        void testReadSingleStr() {
+            assertSelectionQuery(
+                    "from SingleStrA",
+                    SingleStrA.class,
+                    """
+                    {
+                      "aggregate": "SingleStr",
+                      "pipeline": [
+                        {
+                          "$match": {
+                            "dtype": {"$eq": "a'a"}
+                          }
+                        },
+                        {
+                          "$project": {
+                            "_id": true,
+                            "commonField": true,
+                            "uniqueOnA": true
+                          }
+                        }
+                      ]
+                    }""",
+                    List.of(SINGLE_STR_A),
+                    Set.of("SingleStr"));
+        }
+
+        @Test
+        void testReadSingleStrSuper() {
+            assertSelectionQuery(
+                    "from SingleStr",
+                    SingleStrSuper.class,
+                    """
+                    {
+                      "aggregate": "SingleStr",
+                      "pipeline": [
+                        {
+                          "$match": {
+                            "dtype": {"$in": ["a'a", "b"]}
+                          }
+                        },
+                        {
+                          "$project": {
+                            "_id": true,
+                            "dtype": true,
+                            "commonField": true,
+                            "uniqueOnA": true,
+                            "uniqueOnB": true
+                          }
+                        }
+                      ]
+                    }""",
+                    List.of(SINGLE_STR_A, SINGLE_STR_B),
+                    Set.of("SingleStr"));
+        }
+
+        @Test
+        void testReadSingleInt() {
+            assertSelectionQuery(
+                    "from SingleIntA",
+                    SingleIntA.class,
+                    """
+                    {
+                      "aggregate": "SingleInt",
+                      "pipeline": [
+                        {
+                          "$match": {
+                            "dtype": {"$eq": 1}
+                          }
+                        },
+                        {
+                          "$project": {
+                            "_id": true,
+                            "commonField": true,
+                            "uniqueOnA": true
+                          }
+                        }
+                      ]
+                    }""",
+                    List.of(SINGLE_INT_A),
+                    Set.of("SingleInt"));
+        }
     }
 
     @MappedSuperclass
@@ -108,12 +281,403 @@ public class InheritanceIntegrationTests extends AbstractQueryIntegrationTests {
             this.uniqueOnA = uniqueOnA;
         }
 
+        @Override
+        public boolean equals(Object o) {
+            if (o == null || getClass() != o.getClass()) return false;
+            MappedA mappedA = (MappedA) o;
+            return uniqueOnA == mappedA.uniqueOnA;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(uniqueOnA);
+        }
+
         public int getUniqueOnA() {
             return uniqueOnA;
         }
 
         public void setUniqueOnA(int uniqueOnA) {
             this.uniqueOnA = uniqueOnA;
+        }
+    }
+
+    @Entity(name = "SingleChar")
+    @Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+    @DiscriminatorColumn(name = "dtype", discriminatorType = DiscriminatorType.CHAR)
+    @DiscriminatorOptions(force = true, insert = true)
+    @DiscriminatorValue("z")
+    abstract static class SingleCharSuper {
+        @Id
+        int id;
+
+        String commonField;
+
+        public SingleCharSuper(int id, String commonField) {
+            this.id = id;
+            this.commonField = commonField;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (o == null || getClass() != o.getClass()) return false;
+            SingleCharSuper that = (SingleCharSuper) o;
+            return id == that.id && Objects.equals(commonField, that.commonField);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(id, commonField);
+        }
+
+        public String getCommonField() {
+            return commonField;
+        }
+
+        public void setCommonField(String commonField) {
+            this.commonField = commonField;
+        }
+
+        public int getId() {
+            return id;
+        }
+
+        public void setId(int id) {
+            this.id = id;
+        }
+    }
+
+    @Entity(name = "SingleCharA")
+    @DiscriminatorValue("a")
+    static class SingleCharA extends SingleCharSuper {
+        int uniqueOnA;
+
+        public SingleCharA() {
+            this(0, null, 0);
+        }
+
+        public SingleCharA(int id, String commonField, int uniqueOnA) {
+            super(id, commonField);
+            this.uniqueOnA = uniqueOnA;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (o == null || getClass() != o.getClass()) return false;
+            if (!super.equals(o)) return false;
+            SingleCharA singleCharA = (SingleCharA) o;
+            return uniqueOnA == singleCharA.uniqueOnA;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(super.hashCode(), uniqueOnA);
+        }
+
+        public int getUniqueOnA() {
+            return uniqueOnA;
+        }
+
+        public void setUniqueOnA(int uniqueOnA) {
+            this.uniqueOnA = uniqueOnA;
+        }
+
+        @Override
+        public String toString() {
+            return "SingleA{" + "uniqueOnA=" + uniqueOnA + ", id=" + id + ", commonField='" + commonField + '\'' + '}';
+        }
+    }
+
+    @Entity(name = "SingleCharB")
+    @DiscriminatorValue("b")
+    static class SingleCharB extends SingleCharSuper {
+        int uniqueOnB;
+
+        public SingleCharB() {
+            this(0, null, 0);
+        }
+
+        public SingleCharB(int id, String commonField, int uniqueOnB) {
+            super(id, commonField);
+            this.uniqueOnB = uniqueOnB;
+        }
+
+        public int getUniqueOnB() {
+            return uniqueOnB;
+        }
+
+        public void setUniqueOnB(int uniqueOnB) {
+            this.uniqueOnB = uniqueOnB;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (o == null || getClass() != o.getClass()) return false;
+            if (!super.equals(o)) return false;
+            SingleCharB singleCharB = (SingleCharB) o;
+            return uniqueOnB == singleCharB.uniqueOnB;
+        }
+
+        @Override
+        public String toString() {
+            return "SingleB{" + "uniqueOnB=" + uniqueOnB + ", id=" + id + ", commonField='" + commonField + '\'' + '}';
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(super.hashCode(), uniqueOnB);
+        }
+    }
+
+    @Entity(name = "SingleInt")
+    @Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+    @DiscriminatorColumn(name = "dtype", discriminatorType = DiscriminatorType.INTEGER)
+    @DiscriminatorOptions(force = true, insert = true)
+    abstract static class SingleIntSuper {
+        @Id
+        int id;
+
+        String commonField;
+
+        public SingleIntSuper(int id, String commonField) {
+            this.id = id;
+            this.commonField = commonField;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (o == null || getClass() != o.getClass()) return false;
+            SingleIntSuper that = (SingleIntSuper) o;
+            return id == that.id && Objects.equals(commonField, that.commonField);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(id, commonField);
+        }
+
+        public String getCommonField() {
+            return commonField;
+        }
+
+        public void setCommonField(String commonField) {
+            this.commonField = commonField;
+        }
+
+        public int getId() {
+            return id;
+        }
+
+        public void setId(int id) {
+            this.id = id;
+        }
+    }
+
+    @Entity(name = "SingleIntA")
+    @DiscriminatorValue("1")
+    static class SingleIntA extends SingleIntSuper {
+        int uniqueOnA;
+
+        public SingleIntA() {
+            this(0, null, 0);
+        }
+
+        public SingleIntA(int id, String commonField, int uniqueOnA) {
+            super(id, commonField);
+            this.uniqueOnA = uniqueOnA;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (o == null || getClass() != o.getClass()) return false;
+            if (!super.equals(o)) return false;
+            SingleIntA singleIntA = (SingleIntA) o;
+            return uniqueOnA == singleIntA.uniqueOnA;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(super.hashCode(), uniqueOnA);
+        }
+
+        public int getUniqueOnA() {
+            return uniqueOnA;
+        }
+
+        public void setUniqueOnA(int uniqueOnA) {
+            this.uniqueOnA = uniqueOnA;
+        }
+
+        @Override
+        public String toString() {
+            return "SingleA{" + "uniqueOnA=" + uniqueOnA + ", id=" + id + ", commonField='" + commonField + '\'' + '}';
+        }
+    }
+
+    @Entity(name = "SingleIntB")
+    @DiscriminatorValue("2")
+    static class SingleIntB extends SingleIntSuper {
+        int uniqueOnB;
+
+        public SingleIntB() {
+            this(0, null, 0);
+        }
+
+        public SingleIntB(int id, String commonField, int uniqueOnB) {
+            super(id, commonField);
+            this.uniqueOnB = uniqueOnB;
+        }
+
+        public int getUniqueOnB() {
+            return uniqueOnB;
+        }
+
+        public void setUniqueOnB(int uniqueOnB) {
+            this.uniqueOnB = uniqueOnB;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (o == null || getClass() != o.getClass()) return false;
+            if (!super.equals(o)) return false;
+            SingleIntB singleIntB = (SingleIntB) o;
+            return uniqueOnB == singleIntB.uniqueOnB;
+        }
+
+        @Override
+        public String toString() {
+            return "SingleB{" + "uniqueOnB=" + uniqueOnB + ", id=" + id + ", commonField='" + commonField + '\'' + '}';
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(super.hashCode(), uniqueOnB);
+        }
+    }
+
+    @Entity(name = "SingleStr")
+    @Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+    @DiscriminatorColumn(name = "dtype")
+    @DiscriminatorOptions(force = true, insert = true)
+    abstract static class SingleStrSuper {
+        @Id
+        int id;
+
+        String commonField;
+
+        public SingleStrSuper(int id, String commonField) {
+            this.id = id;
+            this.commonField = commonField;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (o == null || getClass() != o.getClass()) return false;
+            SingleStrSuper that = (SingleStrSuper) o;
+            return id == that.id && Objects.equals(commonField, that.commonField);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(id, commonField);
+        }
+
+        public String getCommonField() {
+            return commonField;
+        }
+
+        public void setCommonField(String commonField) {
+            this.commonField = commonField;
+        }
+
+        public int getId() {
+            return id;
+        }
+
+        public void setId(int id) {
+            this.id = id;
+        }
+    }
+
+    @Entity(name = "SingleStrA")
+    @DiscriminatorValue("a'a")
+    static class SingleStrA extends SingleStrSuper {
+        int uniqueOnA;
+
+        public SingleStrA() {
+            this(0, null, 0);
+        }
+
+        public SingleStrA(int id, String commonField, int uniqueOnA) {
+            super(id, commonField);
+            this.uniqueOnA = uniqueOnA;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (o == null || getClass() != o.getClass()) return false;
+            if (!super.equals(o)) return false;
+            SingleStrA singleStrA = (SingleStrA) o;
+            return uniqueOnA == singleStrA.uniqueOnA;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(super.hashCode(), uniqueOnA);
+        }
+
+        public int getUniqueOnA() {
+            return uniqueOnA;
+        }
+
+        public void setUniqueOnA(int uniqueOnA) {
+            this.uniqueOnA = uniqueOnA;
+        }
+
+        @Override
+        public String toString() {
+            return "SingleA{" + "uniqueOnA=" + uniqueOnA + ", id=" + id + ", commonField='" + commonField + '\'' + '}';
+        }
+    }
+
+    @Entity(name = "SingleStrB")
+    @DiscriminatorValue("b")
+    static class SingleStrB extends SingleStrSuper {
+        int uniqueOnB;
+
+        public SingleStrB() {
+            this(0, null, 0);
+        }
+
+        public SingleStrB(int id, String commonField, int uniqueOnB) {
+            super(id, commonField);
+            this.uniqueOnB = uniqueOnB;
+        }
+
+        public int getUniqueOnB() {
+            return uniqueOnB;
+        }
+
+        public void setUniqueOnB(int uniqueOnB) {
+            this.uniqueOnB = uniqueOnB;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (o == null || getClass() != o.getClass()) return false;
+            if (!super.equals(o)) return false;
+            SingleStrB singleStrB = (SingleStrB) o;
+            return uniqueOnB == singleStrB.uniqueOnB;
+        }
+
+        @Override
+        public String toString() {
+            return "SingleB{" + "uniqueOnB=" + uniqueOnB + ", id=" + id + ", commonField='" + commonField + '\'' + '}';
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(super.hashCode(), uniqueOnB);
         }
     }
 }

--- a/src/integrationTest/java/com/mongodb/hibernate/type/JdbcTypeCodeIntegrationTests.java
+++ b/src/integrationTest/java/com/mongodb/hibernate/type/JdbcTypeCodeIntegrationTests.java
@@ -113,6 +113,6 @@ class JdbcTypeCodeIntegrationTests {
         assertThatThrownBy(() ->
                         new MetadataSources().addAnnotatedClass(entityClass).buildMetadata())
                 .isInstanceOf(FeatureNotSupportedException.class)
-                .hasMessageContaining("@JdbcTypeCode is not supported");
+                .hasMessageContaining("Annotation org.hibernate.annotations.JdbcTypeCode is forbidden");
     }
 }

--- a/src/main/java/com/mongodb/hibernate/internal/boot/ClassElementChecker.java
+++ b/src/main/java/com/mongodb/hibernate/internal/boot/ClassElementChecker.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2026-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.hibernate.internal.boot;
+
+import com.mongodb.hibernate.internal.FeatureNotSupportedException;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.hibernate.annotations.CurrentTimestamp;
+import org.hibernate.annotations.SourceType;
+import org.hibernate.mapping.Component;
+import org.hibernate.mapping.PersistentClass;
+import org.hibernate.mapping.Property;
+
+/** Visits all declare fields and classes in a class hierarchy. */
+public interface ClassElementChecker {
+    ClassElementChecker CURRENT_TIMESTAMP_WITH_DB_SOURCE = new ClassElementChecker() {
+        @Override
+        public boolean check(Field field) {
+            return checkAnnotation(field);
+        }
+
+        @Override
+        public boolean check(Method method) {
+            return checkAnnotation(method);
+        }
+
+        boolean checkAnnotation(AnnotatedElement object) {
+            final var annotation = object.getAnnotation(CurrentTimestamp.class);
+            return annotation != null && annotation.source() == SourceType.DB;
+        }
+
+        @Override
+        public String toString() {
+            return "Annotation @CurrentTimestamp(source=DB) is forbidden";
+        }
+    };
+
+    /**
+     * Visits all methods and fields in the class hierarchy for a particular derived class
+     *
+     * @param persistentClass the derived class to start visiting
+     * @param includeProperties also checks the component properties of the class
+     * @param checks the visitor to use
+     */
+    static void check(PersistentClass persistentClass, boolean includeProperties, ClassElementChecker... checks) {
+        check(persistentClass.getMappedClass(), checks);
+        if (includeProperties) {
+            for (final var property : persistentClass.getProperties()) {
+                check(property, checks);
+            }
+        }
+    }
+
+    /**
+     * Recursively visits all properties and checks classes on their components
+     *
+     * @param property the Hibernate property to check
+     * @param checks the properties to check
+     */
+    static void check(Property property, ClassElementChecker... checks) {
+        if (property.getValue() instanceof Component component) {
+            check(component.getComponentClass(), checks);
+            for (final var child : component.getProperties()) {
+                check(child, checks);
+            }
+        }
+    }
+
+    /**
+     * Visits all methods in the class hierarchy for a particular derived class
+     *
+     * @param clazz the derived class to start visiting
+     * @param checks the checks to apply to this code
+     */
+    static void check(Class<?> clazz, ClassElementChecker... checks) {
+        for (var c = clazz; c != null && c != Object.class; c = c.getSuperclass()) {
+            for (var field : c.getDeclaredFields()) {
+                for (final var check : checks) {
+                    if (check.check(field)) {
+                        throw new FeatureNotSupportedException("Field %s of class %s is not supported: %s"
+                                .formatted(
+                                        field.getName(),
+                                        field.getDeclaringClass().getCanonicalName(),
+                                        check));
+                    }
+                }
+            }
+            for (var method : c.getDeclaredMethods()) {
+                for (final var check : checks) {
+                    if (check.check(method)) {
+                        throw new FeatureNotSupportedException("Method %s %s(%s) of class %s is not supported: %s"
+                                .formatted(
+                                        method.getReturnType().getCanonicalName(),
+                                        method.getName(),
+                                        Stream.of(method.getParameterTypes())
+                                                .map(Class::getCanonicalName)
+                                                .collect(Collectors.joining(", ")),
+                                        method.getDeclaringClass().getCanonicalName(),
+                                        check));
+                    }
+                }
+            }
+        }
+    }
+
+    static ClassElementChecker forbid(Class<? extends Annotation> annotation) {
+        return new ClassElementChecker() {
+            @Override
+            public boolean check(Field field) {
+                return field.isAnnotationPresent(annotation);
+            }
+
+            @Override
+            public boolean check(Method method) {
+                return method.isAnnotationPresent(annotation);
+            }
+
+            @Override
+            public String toString() {
+                return "Annotation %s is forbidden".formatted(annotation.getCanonicalName());
+            }
+        };
+    }
+
+    /**
+     * Checks a class's field
+     *
+     * @param field the field definition to check
+     * @return true if this element is forbidden
+     */
+    boolean check(Field field);
+
+    /**
+     * Checks a class's method
+     *
+     * @param method the method definition to check
+     * @return true if this element is forbidden
+     */
+    boolean check(Method method);
+}

--- a/src/main/java/com/mongodb/hibernate/internal/boot/MongoAdditionalMappingContributor.java
+++ b/src/main/java/com/mongodb/hibernate/internal/boot/MongoAdditionalMappingContributor.java
@@ -27,7 +27,7 @@ import com.mongodb.hibernate.internal.FeatureNotSupportedException;
 import com.mongodb.hibernate.internal.dialect.MongoDialect;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
-import java.lang.reflect.AnnotatedElement;
+import jakarta.persistence.GeneratedValue;
 import java.sql.Time;
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
@@ -54,6 +54,8 @@ import org.bson.types.Decimal128;
 import org.bson.types.MaxKey;
 import org.bson.types.MinKey;
 import org.bson.types.Symbol;
+import org.hibernate.annotations.Generated;
+import org.hibernate.annotations.GeneratedColumn;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.annotations.Struct;
 import org.hibernate.boot.Metadata;
@@ -140,6 +142,7 @@ public final class MongoAdditionalMappingContributor implements AdditionalMappin
             checkColumnNames(persistentClass);
             forbidStructIdentifier(persistentClass);
             forbidJdbcTypeCodeAnnotation(persistentClass);
+            forbidColumnFragmentAnnotations(persistentClass);
             setIdentifierColumnName(persistentClass);
         });
     }
@@ -182,37 +185,7 @@ public final class MongoAdditionalMappingContributor implements AdditionalMappin
 
     /** Forbid usage of {@link JdbcTypeCode} annotation. */
     private static void forbidJdbcTypeCodeAnnotation(PersistentClass persistentClass) {
-        forbidJdbcTypeCodeAnnotationOnClass(persistentClass, persistentClass.getMappedClass());
-        forbidJdbcTypeCodeAnnotationOnProperties(persistentClass, persistentClass.getProperties());
-    }
-
-    private static void forbidJdbcTypeCodeAnnotationOnProperties(
-            PersistentClass persistentClass, java.util.List<Property> properties) {
-        properties.forEach(property -> {
-            if (property.getValue() instanceof Component component) {
-                forbidJdbcTypeCodeAnnotationOnClass(persistentClass, component.getComponentClass());
-                forbidJdbcTypeCodeAnnotationOnProperties(persistentClass, component.getProperties());
-            }
-        });
-    }
-
-    /** Forbid usage of {@link JdbcTypeCode} annotation on the given class and its superclasses. */
-    private static void forbidJdbcTypeCodeAnnotationOnClass(PersistentClass persistentClass, Class<?> clazz) {
-        for (var c = clazz; c != null && c != Object.class; c = c.getSuperclass()) {
-            for (var field : c.getDeclaredFields()) {
-                forbidJdbcTypeCodeAnnotationOnElement(persistentClass, field);
-            }
-            for (var method : c.getDeclaredMethods()) {
-                forbidJdbcTypeCodeAnnotationOnElement(persistentClass, method);
-            }
-        }
-    }
-
-    private static void forbidJdbcTypeCodeAnnotationOnElement(
-            PersistentClass persistentClass, AnnotatedElement element) {
-        if (element.isAnnotationPresent(JdbcTypeCode.class)) {
-            throw new FeatureNotSupportedException(format("%s: @JdbcTypeCode is not supported", persistentClass));
-        }
+        ClassElementChecker.check(persistentClass, true, ClassElementChecker.forbid(JdbcTypeCode.class));
     }
 
     private static void forbidEmbeddablesWithoutPersistentAttributes(InFlightMetadataCollector metadata) {
@@ -222,6 +195,20 @@ public final class MongoAdditionalMappingContributor implements AdditionalMappin
                         format("%s: must have at least one persistent attribute", component));
             }
         });
+    }
+
+    /**
+     * Forbid usage of {@link org.hibernate.annotations.Generated} and
+     * {@link org.hibernate.annotations.CurrentTimestamp} annotations.
+     */
+    private static void forbidColumnFragmentAnnotations(PersistentClass persistentClass) {
+        ClassElementChecker.check(
+                persistentClass,
+                false,
+                ClassElementChecker.forbid(Generated.class),
+                ClassElementChecker.forbid(GeneratedColumn.class),
+                ClassElementChecker.forbid(GeneratedValue.class),
+                ClassElementChecker.CURRENT_TIMESTAMP_WITH_DB_SOURCE);
     }
 
     private static void checkPropertyType(

--- a/src/main/java/com/mongodb/hibernate/internal/translate/AbstractMqlTranslator.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/AbstractMqlTranslator.java
@@ -100,7 +100,10 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.regex.Pattern;
+import org.bson.BsonInt32;
 import org.bson.BsonNull;
+import org.bson.BsonString;
 import org.bson.BsonValue;
 import org.bson.json.JsonWriter;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
@@ -231,6 +234,8 @@ public abstract class AbstractMqlTranslator<T extends JdbcOperation> implements 
     // '#' is blocked in mapped field names, so prefixing join aliases with it prevents $lookup from shadowing
     // a local field that happens to share the Hibernate-generated alias name (e.g. "o1_0").
     private static final String JOIN_ALIAS_PREFIX = "#";
+    // Match a quoted SQL string with the contents of the string being in match group 1
+    private static final Pattern SQL_STRING = Pattern.compile("^'((?:''|[^'])*)'$");
 
     private final SessionFactoryImplementor sessionFactory;
 
@@ -349,11 +354,34 @@ public abstract class AbstractMqlTranslator<T extends JdbcOperation> implements 
 
     @Override
     public void visitColumnWriteFragment(ColumnWriteFragment columnWriteFragment) {
-        if (!columnWriteFragment.getFragment().equals("?")) {
-            throw new FeatureNotSupportedException(
-                    "@CurrentTimestamp(source=DB), @Generated, and @ColumnTransformer write expressions are not supported");
+        switch (columnWriteFragment.getParameters().size()) {
+            case 0 -> {
+                // Hibernate inheritance discriminators should be string/char or integer. It is possible that other
+                // fragments are generated with other types through other code paths (_e.g._, @Generated).
+                var matcher = SQL_STRING.matcher(columnWriteFragment.getFragment());
+                BsonValue result;
+                if (matcher.matches()) {
+                    result = new BsonString(matcher.group(1).replace("''", "'"));
+                } else {
+                    try {
+                        result = new BsonInt32(Integer.parseInt(columnWriteFragment.getFragment()));
+                    } catch (NumberFormatException e) {
+                        throw new FeatureNotSupportedException(
+                                "Cannot translate fragment %s into MQL. Expecting string or integer literal."
+                                        .formatted(columnWriteFragment.getFragment()));
+                    }
+                }
+                astVisitorValueHolder.yield(VALUE, new AstLiteral(result));
+            }
+            case 1 -> {
+                if (columnWriteFragment.getFragment().equals("?")) {
+                    columnWriteFragment.getParameters().iterator().next().accept(this);
+                } else {
+                    throw new FeatureNotSupportedException("@ColumnTransformer expressions are not supported");
+                }
+            }
+            default -> throw fail("unexpected multi-parameter discriminator write fragment: " + columnWriteFragment);
         }
-        columnWriteFragment.getParameters().iterator().next().accept(this);
     }
 
     @Override

--- a/src/test/java/com/mongodb/hibernate/boot/ClassElementCheckerTests.java
+++ b/src/test/java/com/mongodb/hibernate/boot/ClassElementCheckerTests.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2026-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.hibernate.boot;
+
+import com.mongodb.hibernate.internal.FeatureNotSupportedException;
+import com.mongodb.hibernate.internal.boot.ClassElementChecker;
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class ClassElementCheckerTests {
+
+    @Deprecated
+    String pointless;
+
+    @Test
+    void testMethodForbidden() {
+        Assertions.assertThrows(
+                FeatureNotSupportedException.class,
+                () -> ClassElementChecker.check(
+                        ClassElementCheckerTests.class, ClassElementChecker.forbid(Test.class)));
+    }
+
+    @Test
+    void testFieldForbidden() {
+        Assertions.assertThrows(
+                FeatureNotSupportedException.class,
+                () -> ClassElementChecker.check(
+                        ClassElementCheckerTests.class, ClassElementChecker.forbid(Deprecated.class)));
+    }
+
+    @Test
+    void testOk() {
+        ClassElementChecker.check(ClassElementCheckerTests.class, ClassElementChecker.forbid(Nullable.class));
+    }
+}


### PR DESCRIPTION
- `MappedSuperclass`: This adds tests to ensure that the `@MappedSuperclass` inheritance type works. It required no additional modifications to work as it does not require any database behaviour to handle inheritance.
- Single-table:  Add support for inheritance hierarchies that use a single table for all subclasses.

Support for table-per-class and joined inheritance requires other features and will be delivered separately.
