### PR TITLE
HIBERNATE-151: Surface cause of boot-time metadata failure

### DIFF
--- a/src/main/java/com/mongodb/hibernate/internal/jdbc/MongoConnection.java
+++ b/src/main/java/com/mongodb/hibernate/internal/jdbc/MongoConnection.java
@@ -155,24 +155,20 @@ final class MongoConnection implements ConnectionAdapter {
     @Override
     public DatabaseMetaData getMetaData() throws SQLException {
         checkClosed();
-        try {
-            var commandResult = mongoClient
-                    .getDatabase("admin")
-                    .runCommand(clientSession, new BsonDocument("buildInfo", new BsonInt32(1)));
-            var versionText = commandResult.getString("version");
-            var versionArray = commandResult.getList("versionArray", Integer.class);
-            if (versionArray.size() < 2) {
-                throw new SQLException(
-                        format("Unexpected versionArray [%s] field length (should be 2 or more)", versionArray));
-            }
-            return new MongoDatabaseMetaData(this, versionText, versionArray.get(0), versionArray.get(1));
-        } catch (RuntimeException e) {
-            // TODO-HIBERNATE-43 Let's do `LOGGER.error(<message>, e)`.
-            // Hibernate ORM neither propagates, nor logs `e` (the cause of the `SQLException` we throw),
-            // so if we fail to get `DatabaseMetaData` due to being unable to connect to a MongoDB deployment,
-            // there is no easy way to know that.
-            throw new SQLException("Failed to get metadata", e);
+        // Runtime exceptions from the driver (e.g. a MongoTimeoutException when the deployment is unreachable) are
+        // deliberately left to propagate rather than being wrapped in a SQLException. When Hibernate ORM queries
+        // metadata on boot, its SQLException handling logs only the message and drops the cause, so wrapping would
+        // hide the real reason for a boot failure.
+        var commandResult = mongoClient
+                .getDatabase("admin")
+                .runCommand(clientSession, new BsonDocument("buildInfo", new BsonInt32(1)));
+        var versionText = commandResult.getString("version");
+        var versionArray = commandResult.getList("versionArray", Integer.class);
+        if (versionArray.size() < 2) {
+            throw new SQLException(
+                    format("Unexpected versionArray [%s] field length (should be 2 or more)", versionArray));
         }
+        return new MongoDatabaseMetaData(this, versionText, versionArray.get(0), versionArray.get(1));
     }
 
     @Override

--- a/src/test/java/com/mongodb/hibernate/internal/jdbc/MongoConnectionTests.java
+++ b/src/test/java/com/mongodb/hibernate/internal/jdbc/MongoConnectionTests.java
@@ -27,6 +27,7 @@ import static org.hibernate.cfg.AvailableSettings.JAKARTA_JDBC_URL;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -39,6 +40,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
+import com.mongodb.MongoTimeoutException;
 import com.mongodb.client.ClientSession;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoDatabase;
@@ -330,14 +332,16 @@ class MongoConnectionTests {
         }
 
         @Test
-        @DisplayName("SQLException is thrown when MongoConnection#getMetaData() failed while interacting with db")
-        void testSQLExceptionThrownWhenMetaDataFetchingFailed() {
+        @DisplayName("Driver runtime exception propagates as-is when getMetaData() fails interacting with db")
+        void testDriverRuntimeExceptionPropagatesWhenMetaDataFetchingFailed() {
             doReturn(mongoDatabase).when(mongoClient).getDatabase(eq("admin"));
-            doThrow(new RuntimeException())
-                    .when(mongoDatabase)
-                    .runCommand(any(ClientSession.class), argThat(arg -> "buildInfo"
-                            .equals(arg.toBsonDocument().getFirstKey())));
-            assertThrows(SQLException.class, () -> mongoConnection.getMetaData());
+            var failure = new MongoTimeoutException("connection timed out");
+            doThrow(failure).when(mongoDatabase).runCommand(any(ClientSession.class), argThat(arg -> "buildInfo"
+                    .equals(arg.toBsonDocument().getFirstKey())));
+
+            // The driver's exception must propagate as-is, not wrapped in a SQLException whose cause Hibernate drops.
+            var thrown = assertThrows(MongoTimeoutException.class, () -> mongoConnection.getMetaData());
+            assertSame(failure, thrown);
         }
     }
 


### PR DESCRIPTION
## Summary

When Hibernate ORM queries JDBC metadata on boot and the MongoDB deployment is unreachable, `MongoConnection.getMetaData()` wrapped the driver's failure in a `SQLException`. Hibernate's boot-time metadata handling logs only the *message* of a `SQLException` and drops its cause, so the boot failed with no explanation of *why* — the report (HIBERNATE-151) shows `RuntimeException: Could not instantiate [MongoDialect], see the earlier exceptions to find out why` with no earlier exception carrying the real cause.

The fix lets the driver's runtime exception (e.g. `MongoTimeoutException`) propagate as-is instead of wrapping it. A non-`SQLException` routes Hibernate to the code path that logs the throwable *with* its cause (`unableToObtainConnectionToQueryMetadata(@Cause ...)`), so the underlying reason (e.g. an unreachable host/port) is now visible in the logs.

## Behavior

- Default (`ALLOW`) boot against an unreachable server: the `HHH100046` WARN log now carries `Caused by: com.mongodb.MongoTimeoutException: ... <host:port>`.
- Boot without metadata access (`allow_jdbc_metadata_access=false` / `DISALLOW`) is unchanged — no connection is attempted, boot still succeeds. This preserves the "boot before the DB is reachable" workflow.
- No change to the healthy-boot path.

## Tests

Updated the existing `MongoConnection#getMetaData()` failure unit test to assert the driver's exception propagates as-is (`assertThrows(MongoTimeoutException.class, ...)` + `assertSame`) rather than being wrapped in a `SQLException`.

Testing Hibernate's own logging behavior is out of scope, but confirmed by manual inspection.

Closes HIBERNATE-151.