### PR TITLE
HIBERNATE-128: Enable automatic release publishing and fix release workflow

### DIFF
--- a/.evergreen/publish.sh
+++ b/.evergreen/publish.sh
@@ -17,7 +17,7 @@ export ORG_GRADLE_PROJECT_signingKey="${SIGNING_KEY}"
 export ORG_GRADLE_PROJECT_signingPassword=${SIGNING_PASSWORD}
 
 if [ "$RELEASE" == "true" ]; then
-  TASK="publishArchives closeSonatypeStagingRepository" # TODO-HIBERNATE-128 - update to closeAndReleaseSonatypeStagingRepository
+  TASK="publishArchives closeAndReleaseSonatypeStagingRepository"
 else
   TASK="publishSnapshots"
 fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,7 +133,7 @@ jobs:
           gh release create "r${RELEASE_VERSION}" \
             ${PRERELEASE} \
             --target "$RELEASE_BRANCH" \
-            --title "Java Driver $RELEASE_VERSION ($(date '+%B %d, %Y'))" \
+            --title "MongoDB Extension for Hibernate ORM $RELEASE_VERSION ($(date '+%B %d, %Y'))" \
             --generate-notes \
             --draft\
           )" >> "$GITHUB_ENV"

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,6 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version=1.0.0-alpha1-SNAPSHOT
+version=1.0.0-SNAPSHOT
 
 org.gradle.jvmargs=-Duser.country=US -Duser.language=en -Dfile.encoding=UTF-8


### PR DESCRIPTION
Rounds out the release automation so the next alpha can be cut end-to-end.

- **Auto-publishing** — `publish.sh` now runs `closeAndReleaseSonatypeStagingRepository` instead of `closeSonatypeStagingRepository`, so a release publishes to Maven Central automatically rather than needing a manual release step.
- **Version convention** — `release.yml` assumes the dev snapshot in `gradle.properties` is `X.Y.Z-SNAPSHOT`, with the pre-release counter living only in the release input and git tag (same model as mongo-java-driver). It was `1.0.0-alpha1-SNAPSHOT`, which fails the snapshot-version check when releasing a pre-release. Changed to `1.0.0-SNAPSHOT`.
- **Release title** — the drafted GitHub release title was `Java Driver <version>` (copied from mongo-java-driver); corrected to `MongoDB Extension for Hibernate ORM <version>`.