### PR TITLE
HIBERNATE-87: Support HQL string contatenation

### DIFF
--- a/src/integrationTest/java/com/mongodb/hibernate/query/function/string/StringFunctionIntegrationTests.java
+++ b/src/integrationTest/java/com/mongodb/hibernate/query/function/string/StringFunctionIntegrationTests.java
@@ -21,11 +21,12 @@ import com.mongodb.hibernate.query.AbstractQueryIntegrationTests;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import org.hibernate.query.sqm.produce.function.FunctionArgumentException;
 import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.SessionFactory;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -37,96 +38,451 @@ public class StringFunctionIntegrationTests extends AbstractQueryIntegrationTest
     private static final String COLLECTION_NAME = "items";
     private static final Item HELLO = new Item(1, " Hello ", "_Hello_");
 
-    private void assertQueryResult(String hql, Object expected) {
-        getSessionFactoryScope().inTransaction(session -> {
-            var selectionQuery = session.createSelectionQuery(hql, Object[].class);
-            var resultList = selectionQuery.getResultList();
-            Assertions.assertEquals(1, resultList.size());
-            Assertions.assertEquals(1, resultList.get(0).length);
-            Assertions.assertEquals(expected, resultList.get(0)[0]);
-        });
+    @SuppressWarnings("unchecked")
+    private <T> void assertQueryResult(String hql, T expected, String expectedMql) {
+        assertSelectionQuery(
+                hql, (Class<T>) expected.getClass(), expectedMql, List.of(expected), Set.of(COLLECTION_NAME));
     }
 
     @BeforeEach
     void beforeEach() {
-        getSessionFactoryScope().inTransaction(session -> {
-            session.persist(HELLO);
-        });
+        getSessionFactoryScope().inTransaction(session -> session.persist(HELLO));
     }
 
     @Test
     void testCharacterLength() {
-        assertQueryResult("select length(s) from Item", 7);
+        assertQueryResult(
+                "select length(s) from Item",
+                7,
+                """
+                {
+                  "aggregate": "items",
+                  "pipeline": [
+                    {
+                      "$project": {
+                        "#c_1": {
+                          "$strLenCP": "$s"
+                        }
+                      }
+                    }
+                  ]
+                }
+                """);
     }
 
     @Test
     void testConcat() {
-        assertQueryResult("select s||s from Item", " Hello  Hello ");
+        assertQueryResult(
+                "select s||s from Item",
+                " Hello  Hello ",
+                """
+                {
+                  "aggregate": "items",
+                  "pipeline": [
+                    {
+                      "$project": {
+                        "#c_1": {
+                          "$concat": [
+                            {
+                              "$toString": "$s"
+                            },
+                            {
+                              "$toString": "$s"
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  ]
+                }
+                """);
     }
 
     @Test
     void testConcatCoerce() {
-        assertQueryResult("select s||3 from Item", " Hello 3");
+        assertQueryResult(
+                "select s||3 from Item",
+                " Hello 3",
+                """
+                {
+                  "aggregate": "items",
+                  "pipeline": [
+                    {
+                      "$project": {
+                        "#c_1": {
+                          "$concat": [
+                            {
+                              "$toString": "$s"
+                            },
+                            {
+                              "$toString": 3
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  ]
+                }
+                """);
     }
 
     @Test
     void testConcatLiteral() {
-        assertQueryResult("select concat(s, '!') from Item", " Hello !");
+        assertQueryResult(
+                "select concat(s, '!') from Item",
+                " Hello !",
+                """
+                {
+                  "aggregate": "items",
+                  "pipeline": [
+                    {
+                      "$project": {
+                        "#c_1": {
+                          "$concat": [
+                            {
+                              "$toString": "$s"
+                            },
+                            {
+                              "$toString": "!"
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  ]
+                }
+                """);
     }
 
     @Test
     void testLocate() {
-        assertQueryResult("select locate('o', s) from Item", 6);
+        assertQueryResult(
+                "select locate('o', s) from Item",
+                6,
+                """
+                {
+                  "aggregate": "items",
+                  "pipeline": [
+                    {
+                      "$project": {
+                        "#c_1": {
+                          "$add": [
+                            {
+                              "$indexOfCP": [
+                                "$s",
+                                "o"
+                              ]
+                            },
+                            {
+                              "$literal": 1
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  ]
+                }
+                """);
     }
 
     @Test
     void testLocateMissing() {
-        assertQueryResult("select locate('z', s) from Item", 0);
+        assertQueryResult(
+                "select locate('z', s) from Item",
+                0,
+                """
+                {
+                  "aggregate": "items",
+                  "pipeline": [
+                    {
+                      "$project": {
+                        "#c_1": {
+                          "$add": [
+                            {
+                              "$indexOfCP": [
+                                "$s",
+                                "z"
+                              ]
+                            },
+                            {
+                              "$literal": 1
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  ]
+                }
+                """);
     }
 
     @Test
     void testLocateOffset() {
-        assertQueryResult("select locate('H', s, 1, 2) from Item", 2);
+        assertQueryResult(
+                "select locate('H', s, 1, 2) from Item",
+                2,
+                """
+                {
+                  "aggregate": "items",
+                  "pipeline": [
+                    {
+                      "$project": {
+                        "#c_1": {
+                          "$add": [
+                            {
+                              "$indexOfCP": [
+                                "$s",
+                                "H",
+                                {
+                                  "$subtract": [
+                                    1,
+                                    {
+                                      "$literal": 1
+                                    }
+                                  ]
+                                },
+                                {
+                                  "$add": [
+                                    {
+                                      "$subtract": [
+                                        1,
+                                        {
+                                          "$literal": 1
+                                        }
+                                      ]
+                                    },
+                                    2
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "$literal": 1
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  ]
+                }
+                """);
     }
 
     @Test
     void testLocateOffsetMissing() {
-        assertQueryResult("select locate('o', s, 1, 2) from Item", 0);
+        assertQueryResult(
+                "select locate('o', s, 1, 2) from Item",
+                0,
+                """
+                {
+                  "aggregate": "items",
+                  "pipeline": [
+                    {
+                      "$project": {
+                        "#c_1": {
+                          "$add": [
+                            {
+                              "$indexOfCP": [
+                                "$s",
+                                "o",
+                                {
+                                  "$subtract": [
+                                    1,
+                                    {
+                                      "$literal": 1
+                                    }
+                                  ]
+                                },
+                                {
+                                  "$add": [
+                                    {
+                                      "$subtract": [
+                                        1,
+                                        {
+                                          "$literal": 1
+                                        }
+                                      ]
+                                    },
+                                    2
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "$literal": 1
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  ]
+                }
+                """);
     }
 
     @Test
     void testLower() {
-        assertQueryResult("select lower(s) from Item", " hello ");
+        assertQueryResult(
+                "select lower(s) from Item",
+                " hello ",
+                """
+                {
+                  "aggregate": "items",
+                  "pipeline": [
+                    {
+                      "$project": {
+                        "#c_1": {
+                          "$toLower": "$s"
+                        }
+                      }
+                    }
+                  ]
+                }
+                """);
     }
 
     @Test
     void testLeftTrim() {
-        assertQueryResult("select ltrim(s) from Item", "Hello ");
+        assertQueryResult(
+                "select ltrim(s) from Item",
+                "Hello ",
+                """
+                {
+                  "aggregate": "items",
+                  "pipeline": [
+                    {
+                      "$project": {
+                        "#c_1": {
+                          "$ltrim": {
+                            "input": "$s"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+                """);
     }
 
     @Test
     void testLeftTrimChars() {
-        assertQueryResult("select ltrim(u, '_') from Item", "Hello_");
+        assertQueryResult(
+                "select ltrim(u, '_') from Item",
+                "Hello_",
+                """
+                {
+                  "aggregate": "items",
+                  "pipeline": [
+                    {
+                      "$project": {
+                        "#c_1": {
+                          "$ltrim": {
+                            "chars": "_",
+                            "input": "$u"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+                """);
     }
 
     @Test
     void testReplaceAll() {
-        assertQueryResult("select replace_all(s, ' ', '_') from Item", "_Hello_");
+        assertQueryResult(
+                "select replace_all(s, ' ', '_') from Item",
+                "_Hello_",
+                """
+                {
+                  "aggregate": "items",
+                  "pipeline": [
+                    {
+                      "$project": {
+                        "#c_1": {
+                          "$replaceAll": {
+                            "find": " ",
+                            "input": "$s",
+                            "replacement": "_"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+                """);
     }
 
     @Test
     void testReplaceOne() {
-        assertQueryResult("select replace_one(s, ' ', '_') from Item", "_Hello ");
+        assertQueryResult(
+                "select replace_one(s, ' ', '_') from Item",
+                "_Hello ",
+                """
+                {
+                  "aggregate": "items",
+                  "pipeline": [
+                    {
+                      "$project": {
+                        "#c_1": {
+                          "$replaceOne": {
+                            "find": " ",
+                            "input": "$s",
+                            "replacement": "_"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+                """);
     }
 
     @Test
     void testRightTrim() {
-        assertQueryResult("select rtrim(s) from Item", " Hello");
+        assertQueryResult(
+                "select rtrim(s) from Item",
+                " Hello",
+                """
+                {
+                  "aggregate": "items",
+                  "pipeline": [
+                    {
+                      "$project": {
+                        "#c_1": {
+                          "$rtrim": {
+                            "input": "$s"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+                """);
     }
 
     @Test
     void testRightTrimChars() {
-        assertQueryResult("select rtrim(u, '_') from Item", "_Hello");
+        assertQueryResult(
+                "select rtrim(u, '_') from Item",
+                "_Hello",
+                """
+                {
+                  "aggregate": "items",
+                  "pipeline": [
+                    {
+                      "$project": {
+                        "#c_1": {
+                          "$rtrim": {
+                            "chars": "_",
+                            "input": "$u"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+                """);
     }
 
     @Test
@@ -140,70 +496,257 @@ public class StringFunctionIntegrationTests extends AbstractQueryIntegrationTest
 
     @Test
     void testSubstring() {
-        assertQueryResult("select substring(s, 2) from Item", "Hello ");
+        assertQueryResult(
+                "select substring(s, 2) from Item",
+                "Hello ",
+                """
+                {
+                  "aggregate": "items",
+                  "pipeline": [
+                    {
+                      "$project": {
+                        "#c_1": {
+                          "$substrCP": [
+                            "$s",
+                            {
+                              "$subtract": [
+                                2,
+                                {
+                                  "$literal": 1
+                                }
+                              ]
+                            },
+                            {
+                              "$literal": 2147483647
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  ]
+                }
+                """);
     }
 
     @Test
     void testSubstringLen() {
-        assertQueryResult("select substring(s, 3, 2) from Item", "el");
+        assertQueryResult(
+                "select substring(s, 3, 2) from Item",
+                "el",
+                """
+                {
+                  "aggregate": "items",
+                  "pipeline": [
+                    {
+                      "$project": {
+                        "#c_1": {
+                          "$substrCP": [
+                            "$s",
+                            {
+                              "$subtract": [
+                                3,
+                                {
+                                  "$literal": 1
+                                }
+                              ]
+                            },
+                            2
+                          ]
+                        }
+                      }
+                    }
+                  ]
+                }
+                """);
     }
 
     @Test
     void testTrim() {
-        assertQueryResult("select trim(s) from Item", "Hello");
+        assertQueryResult(
+                "select trim(s) from Item",
+                "Hello",
+                """
+                {
+                  "aggregate": "items",
+                  "pipeline": [
+                    {
+                      "$project": {
+                        "#c_1": {
+                          "$trim": {
+                            "chars": " ",
+                            "input": "$s"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+                """);
     }
 
     @Test
     void testTrimLeading() {
-        assertQueryResult("select trim(leading from s) from Item", "Hello ");
+        assertQueryResult(
+                "select trim(leading from s) from Item",
+                "Hello ",
+                """
+                 {
+                   "aggregate": "items",
+                   "pipeline": [
+                     {
+                       "$project": {
+                         "#c_1": {
+                           "$ltrim": {
+                             "chars": " ",
+                             "input": "$s"
+                           }
+                         }
+                       }
+                     }
+                   ]
+                 }
+                """);
     }
 
     @Test
     void testTrimTrailing() {
-        assertQueryResult("select trim(trailing from s) from Item", " Hello");
+        assertQueryResult(
+                "select trim(trailing from s) from Item",
+                " Hello",
+                """
+                {
+                  "aggregate": "items",
+                  "pipeline": [
+                    {
+                      "$project": {
+                        "#c_1": {
+                          "$rtrim": {
+                            "chars": " ",
+                            "input": "$s"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+                """);
     }
 
     @Test
     void testTrimBoth() {
-        assertQueryResult("select trim(both from s) from Item", "Hello");
+        assertQueryResult(
+                "select trim(both from s) from Item",
+                "Hello",
+                """
+                {
+                    "aggregate": "items",
+                    "pipeline": [
+                        {
+                            "$project": {
+                                "#c_1": {
+                                    "$trim": {
+                                        "chars": " ",
+                                        "input": "$s"
+                                       }
+                                    }
+                                }
+                        }
+                    ]
+                }
+                """);
     }
 
     @Test
     void testTrimLeadingNonWS() {
-        assertQueryResult("select trim(leading '_' from u) from Item", "Hello_");
+        assertQueryResult(
+                "select trim(leading '_' from u) from Item",
+                "Hello_",
+                """
+                {
+                  "aggregate": "items",
+                  "pipeline": [
+                    {
+                      "$project": {
+                        "#c_1": {
+                          "$ltrim": {
+                            "chars": "_",
+                            "input": "$u"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+                """);
     }
 
     @Test
     void testTrimTrailingNonWS() {
-        assertQueryResult("select trim(trailing '_' from u) from Item", "_Hello");
+        assertQueryResult(
+                "select trim(trailing '_' from u) from Item",
+                "_Hello",
+                """
+                {
+                  "aggregate": "items",
+                  "pipeline": [
+                    {
+                      "$project": {
+                        "#c_1": {
+                          "$rtrim": {
+                            "chars": "_",
+                            "input": "$u"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+                """);
     }
 
     @Test
     void testTrimBothNonWS() {
-        assertQueryResult("select trim(both '_' from u) from Item", "Hello");
+        assertQueryResult(
+                "select trim(both '_' from u) from Item",
+                "Hello",
+                """
+                {
+                  "aggregate": "items",
+                  "pipeline": [
+                    {
+                      "$project": {
+                        "#c_1": {
+                          "$trim": {
+                            "chars": "_",
+                            "input": "$u"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+                """);
     }
 
     @Test
     void testUpper() {
-        assertQueryResult("select upper(s) from Item", " HELLO ");
-    }
-
-    @Test
-    void testSubstringWrongType() {
-        assertSelectQueryFailure(
-                "select substring(3, s) from Item",
-                String.class,
-                FunctionArgumentException.class,
-                "Parameter 1 of function 'substring()' has type 'STRING', but argument is of type 'java.lang.Integer' mapped to 'INTEGER'");
-    }
-
-    @Test
-    void testUpperWrongType() {
-        assertSelectQueryFailure(
-                "select upper(3) from Item",
-                String.class,
-                FunctionArgumentException.class,
-                "Parameter 1 of function 'upper()' has type 'STRING', but argument is of type 'java.lang.Integer' mapped to 'INTEGER'");
+        assertQueryResult(
+                "select upper(s) from Item",
+                " HELLO ",
+                """
+                {
+                  "aggregate": "items",
+                  "pipeline": [
+                    {
+                      "$project": {
+                        "#c_1": {
+                          "$toUpper": "$s"
+                        }
+                      }
+                    }
+                  ]
+                }
+                """);
     }
 
     @Entity(name = "Item")

--- a/src/integrationTest/java/com/mongodb/hibernate/query/function/string/StringFunctionIntegrationTests.java
+++ b/src/integrationTest/java/com/mongodb/hibernate/query/function/string/StringFunctionIntegrationTests.java
@@ -185,6 +185,45 @@ public class StringFunctionIntegrationTests extends AbstractQueryIntegrationTest
     }
 
     @Test
+    void testLocateWithStart() {
+        assertQueryResult(
+                "select locate(' ', s, 4) from Item",
+                7,
+                """
+                        {
+                          "aggregate": "items",
+                          "pipeline": [
+                            {
+                              "$project": {
+                                "#c_1": {
+                                  "$add": [
+                                    {
+                                      "$indexOfCP": [
+                                        "$s",
+                                        " ",
+                                        {
+                                          "$subtract": [
+                                            4,
+                                            {
+                                              "$literal": 1
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "$literal": 1
+                                    }
+                                  ]
+                                }
+                              }
+                            }
+                          ]
+                        }
+                """);
+    }
+
+    @Test
     void testLocateMissing() {
         assertQueryResult(
                 "select locate('z', s) from Item",
@@ -201,110 +240,6 @@ public class StringFunctionIntegrationTests extends AbstractQueryIntegrationTest
                               "$indexOfCP": [
                                 "$s",
                                 "z"
-                              ]
-                            },
-                            {
-                              "$literal": 1
-                            }
-                          ]
-                        }
-                      }
-                    }
-                  ]
-                }
-                """);
-    }
-
-    @Test
-    void testLocateOffset() {
-        assertQueryResult(
-                "select locate('H', s, 1, 2) from Item",
-                2,
-                """
-                {
-                  "aggregate": "items",
-                  "pipeline": [
-                    {
-                      "$project": {
-                        "#c_1": {
-                          "$add": [
-                            {
-                              "$indexOfCP": [
-                                "$s",
-                                "H",
-                                {
-                                  "$subtract": [
-                                    1,
-                                    {
-                                      "$literal": 1
-                                    }
-                                  ]
-                                },
-                                {
-                                  "$add": [
-                                    {
-                                      "$subtract": [
-                                        1,
-                                        {
-                                          "$literal": 1
-                                        }
-                                      ]
-                                    },
-                                    2
-                                  ]
-                                }
-                              ]
-                            },
-                            {
-                              "$literal": 1
-                            }
-                          ]
-                        }
-                      }
-                    }
-                  ]
-                }
-                """);
-    }
-
-    @Test
-    void testLocateOffsetMissing() {
-        assertQueryResult(
-                "select locate('o', s, 1, 2) from Item",
-                0,
-                """
-                {
-                  "aggregate": "items",
-                  "pipeline": [
-                    {
-                      "$project": {
-                        "#c_1": {
-                          "$add": [
-                            {
-                              "$indexOfCP": [
-                                "$s",
-                                "o",
-                                {
-                                  "$subtract": [
-                                    1,
-                                    {
-                                      "$literal": 1
-                                    }
-                                  ]
-                                },
-                                {
-                                  "$add": [
-                                    {
-                                      "$subtract": [
-                                        1,
-                                        {
-                                          "$literal": 1
-                                        }
-                                      ]
-                                    },
-                                    2
-                                  ]
-                                }
                               ]
                             },
                             {
@@ -401,44 +336,114 @@ public class StringFunctionIntegrationTests extends AbstractQueryIntegrationTest
                                 "#c_1": {
                                   "$let": {
                                     "in": {
-                                      "$reduce": {
-                                        "in": {
-                                          "$concat": [
-                                            "$$padding",
-                                            "$$value"
-                                          ]
-                                        },
-                                        "initialValue": "$$baseStr",
-                                        "input": {
-                                          "$range": [
+                                      "$cond": [
+                                        {
+                                          "$lte": [
+                                            "$$targetLen",
                                             {
                                               "$literal": 0
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "$literal": ""
+                                        },
+                                        {
+                                          "$cond": [
+                                            {
+                                              "$or": [
+                                                {
+                                                  "$gte": [
+                                                    {
+                                                      "$strLenCP": "$$baseStr"
+                                                    },
+                                                    "$$targetLen"
+                                                  ]
+                                                },
+                                                {
+                                                  "$eq": [
+                                                    {
+                                                      "$strLenCP": "$$padding"
+                                                    },
+                                                    {
+                                                      "$literal": 0
+                                                    }
+                                                  ]
+                                                }
+                                              ]
                                             },
                                             {
-                                              "$floor": {
-                                                "$divide": [
-                                                  {
-                                                    "$subtract": [
-                                                      "$$targetLen",
-                                                      {
-                                                        "$strLenCP": "$$baseStr"
+                                              "$substrCP": [
+                                                "$$baseStr",
+                                                {
+                                                  "$literal": 0
+                                                },
+                                                "$$targetLen"
+                                              ]
+                                            },
+                                            {
+                                              "$concat": [
+                                                {
+                                                  "$substrCP": [
+                                                    {
+                                                      "$reduce": {
+                                                        "in": {
+                                                          "$concat": [
+                                                            "$$padding",
+                                                            "$$value"
+                                                          ]
+                                                        },
+                                                        "initialValue": {
+                                                          "$literal": ""
+                                                        },
+                                                        "input": {
+                                                          "$range": [
+                                                            {
+                                                              "$literal": 0
+                                                            },
+                                                            {
+                                                              "$ceil": {
+                                                                "$divide": [
+                                                                  {
+                                                                    "$subtract": [
+                                                                      "$$targetLen",
+                                                                      {
+                                                                        "$strLenCP": "$$baseStr"
+                                                                      }
+                                                                    ]
+                                                                  },
+                                                                  {
+                                                                    "$strLenCP": "$$padding"
+                                                                  }
+                                                                ]
+                                                              }
+                                                            }
+                                                          ]
+                                                        }
                                                       }
-                                                    ]
-                                                  },
-                                                  {
-                                                    "$strLenCP": "$$padding"
-                                                  }
-                                                ]
-                                              }
+                                                    },
+                                                    {
+                                                      "$literal": 0
+                                                    },
+                                                    {
+                                                      "$subtract": [
+                                                        "$$targetLen",
+                                                        {
+                                                          "$strLenCP": "$$baseStr"
+                                                        }
+                                                      ]
+                                                    }
+                                                  ]
+                                                },
+                                                "$$baseStr"
+                                              ]
                                             }
                                           ]
                                         }
-                                      }
+                                      ]
                                     },
                                     "vars": {
-                                      "baseStr": {
-                                        "$toString": "$s"
-                                      },
+                                      "baseStr": "$s",
                                       "padding": {
                                         "$literal": " "
                                       },
@@ -460,62 +465,132 @@ public class StringFunctionIntegrationTests extends AbstractQueryIntegrationTest
                 "************* Hello ",
                 """
                         {
-                          "aggregate": "items",
-                          "pipeline": [
-                            {
-                              "$project": {
-                                "#c_1": {
-                                  "$let": {
-                                    "in": {
-                                      "$reduce": {
-                                        "in": {
-                                          "$concat": [
-                                            "$$padding",
-                                            "$$value"
-                                          ]
-                                        },
-                                        "initialValue": "$$baseStr",
-                                        "input": {
-                                          "$range": [
-                                            {
-                                              "$literal": 0
+                                  "aggregate": "items",
+                                  "pipeline": [
+                                    {
+                                      "$project": {
+                                        "#c_1": {
+                                          "$let": {
+                                            "in": {
+                                              "$cond": [
+                                                {
+                                                  "$lte": [
+                                                    "$$targetLen",
+                                                    {
+                                                      "$literal": 0
+                                                    }
+                                                  ]
+                                                },
+                                                {
+                                                  "$literal": ""
+                                                },
+                                                {
+                                                  "$cond": [
+                                                    {
+                                                      "$or": [
+                                                        {
+                                                          "$gte": [
+                                                            {
+                                                              "$strLenCP": "$$baseStr"
+                                                            },
+                                                            "$$targetLen"
+                                                          ]
+                                                        },
+                                                        {
+                                                          "$eq": [
+                                                            {
+                                                              "$strLenCP": "$$padding"
+                                                            },
+                                                            {
+                                                              "$literal": 0
+                                                            }
+                                                          ]
+                                                        }
+                                                      ]
+                                                    },
+                                                    {
+                                                      "$substrCP": [
+                                                        "$$baseStr",
+                                                        {
+                                                          "$literal": 0
+                                                        },
+                                                        "$$targetLen"
+                                                      ]
+                                                    },
+                                                    {
+                                                      "$concat": [
+                                                        {
+                                                          "$substrCP": [
+                                                            {
+                                                              "$reduce": {
+                                                                "in": {
+                                                                  "$concat": [
+                                                                    "$$padding",
+                                                                    "$$value"
+                                                                  ]
+                                                                },
+                                                                "initialValue": {
+                                                                  "$literal": ""
+                                                                },
+                                                                "input": {
+                                                                  "$range": [
+                                                                    {
+                                                                      "$literal": 0
+                                                                    },
+                                                                    {
+                                                                      "$ceil": {
+                                                                        "$divide": [
+                                                                          {
+                                                                            "$subtract": [
+                                                                              "$$targetLen",
+                                                                              {
+                                                                                "$strLenCP": "$$baseStr"
+                                                                              }
+                                                                            ]
+                                                                          },
+                                                                          {
+                                                                            "$strLenCP": "$$padding"
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    }
+                                                                  ]
+                                                                }
+                                                              }
+                                                            },
+                                                            {
+                                                              "$literal": 0
+                                                            },
+                                                            {
+                                                              "$subtract": [
+                                                                "$$targetLen",
+                                                                {
+                                                                  "$strLenCP": "$$baseStr"
+                                                                }
+                                                              ]
+                                                            }
+                                                          ]
+                                                        },
+                                                        "$$baseStr"
+                                                      ]
+                                                    }
+                                                  ]
+                                                }
+                                              ]
                                             },
-                                            {
-                                              "$floor": {
-                                                "$divide": [
-                                                  {
-                                                    "$subtract": [
-                                                      "$$targetLen",
-                                                      {
-                                                        "$strLenCP": "$$baseStr"
-                                                      }
-                                                    ]
-                                                  },
-                                                  {
-                                                    "$strLenCP": "$$padding"
-                                                  }
-                                                ]
-                                              }
+                                            "vars": {
+                                              "baseStr": "$s",
+                                              "padding": {
+                                                "$toString": "*"
+                                              },
+                                              "targetLen": 20
                                             }
-                                          ]
+                                          }
                                         }
                                       }
-                                    },
-                                    "vars": {
-                                      "baseStr": {
-                                        "$toString": "$s"
-                                      },
-                                      "padding": {
-                                        "$toString": "*"
-                                      },
-                                      "targetLen": 20
                                     }
-                                  }
+                                  ]
                                 }
-                              }
-                            }
-                          ]
-                        }
                 """);
     }
 
@@ -526,62 +601,132 @@ public class StringFunctionIntegrationTests extends AbstractQueryIntegrationTest
                 " Hello              ",
                 """
                         {
-                          "aggregate": "items",
-                          "pipeline": [
-                            {
-                              "$project": {
-                                "#c_1": {
-                                  "$let": {
-                                    "in": {
-                                      "$reduce": {
-                                        "in": {
-                                          "$concat": [
-                                            "$$value",
-                                            "$$padding"
-                                          ]
-                                        },
-                                        "initialValue": "$$baseStr",
-                                        "input": {
-                                          "$range": [
-                                            {
-                                              "$literal": 0
+                                  "aggregate": "items",
+                                  "pipeline": [
+                                    {
+                                      "$project": {
+                                        "#c_1": {
+                                          "$let": {
+                                            "in": {
+                                              "$cond": [
+                                                {
+                                                  "$lte": [
+                                                    "$$targetLen",
+                                                    {
+                                                      "$literal": 0
+                                                    }
+                                                  ]
+                                                },
+                                                {
+                                                  "$literal": ""
+                                                },
+                                                {
+                                                  "$cond": [
+                                                    {
+                                                      "$or": [
+                                                        {
+                                                          "$gte": [
+                                                            {
+                                                              "$strLenCP": "$$baseStr"
+                                                            },
+                                                            "$$targetLen"
+                                                          ]
+                                                        },
+                                                        {
+                                                          "$eq": [
+                                                            {
+                                                              "$strLenCP": "$$padding"
+                                                            },
+                                                            {
+                                                              "$literal": 0
+                                                            }
+                                                          ]
+                                                        }
+                                                      ]
+                                                    },
+                                                    {
+                                                      "$substrCP": [
+                                                        "$$baseStr",
+                                                        {
+                                                          "$literal": 0
+                                                        },
+                                                        "$$targetLen"
+                                                      ]
+                                                    },
+                                                    {
+                                                      "$concat": [
+                                                        "$$baseStr",
+                                                        {
+                                                          "$substrCP": [
+                                                            {
+                                                              "$reduce": {
+                                                                "in": {
+                                                                  "$concat": [
+                                                                    "$$value",
+                                                                    "$$padding"
+                                                                  ]
+                                                                },
+                                                                "initialValue": {
+                                                                  "$literal": ""
+                                                                },
+                                                                "input": {
+                                                                  "$range": [
+                                                                    {
+                                                                      "$literal": 0
+                                                                    },
+                                                                    {
+                                                                      "$ceil": {
+                                                                        "$divide": [
+                                                                          {
+                                                                            "$subtract": [
+                                                                              "$$targetLen",
+                                                                              {
+                                                                                "$strLenCP": "$$baseStr"
+                                                                              }
+                                                                            ]
+                                                                          },
+                                                                          {
+                                                                            "$strLenCP": "$$padding"
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    }
+                                                                  ]
+                                                                }
+                                                              }
+                                                            },
+                                                            {
+                                                              "$literal": 0
+                                                            },
+                                                            {
+                                                              "$subtract": [
+                                                                "$$targetLen",
+                                                                {
+                                                                  "$strLenCP": "$$baseStr"
+                                                                }
+                                                              ]
+                                                            }
+                                                          ]
+                                                        }
+                                                      ]
+                                                    }
+                                                  ]
+                                                }
+                                              ]
                                             },
-                                            {
-                                              "$floor": {
-                                                "$divide": [
-                                                  {
-                                                    "$subtract": [
-                                                      "$$targetLen",
-                                                      {
-                                                        "$strLenCP": "$$baseStr"
-                                                      }
-                                                    ]
-                                                  },
-                                                  {
-                                                    "$strLenCP": "$$padding"
-                                                  }
-                                                ]
-                                              }
+                                            "vars": {
+                                              "baseStr": "$s",
+                                              "padding": {
+                                                "$literal": " "
+                                              },
+                                              "targetLen": 20
                                             }
-                                          ]
+                                          }
                                         }
                                       }
-                                    },
-                                    "vars": {
-                                      "baseStr": {
-                                        "$toString": "$s"
-                                      },
-                                      "padding": {
-                                        "$literal": " "
-                                      },
-                                      "targetLen": 20
                                     }
-                                  }
+                                  ]
                                 }
-                              }
-                            }
-                          ]
-                        }
                 """);
     }
 
@@ -592,62 +737,676 @@ public class StringFunctionIntegrationTests extends AbstractQueryIntegrationTest
                 " Hello *************",
                 """
                         {
-                          "aggregate": "items",
-                          "pipeline": [
-                            {
-                              "$project": {
-                                "#c_1": {
-                                  "$let": {
-                                    "in": {
-                                      "$reduce": {
-                                        "in": {
-                                          "$concat": [
-                                            "$$value",
-                                            "$$padding"
+                                  "aggregate": "items",
+                                  "pipeline": [
+                                    {
+                                      "$project": {
+                                        "#c_1": {
+                                          "$let": {
+                                            "in": {
+                                              "$cond": [
+                                                {
+                                                  "$lte": [
+                                                    "$$targetLen",
+                                                    {
+                                                      "$literal": 0
+                                                    }
+                                                  ]
+                                                },
+                                                {
+                                                  "$literal": ""
+                                                },
+                                                {
+                                                  "$cond": [
+                                                    {
+                                                      "$or": [
+                                                        {
+                                                          "$gte": [
+                                                            {
+                                                              "$strLenCP": "$$baseStr"
+                                                            },
+                                                            "$$targetLen"
+                                                          ]
+                                                        },
+                                                        {
+                                                          "$eq": [
+                                                            {
+                                                              "$strLenCP": "$$padding"
+                                                            },
+                                                            {
+                                                              "$literal": 0
+                                                            }
+                                                          ]
+                                                        }
+                                                      ]
+                                                    },
+                                                    {
+                                                      "$substrCP": [
+                                                        "$$baseStr",
+                                                        {
+                                                          "$literal": 0
+                                                        },
+                                                        "$$targetLen"
+                                                      ]
+                                                    },
+                                                    {
+                                                      "$concat": [
+                                                        "$$baseStr",
+                                                        {
+                                                          "$substrCP": [
+                                                            {
+                                                              "$reduce": {
+                                                                "in": {
+                                                                  "$concat": [
+                                                                    "$$value",
+                                                                    "$$padding"
+                                                                  ]
+                                                                },
+                                                                "initialValue": {
+                                                                  "$literal": ""
+                                                                },
+                                                                "input": {
+                                                                  "$range": [
+                                                                    {
+                                                                      "$literal": 0
+                                                                    },
+                                                                    {
+                                                                      "$ceil": {
+                                                                        "$divide": [
+                                                                          {
+                                                                            "$subtract": [
+                                                                              "$$targetLen",
+                                                                              {
+                                                                                "$strLenCP": "$$baseStr"
+                                                                              }
+                                                                            ]
+                                                                          },
+                                                                          {
+                                                                            "$strLenCP": "$$padding"
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    }
+                                                                  ]
+                                                                }
+                                                              }
+                                                            },
+                                                            {
+                                                              "$literal": 0
+                                                            },
+                                                            {
+                                                              "$subtract": [
+                                                                "$$targetLen",
+                                                                {
+                                                                  "$strLenCP": "$$baseStr"
+                                                                }
+                                                              ]
+                                                            }
+                                                          ]
+                                                        }
+                                                      ]
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            },
+                                            "vars": {
+                                              "baseStr": "$s",
+                                              "padding": {
+                                                "$toString": "*"
+                                              },
+                                              "targetLen": 20
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  ]
+                                }
+                """);
+    }
+
+    @Test
+    void testLpadPadsToRequestedLengthWithMultiCharacterPadding() {
+        assertQueryResult(
+                "select lpad('x', 6, 'ab') from Item",
+                "ababax",
+                """
+                                {
+                                  "aggregate": "items",
+                                  "pipeline": [
+                                    {
+                                      "$project": {
+                                        "#c_1": {
+                                          "$let": {
+                                            "in": {
+                                              "$cond": [
+                                                {
+                                                  "$lte": [
+                                                    "$$targetLen",
+                                                    {
+                                                      "$literal": 0
+                                                    }
+                                                  ]
+                                                },
+                                                {
+                                                  "$literal": ""
+                                                },
+                                                {
+                                                  "$cond": [
+                                                    {
+                                                      "$or": [
+                                                        {
+                                                          "$gte": [
+                                                            {
+                                                              "$strLenCP": "$$baseStr"
+                                                            },
+                                                            "$$targetLen"
+                                                          ]
+                                                        },
+                                                        {
+                                                          "$eq": [
+                                                            {
+                                                              "$strLenCP": "$$padding"
+                                                            },
+                                                            {
+                                                              "$literal": 0
+                                                            }
+                                                          ]
+                                                        }
+                                                      ]
+                                                    },
+                                                    {
+                                                      "$substrCP": [
+                                                        "$$baseStr",
+                                                        {
+                                                          "$literal": 0
+                                                        },
+                                                        "$$targetLen"
+                                                      ]
+                                                    },
+                                                    {
+                                                      "$concat": [
+                                                        {
+                                                          "$substrCP": [
+                                                            {
+                                                              "$reduce": {
+                                                                "in": {
+                                                                  "$concat": [
+                                                                    "$$padding",
+                                                                    "$$value"
+                                                                  ]
+                                                                },
+                                                                "initialValue": {
+                                                                  "$literal": ""
+                                                                },
+                                                                "input": {
+                                                                  "$range": [
+                                                                    {
+                                                                      "$literal": 0
+                                                                    },
+                                                                    {
+                                                                      "$ceil": {
+                                                                        "$divide": [
+                                                                          {
+                                                                            "$subtract": [
+                                                                              "$$targetLen",
+                                                                              {
+                                                                                "$strLenCP": "$$baseStr"
+                                                                              }
+                                                                            ]
+                                                                          },
+                                                                          {
+                                                                            "$strLenCP": "$$padding"
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    }
+                                                                  ]
+                                                                }
+                                                              }
+                                                            },
+                                                            {
+                                                              "$literal": 0
+                                                            },
+                                                            {
+                                                              "$subtract": [
+                                                                "$$targetLen",
+                                                                {
+                                                                  "$strLenCP": "$$baseStr"
+                                                                }
+                                                              ]
+                                                            }
+                                                          ]
+                                                        },
+                                                        "$$baseStr"
+                                                      ]
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            },
+                                            "vars": {
+                                              "baseStr": "x",
+                                              "padding": {
+                                                "$toString": "ab"
+                                              },
+                                              "targetLen": 6
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  ]
+                                }
+                """);
+    }
+
+    @Test
+    void testLpadWithEmptyPaddingReturnsInput() {
+        assertQueryResult(
+                "select lpad(s, 60, '') from Item",
+                " Hello ",
+                """
+                {
+                  "aggregate": "items",
+                  "pipeline": [
+                    {
+                      "$project": {
+                        "#c_1": {
+                          "$let": {
+                            "in": {
+                              "$cond": [
+                                {
+                                  "$lte": [
+                                    "$$targetLen",
+                                    {
+                                      "$literal": 0
+                                    }
+                                  ]
+                                },
+                                {
+                                  "$literal": ""
+                                },
+                                {
+                                  "$cond": [
+                                    {
+                                      "$or": [
+                                        {
+                                          "$gte": [
+                                            {
+                                              "$strLenCP": "$$baseStr"
+                                            },
+                                            "$$targetLen"
                                           ]
                                         },
-                                        "initialValue": "$$baseStr",
-                                        "input": {
-                                          "$range": [
+                                        {
+                                          "$eq": [
+                                            {
+                                              "$strLenCP": "$$padding"
+                                            },
+                                            {
+                                              "$literal": 0
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "$substrCP": [
+                                        "$$baseStr",
+                                        {
+                                          "$literal": 0
+                                        },
+                                        "$$targetLen"
+                                      ]
+                                    },
+                                    {
+                                      "$concat": [
+                                        {
+                                          "$substrCP": [
+                                            {
+                                              "$reduce": {
+                                                "in": {
+                                                  "$concat": [
+                                                    "$$padding",
+                                                    "$$value"
+                                                  ]
+                                                },
+                                                "initialValue": {
+                                                  "$literal": ""
+                                                },
+                                                "input": {
+                                                  "$range": [
+                                                    {
+                                                      "$literal": 0
+                                                    },
+                                                    {
+                                                      "$ceil": {
+                                                        "$divide": [
+                                                          {
+                                                            "$subtract": [
+                                                              "$$targetLen",
+                                                              {
+                                                                "$strLenCP": "$$baseStr"
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "$strLenCP": "$$padding"
+                                                          }
+                                                        ]
+                                                      }
+                                                    }
+                                                  ]
+                                                }
+                                              }
+                                            },
                                             {
                                               "$literal": 0
                                             },
                                             {
-                                              "$floor": {
-                                                "$divide": [
-                                                  {
-                                                    "$subtract": [
-                                                      "$$targetLen",
-                                                      {
-                                                        "$strLenCP": "$$baseStr"
-                                                      }
-                                                    ]
-                                                  },
-                                                  {
-                                                    "$strLenCP": "$$padding"
-                                                  }
-                                                ]
-                                              }
+                                              "$subtract": [
+                                                "$$targetLen",
+                                                {
+                                                  "$strLenCP": "$$baseStr"
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        },
+                                        "$$baseStr"
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            "vars": {
+                              "baseStr": "$s",
+                              "padding": {
+                                "$toString": ""
+                              },
+                              "targetLen": 60
+                            }
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+                """);
+    }
+
+    @Test
+    void testPadLeadingTruncatesWhenTargetIsShorterThanInput() {
+        assertQueryResult(
+                "select pad(s with 3 leading) from Item",
+                " He",
+                """
+                {
+                  "aggregate": "items",
+                  "pipeline": [
+                    {
+                      "$project": {
+                        "#c_1": {
+                          "$let": {
+                            "in": {
+                              "$cond": [
+                                {
+                                  "$lte": [
+                                    "$$targetLen",
+                                    {
+                                      "$literal": 0
+                                    }
+                                  ]
+                                },
+                                {
+                                  "$literal": ""
+                                },
+                                {
+                                  "$cond": [
+                                    {
+                                      "$or": [
+                                        {
+                                          "$gte": [
+                                            {
+                                              "$strLenCP": "$$baseStr"
+                                            },
+                                            "$$targetLen"
+                                          ]
+                                        },
+                                        {
+                                          "$eq": [
+                                            {
+                                              "$strLenCP": "$$padding"
+                                            },
+                                            {
+                                              "$literal": 0
                                             }
                                           ]
                                         }
-                                      }
+                                      ]
                                     },
-                                    "vars": {
-                                      "baseStr": {
-                                        "$toString": "$s"
-                                      },
-                                      "padding": {
-                                        "$toString": "*"
-                                      },
-                                      "targetLen": 20
+                                    {
+                                      "$substrCP": [
+                                        "$$baseStr",
+                                        {
+                                          "$literal": 0
+                                        },
+                                        "$$targetLen"
+                                      ]
+                                    },
+                                    {
+                                      "$concat": [
+                                        {
+                                          "$substrCP": [
+                                            {
+                                              "$reduce": {
+                                                "in": {
+                                                  "$concat": [
+                                                    "$$padding",
+                                                    "$$value"
+                                                  ]
+                                                },
+                                                "initialValue": {
+                                                  "$literal": ""
+                                                },
+                                                "input": {
+                                                  "$range": [
+                                                    {
+                                                      "$literal": 0
+                                                    },
+                                                    {
+                                                      "$ceil": {
+                                                        "$divide": [
+                                                          {
+                                                            "$subtract": [
+                                                              "$$targetLen",
+                                                              {
+                                                                "$strLenCP": "$$baseStr"
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "$strLenCP": "$$padding"
+                                                          }
+                                                        ]
+                                                      }
+                                                    }
+                                                  ]
+                                                }
+                                              }
+                                            },
+                                            {
+                                              "$literal": 0
+                                            },
+                                            {
+                                              "$subtract": [
+                                                "$$targetLen",
+                                                {
+                                                  "$strLenCP": "$$baseStr"
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        },
+                                        "$$baseStr"
+                                      ]
                                     }
-                                  }
+                                  ]
                                 }
-                              }
+                              ]
+                            },
+                            "vars": {
+                              "baseStr": "$s",
+                              "padding": {
+                                "$literal": " "
+                              },
+                              "targetLen": 3
                             }
-                          ]
+                          }
                         }
+                      }
+                    }
+                  ]
+                }
+                """);
+    }
+
+    @Test
+    void testPadWithNegativeTargetReturnsEmptyString() {
+        assertQueryResult(
+                "select pad(s with -1 leading) from Item",
+                "",
+                """
+                {
+                  "aggregate": "items",
+                  "pipeline": [
+                    {
+                      "$project": {
+                        "#c_1": {
+                          "$let": {
+                            "in": {
+                              "$cond": [
+                                {
+                                  "$lte": [
+                                    "$$targetLen",
+                                    {
+                                      "$literal": 0
+                                    }
+                                  ]
+                                },
+                                {
+                                  "$literal": ""
+                                },
+                                {
+                                  "$cond": [
+                                    {
+                                      "$or": [
+                                        {
+                                          "$gte": [
+                                            {
+                                              "$strLenCP": "$$baseStr"
+                                            },
+                                            "$$targetLen"
+                                          ]
+                                        },
+                                        {
+                                          "$eq": [
+                                            {
+                                              "$strLenCP": "$$padding"
+                                            },
+                                            {
+                                              "$literal": 0
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "$substrCP": [
+                                        "$$baseStr",
+                                        {
+                                          "$literal": 0
+                                        },
+                                        "$$targetLen"
+                                      ]
+                                    },
+                                    {
+                                      "$concat": [
+                                        {
+                                          "$substrCP": [
+                                            {
+                                              "$reduce": {
+                                                "in": {
+                                                  "$concat": [
+                                                    "$$padding",
+                                                    "$$value"
+                                                  ]
+                                                },
+                                                "initialValue": {
+                                                  "$literal": ""
+                                                },
+                                                "input": {
+                                                  "$range": [
+                                                    {
+                                                      "$literal": 0
+                                                    },
+                                                    {
+                                                      "$ceil": {
+                                                        "$divide": [
+                                                          {
+                                                            "$subtract": [
+                                                              "$$targetLen",
+                                                              {
+                                                                "$strLenCP": "$$baseStr"
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "$strLenCP": "$$padding"
+                                                          }
+                                                        ]
+                                                      }
+                                                    }
+                                                  ]
+                                                }
+                                              }
+                                            },
+                                            {
+                                              "$literal": 0
+                                            },
+                                            {
+                                              "$subtract": [
+                                                "$$targetLen",
+                                                {
+                                                  "$strLenCP": "$$baseStr"
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        },
+                                        "$$baseStr"
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            "vars": {
+                              "baseStr": "$s",
+                              "padding": {
+                                "$literal": " "
+                              },
+                              "targetLen": -1
+                            }
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
                 """);
     }
 
@@ -663,20 +1422,50 @@ public class StringFunctionIntegrationTests extends AbstractQueryIntegrationTest
                     {
                       "$project": {
                         "#c_1": {
-                          "$substrCP": [
-                            "$s",
-                            {
-                              "$subtract": [
-                                2,
-                                {
-                                  "$literal": 1
+                          "$let": {
+                            "in": {
+                              "$let": {
+                                "in": {
+                                  "$substrCP": [
+                                    "$$str",
+                                    "$$adjustedStart",
+                                    {
+                                      "$literal": 2147483647
+                                    }
+                                  ]
+                                },
+                                "vars": {
+                                  "adjustedStart": {
+                                    "$cond": [
+                                      {
+                                        "$lt": [
+                                          "$$start",
+                                          {
+                                            "$literal": 0
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "$literal": 0
+                                      },
+                                      "$$start"
+                                    ]
+                                  }
                                 }
-                              ]
+                              }
                             },
-                            {
-                              "$literal": 2147483647
+                            "vars": {
+                              "start": {
+                                "$subtract": [
+                                  2,
+                                  {
+                                    "$literal": 1
+                                  }
+                                ]
+                              },
+                              "str": "$s"
                             }
-                          ]
+                          }
                         }
                       }
                     }
@@ -697,18 +1486,269 @@ public class StringFunctionIntegrationTests extends AbstractQueryIntegrationTest
                     {
                       "$project": {
                         "#c_1": {
-                          "$substrCP": [
-                            "$s",
-                            {
-                              "$subtract": [
-                                3,
-                                {
-                                  "$literal": 1
+                          "$let": {
+                            "in": {
+                              "$let": {
+                                "in": {
+                                  "$substrCP": [
+                                    "$$str",
+                                    "$$adjustedStart",
+                                    {
+                                      "$add": [
+                                        "$$len",
+                                        {
+                                          "$subtract": [
+                                            "$$start",
+                                            "$$adjustedStart"
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                "vars": {
+                                  "adjustedStart": {
+                                    "$cond": [
+                                      {
+                                        "$lt": [
+                                          "$$start",
+                                          {
+                                            "$literal": 0
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "$literal": 0
+                                      },
+                                      "$$start"
+                                    ]
+                                  }
                                 }
-                              ]
+                              }
                             },
-                            2
-                          ]
+                            "vars": {
+                              "len": 2,
+                              "start": {
+                                "$subtract": [
+                                  3,
+                                  {
+                                    "$literal": 1
+                                  }
+                                ]
+                              },
+                              "str": "$s"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+                """);
+    }
+
+    @Test
+    void testSubstringWithZeroStart() {
+        assertQueryResult(
+                "select substring(s, 0) from Item",
+                " Hello ",
+                """
+                {
+                  "aggregate": "items",
+                  "pipeline": [
+                    {
+                      "$project": {
+                        "#c_1": {
+                          "$let": {
+                            "in": {
+                              "$let": {
+                                "in": {
+                                  "$substrCP": [
+                                    "$$str",
+                                    "$$adjustedStart",
+                                    {
+                                      "$literal": 2147483647
+                                    }
+                                  ]
+                                },
+                                "vars": {
+                                  "adjustedStart": {
+                                    "$cond": [
+                                      {
+                                        "$lt": [
+                                          "$$start",
+                                          {
+                                            "$literal": 0
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "$literal": 0
+                                      },
+                                      "$$start"
+                                    ]
+                                  }
+                                }
+                              }
+                            },
+                            "vars": {
+                              "start": {
+                                "$subtract": [
+                                  0,
+                                  {
+                                    "$literal": 1
+                                  }
+                                ]
+                              },
+                              "str": "$s"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+                """);
+    }
+
+    @Test
+    void testSubstringFromNegativeStartForLength() {
+        assertQueryResult(
+                "select substring(s, -1, 3) from Item",
+                " ",
+                """
+                {
+                  "aggregate": "items",
+                  "pipeline": [
+                    {
+                      "$project": {
+                        "#c_1": {
+                          "$let": {
+                            "in": {
+                              "$let": {
+                                "in": {
+                                  "$substrCP": [
+                                    "$$str",
+                                    "$$adjustedStart",
+                                    {
+                                      "$add": [
+                                        "$$len",
+                                        {
+                                          "$subtract": [
+                                            "$$start",
+                                            "$$adjustedStart"
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                "vars": {
+                                  "adjustedStart": {
+                                    "$cond": [
+                                      {
+                                        "$lt": [
+                                          "$$start",
+                                          {
+                                            "$literal": 0
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "$literal": 0
+                                      },
+                                      "$$start"
+                                    ]
+                                  }
+                                }
+                              }
+                            },
+                            "vars": {
+                              "len": 3,
+                              "start": {
+                                "$subtract": [
+                                  -1,
+                                  {
+                                    "$literal": 1
+                                  }
+                                ]
+                              },
+                              "str": "$s"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+                """);
+    }
+
+    @Test
+    void testSubstringWithZeroStartAndLength() {
+        assertQueryResult(
+                "select substring(s, 0, 3) from Item",
+                " H",
+                """
+                {
+                  "aggregate": "items",
+                  "pipeline": [
+                    {
+                      "$project": {
+                        "#c_1": {
+                          "$let": {
+                            "in": {
+                              "$let": {
+                                "in": {
+                                  "$substrCP": [
+                                    "$$str",
+                                    "$$adjustedStart",
+                                    {
+                                      "$add": [
+                                        "$$len",
+                                        {
+                                          "$subtract": [
+                                            "$$start",
+                                            "$$adjustedStart"
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                "vars": {
+                                  "adjustedStart": {
+                                    "$cond": [
+                                      {
+                                        "$lt": [
+                                          "$$start",
+                                          {
+                                            "$literal": 0
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "$literal": 0
+                                      },
+                                      "$$start"
+                                    ]
+                                  }
+                                }
+                              }
+                            },
+                            "vars": {
+                              "len": 3,
+                              "start": {
+                                "$subtract": [
+                                  0,
+                                  {
+                                    "$literal": 1
+                                  }
+                                ]
+                              },
+                              "str": "$s"
+                            }
+                          }
                         }
                       }
                     }

--- a/src/integrationTest/java/com/mongodb/hibernate/query/function/string/StringFunctionIntegrationTests.java
+++ b/src/integrationTest/java/com/mongodb/hibernate/query/function/string/StringFunctionIntegrationTests.java
@@ -24,7 +24,6 @@ import jakarta.persistence.Table;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
-import org.hibernate.query.sqm.produce.function.FunctionArgumentException;
 import org.hibernate.testing.orm.junit.DomainModel;
 import org.hibernate.testing.orm.junit.SessionFactory;
 import org.junit.jupiter.api.BeforeEach;
@@ -342,156 +341,314 @@ public class StringFunctionIntegrationTests extends AbstractQueryIntegrationTest
     }
 
     @Test
-    void testLeftTrim() {
+    void testRepeat() {
         assertQueryResult(
-                "select ltrim(s) from Item",
-                "Hello ",
+                "select repeat(s, 2) from Item",
+                " Hello  Hello ",
                 """
-                {
-                  "aggregate": "items",
-                  "pipeline": [
-                    {
-                      "$project": {
-                        "#c_1": {
-                          "$ltrim": {
-                            "input": "$s"
-                          }
-                        }
-                      }
-                    }
-                  ]
-                }
+                        {
+                                  "aggregate": "items",
+                                  "pipeline": [
+                                    {
+                                      "$project": {
+                                        "#c_1": {
+                                          "$let": {
+                                            "in": {
+                                              "$reduce": {
+                                                "in": {
+                                                  "$concat": [
+                                                    "$$value",
+                                                    "$$repeatStr"
+                                                  ]
+                                                },
+                                                "initialValue": {
+                                                  "$literal": ""
+                                                },
+                                                "input": {
+                                                  "$range": [
+                                                    {
+                                                      "$literal": 0
+                                                    },
+                                                    "$$count"
+                                                  ]
+                                                }
+                                              }
+                                            },
+                                            "vars": {
+                                              "count": 2,
+                                              "repeatStr": "$s"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  ]
+                                }
                 """);
     }
 
     @Test
-    void testLeftTrimChars() {
+    void testPadLeadingWS() {
         assertQueryResult(
-                "select ltrim(u, '_') from Item",
-                "Hello_",
+                "select pad(s with 20 leading) from Item",
+                "              Hello ",
                 """
-                {
-                  "aggregate": "items",
-                  "pipeline": [
-                    {
-                      "$project": {
-                        "#c_1": {
-                          "$ltrim": {
-                            "chars": "_",
-                            "input": "$u"
-                          }
+                        {
+                          "aggregate": "items",
+                          "pipeline": [
+                            {
+                              "$project": {
+                                "#c_1": {
+                                  "$let": {
+                                    "in": {
+                                      "$reduce": {
+                                        "in": {
+                                          "$concat": [
+                                            "$$padding",
+                                            "$$value"
+                                          ]
+                                        },
+                                        "initialValue": "$$baseStr",
+                                        "input": {
+                                          "$range": [
+                                            {
+                                              "$literal": 0
+                                            },
+                                            {
+                                              "$floor": {
+                                                "$divide": [
+                                                  {
+                                                    "$subtract": [
+                                                      "$$targetLen",
+                                                      {
+                                                        "$strLenCP": "$$baseStr"
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "$strLenCP": "$$padding"
+                                                  }
+                                                ]
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      }
+                                    },
+                                    "vars": {
+                                      "baseStr": {
+                                        "$toString": "$s"
+                                      },
+                                      "padding": {
+                                        "$literal": " "
+                                      },
+                                      "targetLen": 20
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          ]
                         }
-                      }
-                    }
-                  ]
-                }
                 """);
     }
 
     @Test
-    void testReplaceAll() {
+    void testPadLeadingCh() {
         assertQueryResult(
-                "select replace_all(s, ' ', '_') from Item",
-                "_Hello_",
+                "select pad(s with 20 leading '*') from Item",
+                "************* Hello ",
                 """
-                {
-                  "aggregate": "items",
-                  "pipeline": [
-                    {
-                      "$project": {
-                        "#c_1": {
-                          "$replaceAll": {
-                            "find": " ",
-                            "input": "$s",
-                            "replacement": "_"
-                          }
+                        {
+                          "aggregate": "items",
+                          "pipeline": [
+                            {
+                              "$project": {
+                                "#c_1": {
+                                  "$let": {
+                                    "in": {
+                                      "$reduce": {
+                                        "in": {
+                                          "$concat": [
+                                            "$$padding",
+                                            "$$value"
+                                          ]
+                                        },
+                                        "initialValue": "$$baseStr",
+                                        "input": {
+                                          "$range": [
+                                            {
+                                              "$literal": 0
+                                            },
+                                            {
+                                              "$floor": {
+                                                "$divide": [
+                                                  {
+                                                    "$subtract": [
+                                                      "$$targetLen",
+                                                      {
+                                                        "$strLenCP": "$$baseStr"
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "$strLenCP": "$$padding"
+                                                  }
+                                                ]
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      }
+                                    },
+                                    "vars": {
+                                      "baseStr": {
+                                        "$toString": "$s"
+                                      },
+                                      "padding": {
+                                        "$toString": "*"
+                                      },
+                                      "targetLen": 20
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          ]
                         }
-                      }
-                    }
-                  ]
-                }
                 """);
     }
 
     @Test
-    void testReplaceOne() {
+    void testPadTrailingWS() {
         assertQueryResult(
-                "select replace_one(s, ' ', '_') from Item",
-                "_Hello ",
+                "select pad(s with 20 trailing) from Item",
+                " Hello              ",
                 """
-                {
-                  "aggregate": "items",
-                  "pipeline": [
-                    {
-                      "$project": {
-                        "#c_1": {
-                          "$replaceOne": {
-                            "find": " ",
-                            "input": "$s",
-                            "replacement": "_"
-                          }
+                        {
+                          "aggregate": "items",
+                          "pipeline": [
+                            {
+                              "$project": {
+                                "#c_1": {
+                                  "$let": {
+                                    "in": {
+                                      "$reduce": {
+                                        "in": {
+                                          "$concat": [
+                                            "$$value",
+                                            "$$padding"
+                                          ]
+                                        },
+                                        "initialValue": "$$baseStr",
+                                        "input": {
+                                          "$range": [
+                                            {
+                                              "$literal": 0
+                                            },
+                                            {
+                                              "$floor": {
+                                                "$divide": [
+                                                  {
+                                                    "$subtract": [
+                                                      "$$targetLen",
+                                                      {
+                                                        "$strLenCP": "$$baseStr"
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "$strLenCP": "$$padding"
+                                                  }
+                                                ]
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      }
+                                    },
+                                    "vars": {
+                                      "baseStr": {
+                                        "$toString": "$s"
+                                      },
+                                      "padding": {
+                                        "$literal": " "
+                                      },
+                                      "targetLen": 20
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          ]
                         }
-                      }
-                    }
-                  ]
-                }
                 """);
     }
 
     @Test
-    void testRightTrim() {
+    void testPadTrailingCh() {
         assertQueryResult(
-                "select rtrim(s) from Item",
-                " Hello",
+                "select pad(s with 20 trailing '*') from Item",
+                " Hello *************",
                 """
-                {
-                  "aggregate": "items",
-                  "pipeline": [
-                    {
-                      "$project": {
-                        "#c_1": {
-                          "$rtrim": {
-                            "input": "$s"
-                          }
+                        {
+                          "aggregate": "items",
+                          "pipeline": [
+                            {
+                              "$project": {
+                                "#c_1": {
+                                  "$let": {
+                                    "in": {
+                                      "$reduce": {
+                                        "in": {
+                                          "$concat": [
+                                            "$$value",
+                                            "$$padding"
+                                          ]
+                                        },
+                                        "initialValue": "$$baseStr",
+                                        "input": {
+                                          "$range": [
+                                            {
+                                              "$literal": 0
+                                            },
+                                            {
+                                              "$floor": {
+                                                "$divide": [
+                                                  {
+                                                    "$subtract": [
+                                                      "$$targetLen",
+                                                      {
+                                                        "$strLenCP": "$$baseStr"
+                                                      }
+                                                    ]
+                                                  },
+                                                  {
+                                                    "$strLenCP": "$$padding"
+                                                  }
+                                                ]
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      }
+                                    },
+                                    "vars": {
+                                      "baseStr": {
+                                        "$toString": "$s"
+                                      },
+                                      "padding": {
+                                        "$toString": "*"
+                                      },
+                                      "targetLen": 20
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          ]
                         }
-                      }
-                    }
-                  ]
-                }
                 """);
-    }
-
-    @Test
-    void testRightTrimChars() {
-        assertQueryResult(
-                "select rtrim(u, '_') from Item",
-                "_Hello",
-                """
-                {
-                  "aggregate": "items",
-                  "pipeline": [
-                    {
-                      "$project": {
-                        "#c_1": {
-                          "$rtrim": {
-                            "chars": "_",
-                            "input": "$u"
-                          }
-                        }
-                      }
-                    }
-                  ]
-                }
-                """);
-    }
-
-    @Test
-    void testRightTrimWrongType() {
-        assertSelectQueryFailure(
-                "select rtrim(u, 3) from Item",
-                String.class,
-                FunctionArgumentException.class,
-                "Parameter 2 of function 'rtrim()' has type 'STRING', but argument is of type 'java.lang.Integer' mapped to 'INTEGER'");
     }
 
     @Test

--- a/src/integrationTest/java/com/mongodb/hibernate/query/function/string/StringFunctionIntegrationTests.java
+++ b/src/integrationTest/java/com/mongodb/hibernate/query/function/string/StringFunctionIntegrationTests.java
@@ -202,34 +202,19 @@ public class StringFunctionIntegrationTests extends AbstractQueryIntegrationTest
                                 "$s",
                                 " ",
                                 {
-                                  "$let": {
-                                    "in": {
-                                      "$cond": [
+                                  "$max": [
+                                    {
+                                      "$subtract": [
+                                        4,
                                         {
-                                          "$lt": [
-                                            "$$x",
-                                            {
-                                              "$literal": 0
-                                            }
-                                          ]
-                                        },
-                                        {
-                                          "$literal": 0
-                                        },
-                                        "$$x"
+                                          "$literal": 1
+                                        }
                                       ]
                                     },
-                                    "vars": {
-                                      "x": {
-                                        "$subtract": [
-                                          4,
-                                          {
-                                            "$literal": 1
-                                          }
-                                        ]
-                                      }
+                                    {
+                                      "$literal": 0
                                     }
-                                  }
+                                  ]
                                 }
                               ]
                             },
@@ -263,34 +248,19 @@ public class StringFunctionIntegrationTests extends AbstractQueryIntegrationTest
                                 "$s",
                                 "o",
                                 {
-                                  "$let": {
-                                    "in": {
-                                      "$cond": [
+                                  "$max": [
+                                    {
+                                      "$subtract": [
+                                        0,
                                         {
-                                          "$lt": [
-                                            "$$x",
-                                            {
-                                              "$literal": 0
-                                            }
-                                          ]
-                                        },
-                                        {
-                                          "$literal": 0
-                                        },
-                                        "$$x"
+                                          "$literal": 1
+                                        }
                                       ]
                                     },
-                                    "vars": {
-                                      "x": {
-                                        "$subtract": [
-                                          0,
-                                          {
-                                            "$literal": 1
-                                          }
-                                        ]
-                                      }
+                                    {
+                                      "$literal": 0
                                     }
-                                  }
+                                  ]
                                 }
                               ]
                             },
@@ -324,34 +294,19 @@ public class StringFunctionIntegrationTests extends AbstractQueryIntegrationTest
                                 "$s",
                                 "o",
                                 {
-                                  "$let": {
-                                    "in": {
-                                      "$cond": [
+                                  "$max": [
+                                    {
+                                      "$subtract": [
+                                        -3,
                                         {
-                                          "$lt": [
-                                            "$$x",
-                                            {
-                                              "$literal": 0
-                                            }
-                                          ]
-                                        },
-                                        {
-                                          "$literal": 0
-                                        },
-                                        "$$x"
+                                          "$literal": 1
+                                        }
                                       ]
                                     },
-                                    "vars": {
-                                      "x": {
-                                        "$subtract": [
-                                          -3,
-                                          {
-                                            "$literal": 1
-                                          }
-                                        ]
-                                      }
+                                    {
+                                      "$literal": 0
                                     }
-                                  }
+                                  ]
                                 }
                               ]
                             },
@@ -385,34 +340,19 @@ public class StringFunctionIntegrationTests extends AbstractQueryIntegrationTest
                                 "$s",
                                 " ",
                                 {
-                                  "$let": {
-                                    "in": {
-                                      "$cond": [
+                                  "$max": [
+                                    {
+                                      "$subtract": [
+                                        4,
                                         {
-                                          "$lt": [
-                                            "$$x",
-                                            {
-                                              "$literal": 0
-                                            }
-                                          ]
-                                        },
-                                        {
-                                          "$literal": 0
-                                        },
-                                        "$$x"
+                                          "$literal": 1
+                                        }
                                       ]
                                     },
-                                    "vars": {
-                                      "x": {
-                                        "$subtract": [
-                                          4,
-                                          {
-                                            "$literal": 1
-                                          }
-                                        ]
-                                      }
+                                    {
+                                      "$literal": 0
                                     }
-                                  }
+                                  ]
                                 }
                               ]
                             },
@@ -2767,37 +2707,22 @@ public class StringFunctionIntegrationTests extends AbstractQueryIntegrationTest
                                     "$$str",
                                     "$$adjustedStart",
                                     {
-                                      "$let": {
-                                        "in": {
-                                          "$cond": [
+                                      "$max": [
+                                        {
+                                          "$add": [
+                                            "$$len",
                                             {
-                                              "$lt": [
-                                                "$$x",
-                                                {
-                                                  "$literal": 0
-                                                }
+                                              "$subtract": [
+                                                "$$start",
+                                                "$$adjustedStart"
                                               ]
-                                            },
-                                            {
-                                              "$literal": 0
-                                            },
-                                            "$$x"
+                                            }
                                           ]
                                         },
-                                        "vars": {
-                                          "x": {
-                                            "$add": [
-                                              "$$len",
-                                              {
-                                                "$subtract": [
-                                                  "$$start",
-                                                  "$$adjustedStart"
-                                                ]
-                                              }
-                                            ]
-                                          }
+                                        {
+                                          "$literal": 0
                                         }
-                                      }
+                                      ]
                                     }
                                   ]
                                 },
@@ -2926,37 +2851,22 @@ public class StringFunctionIntegrationTests extends AbstractQueryIntegrationTest
                                     "$$str",
                                     "$$adjustedStart",
                                     {
-                                      "$let": {
-                                        "in": {
-                                          "$cond": [
+                                      "$max": [
+                                        {
+                                          "$add": [
+                                            "$$len",
                                             {
-                                              "$lt": [
-                                                "$$x",
-                                                {
-                                                  "$literal": 0
-                                                }
+                                              "$subtract": [
+                                                "$$start",
+                                                "$$adjustedStart"
                                               ]
-                                            },
-                                            {
-                                              "$literal": 0
-                                            },
-                                            "$$x"
+                                            }
                                           ]
                                         },
-                                        "vars": {
-                                          "x": {
-                                            "$add": [
-                                              "$$len",
-                                              {
-                                                "$subtract": [
-                                                  "$$start",
-                                                  "$$adjustedStart"
-                                                ]
-                                              }
-                                            ]
-                                          }
+                                        {
+                                          "$literal": 0
                                         }
-                                      }
+                                      ]
                                     }
                                   ]
                                 },
@@ -3021,37 +2931,22 @@ public class StringFunctionIntegrationTests extends AbstractQueryIntegrationTest
                                     "$$str",
                                     "$$adjustedStart",
                                     {
-                                      "$let": {
-                                        "in": {
-                                          "$cond": [
+                                      "$max": [
+                                        {
+                                          "$add": [
+                                            "$$len",
                                             {
-                                              "$lt": [
-                                                "$$x",
-                                                {
-                                                  "$literal": 0
-                                                }
+                                              "$subtract": [
+                                                "$$start",
+                                                "$$adjustedStart"
                                               ]
-                                            },
-                                            {
-                                              "$literal": 0
-                                            },
-                                            "$$x"
+                                            }
                                           ]
                                         },
-                                        "vars": {
-                                          "x": {
-                                            "$add": [
-                                              "$$len",
-                                              {
-                                                "$subtract": [
-                                                  "$$start",
-                                                  "$$adjustedStart"
-                                                ]
-                                              }
-                                            ]
-                                          }
+                                        {
+                                          "$literal": 0
                                         }
-                                      }
+                                      ]
                                     }
                                   ]
                                 },
@@ -3116,37 +3011,22 @@ public class StringFunctionIntegrationTests extends AbstractQueryIntegrationTest
                                     "$$str",
                                     "$$adjustedStart",
                                     {
-                                      "$let": {
-                                        "in": {
-                                          "$cond": [
+                                      "$max": [
+                                        {
+                                          "$add": [
+                                            "$$len",
                                             {
-                                              "$lt": [
-                                                "$$x",
-                                                {
-                                                  "$literal": 0
-                                                }
+                                              "$subtract": [
+                                                "$$start",
+                                                "$$adjustedStart"
                                               ]
-                                            },
-                                            {
-                                              "$literal": 0
-                                            },
-                                            "$$x"
+                                            }
                                           ]
                                         },
-                                        "vars": {
-                                          "x": {
-                                            "$add": [
-                                              "$$len",
-                                              {
-                                                "$subtract": [
-                                                  "$$start",
-                                                  "$$adjustedStart"
-                                                ]
-                                              }
-                                            ]
-                                          }
+                                        {
+                                          "$literal": 0
                                         }
-                                      }
+                                      ]
                                     }
                                   ]
                                 },

--- a/src/integrationTest/java/com/mongodb/hibernate/query/function/string/StringFunctionIntegrationTests.java
+++ b/src/integrationTest/java/com/mongodb/hibernate/query/function/string/StringFunctionIntegrationTests.java
@@ -190,36 +190,241 @@ public class StringFunctionIntegrationTests extends AbstractQueryIntegrationTest
                 "select locate(' ', s, 4) from Item",
                 7,
                 """
-                        {
-                          "aggregate": "items",
-                          "pipeline": [
+                {
+                  "aggregate": "items",
+                  "pipeline": [
+                    {
+                      "$project": {
+                        "#c_1": {
+                          "$add": [
                             {
-                              "$project": {
-                                "#c_1": {
-                                  "$add": [
-                                    {
-                                      "$indexOfCP": [
-                                        "$s",
-                                        " ",
+                              "$indexOfCP": [
+                                "$s",
+                                " ",
+                                {
+                                  "$let": {
+                                    "in": {
+                                      "$cond": [
                                         {
-                                          "$subtract": [
-                                            4,
+                                          "$lt": [
+                                            "$$x",
                                             {
-                                              "$literal": 1
+                                              "$literal": 0
                                             }
                                           ]
-                                        }
+                                        },
+                                        {
+                                          "$literal": 0
+                                        },
+                                        "$$x"
                                       ]
                                     },
-                                    {
-                                      "$literal": 1
+                                    "vars": {
+                                      "x": {
+                                        "$subtract": [
+                                          4,
+                                          {
+                                            "$literal": 1
+                                          }
+                                        ]
+                                      }
                                     }
-                                  ]
+                                  }
                                 }
-                              }
+                              ]
+                            },
+                            {
+                              "$literal": 1
                             }
                           ]
                         }
+                      }
+                    }
+                  ]
+                }
+                """);
+    }
+
+    @Test
+    void testLocateZeroStart() {
+        assertQueryResult(
+                "select locate('o', s, 0) from Item",
+                6,
+                """
+                {
+                  "aggregate": "items",
+                  "pipeline": [
+                    {
+                      "$project": {
+                        "#c_1": {
+                          "$add": [
+                            {
+                              "$indexOfCP": [
+                                "$s",
+                                "o",
+                                {
+                                  "$let": {
+                                    "in": {
+                                      "$cond": [
+                                        {
+                                          "$lt": [
+                                            "$$x",
+                                            {
+                                              "$literal": 0
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "$literal": 0
+                                        },
+                                        "$$x"
+                                      ]
+                                    },
+                                    "vars": {
+                                      "x": {
+                                        "$subtract": [
+                                          0,
+                                          {
+                                            "$literal": 1
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  }
+                                }
+                              ]
+                            },
+                            {
+                              "$literal": 1
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  ]
+                }
+                """);
+    }
+
+    @Test
+    void testLocateNegativeStart() {
+        assertQueryResult(
+                "select locate('o', s, -3) from Item",
+                6,
+                """
+                {
+                  "aggregate": "items",
+                  "pipeline": [
+                    {
+                      "$project": {
+                        "#c_1": {
+                          "$add": [
+                            {
+                              "$indexOfCP": [
+                                "$s",
+                                "o",
+                                {
+                                  "$let": {
+                                    "in": {
+                                      "$cond": [
+                                        {
+                                          "$lt": [
+                                            "$$x",
+                                            {
+                                              "$literal": 0
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "$literal": 0
+                                        },
+                                        "$$x"
+                                      ]
+                                    },
+                                    "vars": {
+                                      "x": {
+                                        "$subtract": [
+                                          -3,
+                                          {
+                                            "$literal": 1
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  }
+                                }
+                              ]
+                            },
+                            {
+                              "$literal": 1
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  ]
+                }
+                """);
+    }
+
+    @Test
+    void testLocatePositiveStart() {
+        assertQueryResult(
+                "select locate(' ', s, 4) from Item",
+                7,
+                """
+                {
+                  "aggregate": "items",
+                  "pipeline": [
+                    {
+                      "$project": {
+                        "#c_1": {
+                          "$add": [
+                            {
+                              "$indexOfCP": [
+                                "$s",
+                                " ",
+                                {
+                                  "$let": {
+                                    "in": {
+                                      "$cond": [
+                                        {
+                                          "$lt": [
+                                            "$$x",
+                                            {
+                                              "$literal": 0
+                                            }
+                                          ]
+                                        },
+                                        {
+                                          "$literal": 0
+                                        },
+                                        "$$x"
+                                      ]
+                                    },
+                                    "vars": {
+                                      "x": {
+                                        "$subtract": [
+                                          4,
+                                          {
+                                            "$literal": 1
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  }
+                                }
+                              ]
+                            },
+                            {
+                              "$literal": 1
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  ]
+                }
                 """);
     }
 
@@ -464,133 +669,131 @@ public class StringFunctionIntegrationTests extends AbstractQueryIntegrationTest
                 "select pad(s with 20 leading '*') from Item",
                 "************* Hello ",
                 """
-                        {
-                                  "aggregate": "items",
-                                  "pipeline": [
+                {
+                  "aggregate": "items",
+                  "pipeline": [
+                    {
+                      "$project": {
+                        "#c_1": {
+                          "$let": {
+                            "in": {
+                              "$cond": [
+                                {
+                                  "$lte": [
+                                    "$$targetLen",
                                     {
-                                      "$project": {
-                                        "#c_1": {
-                                          "$let": {
-                                            "in": {
-                                              "$cond": [
-                                                {
-                                                  "$lte": [
-                                                    "$$targetLen",
-                                                    {
-                                                      "$literal": 0
-                                                    }
+                                      "$literal": 0
+                                    }
+                                  ]
+                                },
+                                {
+                                  "$literal": ""
+                                },
+                                {
+                                  "$cond": [
+                                    {
+                                      "$or": [
+                                        {
+                                          "$gte": [
+                                            {
+                                              "$strLenCP": "$$baseStr"
+                                            },
+                                            "$$targetLen"
+                                          ]
+                                        },
+                                        {
+                                          "$eq": [
+                                            {
+                                              "$strLenCP": "$$padding"
+                                            },
+                                            {
+                                              "$literal": 0
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "$substrCP": [
+                                        "$$baseStr",
+                                        {
+                                          "$literal": 0
+                                        },
+                                        "$$targetLen"
+                                      ]
+                                    },
+                                    {
+                                      "$concat": [
+                                        {
+                                          "$substrCP": [
+                                            {
+                                              "$reduce": {
+                                                "in": {
+                                                  "$concat": [
+                                                    "$$padding",
+                                                    "$$value"
                                                   ]
                                                 },
-                                                {
+                                                "initialValue": {
                                                   "$literal": ""
                                                 },
-                                                {
-                                                  "$cond": [
+                                                "input": {
+                                                  "$range": [
                                                     {
-                                                      "$or": [
-                                                        {
-                                                          "$gte": [
-                                                            {
-                                                              "$strLenCP": "$$baseStr"
-                                                            },
-                                                            "$$targetLen"
-                                                          ]
-                                                        },
-                                                        {
-                                                          "$eq": [
-                                                            {
-                                                              "$strLenCP": "$$padding"
-                                                            },
-                                                            {
-                                                              "$literal": 0
-                                                            }
-                                                          ]
-                                                        }
-                                                      ]
+                                                      "$literal": 0
                                                     },
                                                     {
-                                                      "$substrCP": [
-                                                        "$$baseStr",
-                                                        {
-                                                          "$literal": 0
-                                                        },
-                                                        "$$targetLen"
-                                                      ]
-                                                    },
-                                                    {
-                                                      "$concat": [
-                                                        {
-                                                          "$substrCP": [
-                                                            {
-                                                              "$reduce": {
-                                                                "in": {
-                                                                  "$concat": [
-                                                                    "$$padding",
-                                                                    "$$value"
-                                                                  ]
-                                                                },
-                                                                "initialValue": {
-                                                                  "$literal": ""
-                                                                },
-                                                                "input": {
-                                                                  "$range": [
-                                                                    {
-                                                                      "$literal": 0
-                                                                    },
-                                                                    {
-                                                                      "$ceil": {
-                                                                        "$divide": [
-                                                                          {
-                                                                            "$subtract": [
-                                                                              "$$targetLen",
-                                                                              {
-                                                                                "$strLenCP": "$$baseStr"
-                                                                              }
-                                                                            ]
-                                                                          },
-                                                                          {
-                                                                            "$strLenCP": "$$padding"
-                                                                          }
-                                                                        ]
-                                                                      }
-                                                                    }
-                                                                  ]
-                                                                }
+                                                      "$ceil": {
+                                                        "$divide": [
+                                                          {
+                                                            "$subtract": [
+                                                              "$$targetLen",
+                                                              {
+                                                                "$strLenCP": "$$baseStr"
                                                               }
-                                                            },
-                                                            {
-                                                              "$literal": 0
-                                                            },
-                                                            {
-                                                              "$subtract": [
-                                                                "$$targetLen",
-                                                                {
-                                                                  "$strLenCP": "$$baseStr"
-                                                                }
-                                                              ]
-                                                            }
-                                                          ]
-                                                        },
-                                                        "$$baseStr"
-                                                      ]
+                                                            ]
+                                                          },
+                                                          {
+                                                            "$strLenCP": "$$padding"
+                                                          }
+                                                        ]
+                                                      }
                                                     }
                                                   ]
                                                 }
-                                              ]
+                                              }
                                             },
-                                            "vars": {
-                                              "baseStr": "$s",
-                                              "padding": {
-                                                "$toString": "*"
-                                              },
-                                              "targetLen": 20
+                                            {
+                                              "$literal": 0
+                                            },
+                                            {
+                                              "$subtract": [
+                                                "$$targetLen",
+                                                {
+                                                  "$strLenCP": "$$baseStr"
+                                                }
+                                              ]
                                             }
-                                          }
-                                        }
-                                      }
+                                          ]
+                                        },
+                                        "$$baseStr"
+                                      ]
                                     }
                                   ]
                                 }
+                              ]
+                            },
+                            "vars": {
+                              "baseStr": "$s",
+                              "padding": "*",
+                              "targetLen": 20
+                            }
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
                 """);
     }
 
@@ -736,133 +939,131 @@ public class StringFunctionIntegrationTests extends AbstractQueryIntegrationTest
                 "select pad(s with 20 trailing '*') from Item",
                 " Hello *************",
                 """
-                        {
-                                  "aggregate": "items",
-                                  "pipeline": [
+                {
+                  "aggregate": "items",
+                  "pipeline": [
+                    {
+                      "$project": {
+                        "#c_1": {
+                          "$let": {
+                            "in": {
+                              "$cond": [
+                                {
+                                  "$lte": [
+                                    "$$targetLen",
                                     {
-                                      "$project": {
-                                        "#c_1": {
-                                          "$let": {
-                                            "in": {
-                                              "$cond": [
-                                                {
-                                                  "$lte": [
-                                                    "$$targetLen",
-                                                    {
-                                                      "$literal": 0
-                                                    }
+                                      "$literal": 0
+                                    }
+                                  ]
+                                },
+                                {
+                                  "$literal": ""
+                                },
+                                {
+                                  "$cond": [
+                                    {
+                                      "$or": [
+                                        {
+                                          "$gte": [
+                                            {
+                                              "$strLenCP": "$$baseStr"
+                                            },
+                                            "$$targetLen"
+                                          ]
+                                        },
+                                        {
+                                          "$eq": [
+                                            {
+                                              "$strLenCP": "$$padding"
+                                            },
+                                            {
+                                              "$literal": 0
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "$substrCP": [
+                                        "$$baseStr",
+                                        {
+                                          "$literal": 0
+                                        },
+                                        "$$targetLen"
+                                      ]
+                                    },
+                                    {
+                                      "$concat": [
+                                        "$$baseStr",
+                                        {
+                                          "$substrCP": [
+                                            {
+                                              "$reduce": {
+                                                "in": {
+                                                  "$concat": [
+                                                    "$$value",
+                                                    "$$padding"
                                                   ]
                                                 },
-                                                {
+                                                "initialValue": {
                                                   "$literal": ""
                                                 },
-                                                {
-                                                  "$cond": [
+                                                "input": {
+                                                  "$range": [
                                                     {
-                                                      "$or": [
-                                                        {
-                                                          "$gte": [
-                                                            {
-                                                              "$strLenCP": "$$baseStr"
-                                                            },
-                                                            "$$targetLen"
-                                                          ]
-                                                        },
-                                                        {
-                                                          "$eq": [
-                                                            {
-                                                              "$strLenCP": "$$padding"
-                                                            },
-                                                            {
-                                                              "$literal": 0
-                                                            }
-                                                          ]
-                                                        }
-                                                      ]
+                                                      "$literal": 0
                                                     },
                                                     {
-                                                      "$substrCP": [
-                                                        "$$baseStr",
-                                                        {
-                                                          "$literal": 0
-                                                        },
-                                                        "$$targetLen"
-                                                      ]
-                                                    },
-                                                    {
-                                                      "$concat": [
-                                                        "$$baseStr",
-                                                        {
-                                                          "$substrCP": [
-                                                            {
-                                                              "$reduce": {
-                                                                "in": {
-                                                                  "$concat": [
-                                                                    "$$value",
-                                                                    "$$padding"
-                                                                  ]
-                                                                },
-                                                                "initialValue": {
-                                                                  "$literal": ""
-                                                                },
-                                                                "input": {
-                                                                  "$range": [
-                                                                    {
-                                                                      "$literal": 0
-                                                                    },
-                                                                    {
-                                                                      "$ceil": {
-                                                                        "$divide": [
-                                                                          {
-                                                                            "$subtract": [
-                                                                              "$$targetLen",
-                                                                              {
-                                                                                "$strLenCP": "$$baseStr"
-                                                                              }
-                                                                            ]
-                                                                          },
-                                                                          {
-                                                                            "$strLenCP": "$$padding"
-                                                                          }
-                                                                        ]
-                                                                      }
-                                                                    }
-                                                                  ]
-                                                                }
+                                                      "$ceil": {
+                                                        "$divide": [
+                                                          {
+                                                            "$subtract": [
+                                                              "$$targetLen",
+                                                              {
+                                                                "$strLenCP": "$$baseStr"
                                                               }
-                                                            },
-                                                            {
-                                                              "$literal": 0
-                                                            },
-                                                            {
-                                                              "$subtract": [
-                                                                "$$targetLen",
-                                                                {
-                                                                  "$strLenCP": "$$baseStr"
-                                                                }
-                                                              ]
-                                                            }
-                                                          ]
-                                                        }
-                                                      ]
+                                                            ]
+                                                          },
+                                                          {
+                                                            "$strLenCP": "$$padding"
+                                                          }
+                                                        ]
+                                                      }
                                                     }
                                                   ]
                                                 }
-                                              ]
+                                              }
                                             },
-                                            "vars": {
-                                              "baseStr": "$s",
-                                              "padding": {
-                                                "$toString": "*"
-                                              },
-                                              "targetLen": 20
+                                            {
+                                              "$literal": 0
+                                            },
+                                            {
+                                              "$subtract": [
+                                                "$$targetLen",
+                                                {
+                                                  "$strLenCP": "$$baseStr"
+                                                }
+                                              ]
                                             }
-                                          }
+                                          ]
                                         }
-                                      }
+                                      ]
                                     }
                                   ]
                                 }
+                              ]
+                            },
+                            "vars": {
+                              "baseStr": "$s",
+                              "padding": "*",
+                              "targetLen": 20
+                            }
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
                 """);
     }
 
@@ -872,133 +1073,265 @@ public class StringFunctionIntegrationTests extends AbstractQueryIntegrationTest
                 "select lpad('x', 6, 'ab') from Item",
                 "ababax",
                 """
+                {
+                  "aggregate": "items",
+                  "pipeline": [
+                    {
+                      "$project": {
+                        "#c_1": {
+                          "$let": {
+                            "in": {
+                              "$cond": [
                                 {
-                                  "aggregate": "items",
-                                  "pipeline": [
+                                  "$lte": [
+                                    "$$targetLen",
                                     {
-                                      "$project": {
-                                        "#c_1": {
-                                          "$let": {
-                                            "in": {
-                                              "$cond": [
-                                                {
-                                                  "$lte": [
-                                                    "$$targetLen",
-                                                    {
-                                                      "$literal": 0
-                                                    }
+                                      "$literal": 0
+                                    }
+                                  ]
+                                },
+                                {
+                                  "$literal": ""
+                                },
+                                {
+                                  "$cond": [
+                                    {
+                                      "$or": [
+                                        {
+                                          "$gte": [
+                                            {
+                                              "$strLenCP": "$$baseStr"
+                                            },
+                                            "$$targetLen"
+                                          ]
+                                        },
+                                        {
+                                          "$eq": [
+                                            {
+                                              "$strLenCP": "$$padding"
+                                            },
+                                            {
+                                              "$literal": 0
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "$substrCP": [
+                                        "$$baseStr",
+                                        {
+                                          "$literal": 0
+                                        },
+                                        "$$targetLen"
+                                      ]
+                                    },
+                                    {
+                                      "$concat": [
+                                        {
+                                          "$substrCP": [
+                                            {
+                                              "$reduce": {
+                                                "in": {
+                                                  "$concat": [
+                                                    "$$padding",
+                                                    "$$value"
                                                   ]
                                                 },
-                                                {
+                                                "initialValue": {
                                                   "$literal": ""
                                                 },
-                                                {
-                                                  "$cond": [
+                                                "input": {
+                                                  "$range": [
                                                     {
-                                                      "$or": [
-                                                        {
-                                                          "$gte": [
-                                                            {
-                                                              "$strLenCP": "$$baseStr"
-                                                            },
-                                                            "$$targetLen"
-                                                          ]
-                                                        },
-                                                        {
-                                                          "$eq": [
-                                                            {
-                                                              "$strLenCP": "$$padding"
-                                                            },
-                                                            {
-                                                              "$literal": 0
-                                                            }
-                                                          ]
-                                                        }
-                                                      ]
+                                                      "$literal": 0
                                                     },
                                                     {
-                                                      "$substrCP": [
-                                                        "$$baseStr",
-                                                        {
-                                                          "$literal": 0
-                                                        },
-                                                        "$$targetLen"
-                                                      ]
-                                                    },
-                                                    {
-                                                      "$concat": [
-                                                        {
-                                                          "$substrCP": [
-                                                            {
-                                                              "$reduce": {
-                                                                "in": {
-                                                                  "$concat": [
-                                                                    "$$padding",
-                                                                    "$$value"
-                                                                  ]
-                                                                },
-                                                                "initialValue": {
-                                                                  "$literal": ""
-                                                                },
-                                                                "input": {
-                                                                  "$range": [
-                                                                    {
-                                                                      "$literal": 0
-                                                                    },
-                                                                    {
-                                                                      "$ceil": {
-                                                                        "$divide": [
-                                                                          {
-                                                                            "$subtract": [
-                                                                              "$$targetLen",
-                                                                              {
-                                                                                "$strLenCP": "$$baseStr"
-                                                                              }
-                                                                            ]
-                                                                          },
-                                                                          {
-                                                                            "$strLenCP": "$$padding"
-                                                                          }
-                                                                        ]
-                                                                      }
-                                                                    }
-                                                                  ]
-                                                                }
+                                                      "$ceil": {
+                                                        "$divide": [
+                                                          {
+                                                            "$subtract": [
+                                                              "$$targetLen",
+                                                              {
+                                                                "$strLenCP": "$$baseStr"
                                                               }
-                                                            },
-                                                            {
-                                                              "$literal": 0
-                                                            },
-                                                            {
-                                                              "$subtract": [
-                                                                "$$targetLen",
-                                                                {
-                                                                  "$strLenCP": "$$baseStr"
-                                                                }
-                                                              ]
-                                                            }
-                                                          ]
-                                                        },
-                                                        "$$baseStr"
-                                                      ]
+                                                            ]
+                                                          },
+                                                          {
+                                                            "$strLenCP": "$$padding"
+                                                          }
+                                                        ]
+                                                      }
                                                     }
                                                   ]
                                                 }
-                                              ]
+                                              }
                                             },
-                                            "vars": {
-                                              "baseStr": "x",
-                                              "padding": {
-                                                "$toString": "ab"
-                                              },
-                                              "targetLen": 6
+                                            {
+                                              "$literal": 0
+                                            },
+                                            {
+                                              "$subtract": [
+                                                "$$targetLen",
+                                                {
+                                                  "$strLenCP": "$$baseStr"
+                                                }
+                                              ]
                                             }
-                                          }
-                                        }
-                                      }
+                                          ]
+                                        },
+                                        "$$baseStr"
+                                      ]
                                     }
                                   ]
                                 }
+                              ]
+                            },
+                            "vars": {
+                              "baseStr": "x",
+                              "padding": "ab",
+                              "targetLen": 6
+                            }
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+                """);
+    }
+
+    @Test
+    void testRpadPadsToRequestedLengthWithMultiCharacterPadding() {
+        assertQueryResult(
+                "select rpad('x', 6, 'ab') from Item",
+                "xababa",
+                """
+                {
+                  "aggregate": "items",
+                  "pipeline": [
+                    {
+                      "$project": {
+                        "#c_1": {
+                          "$let": {
+                            "in": {
+                              "$cond": [
+                                {
+                                  "$lte": [
+                                    "$$targetLen",
+                                    {
+                                      "$literal": 0
+                                    }
+                                  ]
+                                },
+                                {
+                                  "$literal": ""
+                                },
+                                {
+                                  "$cond": [
+                                    {
+                                      "$or": [
+                                        {
+                                          "$gte": [
+                                            {
+                                              "$strLenCP": "$$baseStr"
+                                            },
+                                            "$$targetLen"
+                                          ]
+                                        },
+                                        {
+                                          "$eq": [
+                                            {
+                                              "$strLenCP": "$$padding"
+                                            },
+                                            {
+                                              "$literal": 0
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "$substrCP": [
+                                        "$$baseStr",
+                                        {
+                                          "$literal": 0
+                                        },
+                                        "$$targetLen"
+                                      ]
+                                    },
+                                    {
+                                      "$concat": [
+                                        "$$baseStr",
+                                        {
+                                          "$substrCP": [
+                                            {
+                                              "$reduce": {
+                                                "in": {
+                                                  "$concat": [
+                                                    "$$value",
+                                                    "$$padding"
+                                                  ]
+                                                },
+                                                "initialValue": {
+                                                  "$literal": ""
+                                                },
+                                                "input": {
+                                                  "$range": [
+                                                    {
+                                                      "$literal": 0
+                                                    },
+                                                    {
+                                                      "$ceil": {
+                                                        "$divide": [
+                                                          {
+                                                            "$subtract": [
+                                                              "$$targetLen",
+                                                              {
+                                                                "$strLenCP": "$$baseStr"
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "$strLenCP": "$$padding"
+                                                          }
+                                                        ]
+                                                      }
+                                                    }
+                                                  ]
+                                                }
+                                              }
+                                            },
+                                            {
+                                              "$literal": 0
+                                            },
+                                            {
+                                              "$subtract": [
+                                                "$$targetLen",
+                                                {
+                                                  "$strLenCP": "$$baseStr"
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            "vars": {
+                              "baseStr": "x",
+                              "padding": "ab",
+                              "targetLen": 6
+                            }
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
                 """);
     }
 
@@ -1124,9 +1457,141 @@ public class StringFunctionIntegrationTests extends AbstractQueryIntegrationTest
                             },
                             "vars": {
                               "baseStr": "$s",
-                              "padding": {
-                                "$toString": ""
-                              },
+                              "padding": "",
+                              "targetLen": 60
+                            }
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+                """);
+    }
+
+    @Test
+    void testRpadWithEmptyPaddingReturnsInput() {
+        assertQueryResult(
+                "select rpad(s, 60, '') from Item",
+                " Hello ",
+                """
+                {
+                  "aggregate": "items",
+                  "pipeline": [
+                    {
+                      "$project": {
+                        "#c_1": {
+                          "$let": {
+                            "in": {
+                              "$cond": [
+                                {
+                                  "$lte": [
+                                    "$$targetLen",
+                                    {
+                                      "$literal": 0
+                                    }
+                                  ]
+                                },
+                                {
+                                  "$literal": ""
+                                },
+                                {
+                                  "$cond": [
+                                    {
+                                      "$or": [
+                                        {
+                                          "$gte": [
+                                            {
+                                              "$strLenCP": "$$baseStr"
+                                            },
+                                            "$$targetLen"
+                                          ]
+                                        },
+                                        {
+                                          "$eq": [
+                                            {
+                                              "$strLenCP": "$$padding"
+                                            },
+                                            {
+                                              "$literal": 0
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "$substrCP": [
+                                        "$$baseStr",
+                                        {
+                                          "$literal": 0
+                                        },
+                                        "$$targetLen"
+                                      ]
+                                    },
+                                    {
+                                      "$concat": [
+                                        "$$baseStr",
+                                        {
+                                          "$substrCP": [
+                                            {
+                                              "$reduce": {
+                                                "in": {
+                                                  "$concat": [
+                                                    "$$value",
+                                                    "$$padding"
+                                                  ]
+                                                },
+                                                "initialValue": {
+                                                  "$literal": ""
+                                                },
+                                                "input": {
+                                                  "$range": [
+                                                    {
+                                                      "$literal": 0
+                                                    },
+                                                    {
+                                                      "$ceil": {
+                                                        "$divide": [
+                                                          {
+                                                            "$subtract": [
+                                                              "$$targetLen",
+                                                              {
+                                                                "$strLenCP": "$$baseStr"
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "$strLenCP": "$$padding"
+                                                          }
+                                                        ]
+                                                      }
+                                                    }
+                                                  ]
+                                                }
+                                              }
+                                            },
+                                            {
+                                              "$literal": 0
+                                            },
+                                            {
+                                              "$subtract": [
+                                                "$$targetLen",
+                                                {
+                                                  "$strLenCP": "$$baseStr"
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            "vars": {
+                              "baseStr": "$s",
+                              "padding": "",
                               "targetLen": 60
                             }
                           }
@@ -1275,7 +1740,143 @@ public class StringFunctionIntegrationTests extends AbstractQueryIntegrationTest
     }
 
     @Test
-    void testPadWithNegativeTargetReturnsEmptyString() {
+    void testPadTrailingTruncatesWhenTargetIsShorterThanInput() {
+        assertQueryResult(
+                "select pad(s with 3 trailing) from Item",
+                " He",
+                """
+                {
+                  "aggregate": "items",
+                  "pipeline": [
+                    {
+                      "$project": {
+                        "#c_1": {
+                          "$let": {
+                            "in": {
+                              "$cond": [
+                                {
+                                  "$lte": [
+                                    "$$targetLen",
+                                    {
+                                      "$literal": 0
+                                    }
+                                  ]
+                                },
+                                {
+                                  "$literal": ""
+                                },
+                                {
+                                  "$cond": [
+                                    {
+                                      "$or": [
+                                        {
+                                          "$gte": [
+                                            {
+                                              "$strLenCP": "$$baseStr"
+                                            },
+                                            "$$targetLen"
+                                          ]
+                                        },
+                                        {
+                                          "$eq": [
+                                            {
+                                              "$strLenCP": "$$padding"
+                                            },
+                                            {
+                                              "$literal": 0
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "$substrCP": [
+                                        "$$baseStr",
+                                        {
+                                          "$literal": 0
+                                        },
+                                        "$$targetLen"
+                                      ]
+                                    },
+                                    {
+                                      "$concat": [
+                                        "$$baseStr",
+                                        {
+                                          "$substrCP": [
+                                            {
+                                              "$reduce": {
+                                                "in": {
+                                                  "$concat": [
+                                                    "$$value",
+                                                    "$$padding"
+                                                  ]
+                                                },
+                                                "initialValue": {
+                                                  "$literal": ""
+                                                },
+                                                "input": {
+                                                  "$range": [
+                                                    {
+                                                      "$literal": 0
+                                                    },
+                                                    {
+                                                      "$ceil": {
+                                                        "$divide": [
+                                                          {
+                                                            "$subtract": [
+                                                              "$$targetLen",
+                                                              {
+                                                                "$strLenCP": "$$baseStr"
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "$strLenCP": "$$padding"
+                                                          }
+                                                        ]
+                                                      }
+                                                    }
+                                                  ]
+                                                }
+                                              }
+                                            },
+                                            {
+                                              "$literal": 0
+                                            },
+                                            {
+                                              "$subtract": [
+                                                "$$targetLen",
+                                                {
+                                                  "$strLenCP": "$$baseStr"
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            "vars": {
+                              "baseStr": "$s",
+                              "padding": {
+                                "$literal": " "
+                              },
+                              "targetLen": 3
+                            }
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+                """);
+    }
+
+    @Test
+    void testPadLeadingWithNegativeTargetReturnsEmptyString() {
         assertQueryResult(
                 "select pad(s with -1 leading) from Item",
                 "",
@@ -1411,6 +2012,678 @@ public class StringFunctionIntegrationTests extends AbstractQueryIntegrationTest
     }
 
     @Test
+    void testPadTrailingWithNegativeTargetReturnsEmptyString() {
+        assertQueryResult(
+                "select pad(s with -1 trailing) from Item",
+                "",
+                """
+                {
+                  "aggregate": "items",
+                  "pipeline": [
+                    {
+                      "$project": {
+                        "#c_1": {
+                          "$let": {
+                            "in": {
+                              "$cond": [
+                                {
+                                  "$lte": [
+                                    "$$targetLen",
+                                    {
+                                      "$literal": 0
+                                    }
+                                  ]
+                                },
+                                {
+                                  "$literal": ""
+                                },
+                                {
+                                  "$cond": [
+                                    {
+                                      "$or": [
+                                        {
+                                          "$gte": [
+                                            {
+                                              "$strLenCP": "$$baseStr"
+                                            },
+                                            "$$targetLen"
+                                          ]
+                                        },
+                                        {
+                                          "$eq": [
+                                            {
+                                              "$strLenCP": "$$padding"
+                                            },
+                                            {
+                                              "$literal": 0
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "$substrCP": [
+                                        "$$baseStr",
+                                        {
+                                          "$literal": 0
+                                        },
+                                        "$$targetLen"
+                                      ]
+                                    },
+                                    {
+                                      "$concat": [
+                                        "$$baseStr",
+                                        {
+                                          "$substrCP": [
+                                            {
+                                              "$reduce": {
+                                                "in": {
+                                                  "$concat": [
+                                                    "$$value",
+                                                    "$$padding"
+                                                  ]
+                                                },
+                                                "initialValue": {
+                                                  "$literal": ""
+                                                },
+                                                "input": {
+                                                  "$range": [
+                                                    {
+                                                      "$literal": 0
+                                                    },
+                                                    {
+                                                      "$ceil": {
+                                                        "$divide": [
+                                                          {
+                                                            "$subtract": [
+                                                              "$$targetLen",
+                                                              {
+                                                                "$strLenCP": "$$baseStr"
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "$strLenCP": "$$padding"
+                                                          }
+                                                        ]
+                                                      }
+                                                    }
+                                                  ]
+                                                }
+                                              }
+                                            },
+                                            {
+                                              "$literal": 0
+                                            },
+                                            {
+                                              "$subtract": [
+                                                "$$targetLen",
+                                                {
+                                                  "$strLenCP": "$$baseStr"
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            "vars": {
+                              "baseStr": "$s",
+                              "padding": {
+                                "$literal": " "
+                              },
+                              "targetLen": -1
+                            }
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+                """);
+    }
+
+    @Test
+    void testLpadMuliCharExact() {
+        assertQueryResult(
+                "select lpad('ab', 6, 'ab') from Item",
+                "ababab",
+                """
+                {
+                  "aggregate": "items",
+                  "pipeline": [
+                    {
+                      "$project": {
+                        "#c_1": {
+                          "$let": {
+                            "in": {
+                              "$cond": [
+                                {
+                                  "$lte": [
+                                    "$$targetLen",
+                                    {
+                                      "$literal": 0
+                                    }
+                                  ]
+                                },
+                                {
+                                  "$literal": ""
+                                },
+                                {
+                                  "$cond": [
+                                    {
+                                      "$or": [
+                                        {
+                                          "$gte": [
+                                            {
+                                              "$strLenCP": "$$baseStr"
+                                            },
+                                            "$$targetLen"
+                                          ]
+                                        },
+                                        {
+                                          "$eq": [
+                                            {
+                                              "$strLenCP": "$$padding"
+                                            },
+                                            {
+                                              "$literal": 0
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "$substrCP": [
+                                        "$$baseStr",
+                                        {
+                                          "$literal": 0
+                                        },
+                                        "$$targetLen"
+                                      ]
+                                    },
+                                    {
+                                      "$concat": [
+                                        {
+                                          "$substrCP": [
+                                            {
+                                              "$reduce": {
+                                                "in": {
+                                                  "$concat": [
+                                                    "$$padding",
+                                                    "$$value"
+                                                  ]
+                                                },
+                                                "initialValue": {
+                                                  "$literal": ""
+                                                },
+                                                "input": {
+                                                  "$range": [
+                                                    {
+                                                      "$literal": 0
+                                                    },
+                                                    {
+                                                      "$ceil": {
+                                                        "$divide": [
+                                                          {
+                                                            "$subtract": [
+                                                              "$$targetLen",
+                                                              {
+                                                                "$strLenCP": "$$baseStr"
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "$strLenCP": "$$padding"
+                                                          }
+                                                        ]
+                                                      }
+                                                    }
+                                                  ]
+                                                }
+                                              }
+                                            },
+                                            {
+                                              "$literal": 0
+                                            },
+                                            {
+                                              "$subtract": [
+                                                "$$targetLen",
+                                                {
+                                                  "$strLenCP": "$$baseStr"
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        },
+                                        "$$baseStr"
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            "vars": {
+                              "baseStr": "ab",
+                              "padding": "ab",
+                              "targetLen": 6
+                            }
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+                """);
+    }
+
+    @Test
+    void testRpadMuliCharExact() {
+        assertQueryResult(
+                "select rpad('ab', 6, 'ab') from Item",
+                "ababab",
+                """
+                {
+                  "aggregate": "items",
+                  "pipeline": [
+                    {
+                      "$project": {
+                        "#c_1": {
+                          "$let": {
+                            "in": {
+                              "$cond": [
+                                {
+                                  "$lte": [
+                                    "$$targetLen",
+                                    {
+                                      "$literal": 0
+                                    }
+                                  ]
+                                },
+                                {
+                                  "$literal": ""
+                                },
+                                {
+                                  "$cond": [
+                                    {
+                                      "$or": [
+                                        {
+                                          "$gte": [
+                                            {
+                                              "$strLenCP": "$$baseStr"
+                                            },
+                                            "$$targetLen"
+                                          ]
+                                        },
+                                        {
+                                          "$eq": [
+                                            {
+                                              "$strLenCP": "$$padding"
+                                            },
+                                            {
+                                              "$literal": 0
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "$substrCP": [
+                                        "$$baseStr",
+                                        {
+                                          "$literal": 0
+                                        },
+                                        "$$targetLen"
+                                      ]
+                                    },
+                                    {
+                                      "$concat": [
+                                        "$$baseStr",
+                                        {
+                                          "$substrCP": [
+                                            {
+                                              "$reduce": {
+                                                "in": {
+                                                  "$concat": [
+                                                    "$$value",
+                                                    "$$padding"
+                                                  ]
+                                                },
+                                                "initialValue": {
+                                                  "$literal": ""
+                                                },
+                                                "input": {
+                                                  "$range": [
+                                                    {
+                                                      "$literal": 0
+                                                    },
+                                                    {
+                                                      "$ceil": {
+                                                        "$divide": [
+                                                          {
+                                                            "$subtract": [
+                                                              "$$targetLen",
+                                                              {
+                                                                "$strLenCP": "$$baseStr"
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "$strLenCP": "$$padding"
+                                                          }
+                                                        ]
+                                                      }
+                                                    }
+                                                  ]
+                                                }
+                                              }
+                                            },
+                                            {
+                                              "$literal": 0
+                                            },
+                                            {
+                                              "$subtract": [
+                                                "$$targetLen",
+                                                {
+                                                  "$strLenCP": "$$baseStr"
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            "vars": {
+                              "baseStr": "ab",
+                              "padding": "ab",
+                              "targetLen": 6
+                            }
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+                """);
+    }
+
+    @Test
+    void testLpadLongPadding() {
+        assertQueryResult(
+                "select lpad('x', 3, 'abcdef') from Item",
+                "abx",
+                """
+                {
+                  "aggregate": "items",
+                  "pipeline": [
+                    {
+                      "$project": {
+                        "#c_1": {
+                          "$let": {
+                            "in": {
+                              "$cond": [
+                                {
+                                  "$lte": [
+                                    "$$targetLen",
+                                    {
+                                      "$literal": 0
+                                    }
+                                  ]
+                                },
+                                {
+                                  "$literal": ""
+                                },
+                                {
+                                  "$cond": [
+                                    {
+                                      "$or": [
+                                        {
+                                          "$gte": [
+                                            {
+                                              "$strLenCP": "$$baseStr"
+                                            },
+                                            "$$targetLen"
+                                          ]
+                                        },
+                                        {
+                                          "$eq": [
+                                            {
+                                              "$strLenCP": "$$padding"
+                                            },
+                                            {
+                                              "$literal": 0
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "$substrCP": [
+                                        "$$baseStr",
+                                        {
+                                          "$literal": 0
+                                        },
+                                        "$$targetLen"
+                                      ]
+                                    },
+                                    {
+                                      "$concat": [
+                                        {
+                                          "$substrCP": [
+                                            {
+                                              "$reduce": {
+                                                "in": {
+                                                  "$concat": [
+                                                    "$$padding",
+                                                    "$$value"
+                                                  ]
+                                                },
+                                                "initialValue": {
+                                                  "$literal": ""
+                                                },
+                                                "input": {
+                                                  "$range": [
+                                                    {
+                                                      "$literal": 0
+                                                    },
+                                                    {
+                                                      "$ceil": {
+                                                        "$divide": [
+                                                          {
+                                                            "$subtract": [
+                                                              "$$targetLen",
+                                                              {
+                                                                "$strLenCP": "$$baseStr"
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "$strLenCP": "$$padding"
+                                                          }
+                                                        ]
+                                                      }
+                                                    }
+                                                  ]
+                                                }
+                                              }
+                                            },
+                                            {
+                                              "$literal": 0
+                                            },
+                                            {
+                                              "$subtract": [
+                                                "$$targetLen",
+                                                {
+                                                  "$strLenCP": "$$baseStr"
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        },
+                                        "$$baseStr"
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            "vars": {
+                              "baseStr": "x",
+                              "padding": "abcdef",
+                              "targetLen": 3
+                            }
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+                """);
+    }
+
+    @Test
+    void testRpadLongPadding() {
+        assertQueryResult(
+                "select rpad('x', 3, 'abcdef') from Item",
+                "xab",
+                """
+                {
+                  "aggregate": "items",
+                  "pipeline": [
+                    {
+                      "$project": {
+                        "#c_1": {
+                          "$let": {
+                            "in": {
+                              "$cond": [
+                                {
+                                  "$lte": [
+                                    "$$targetLen",
+                                    {
+                                      "$literal": 0
+                                    }
+                                  ]
+                                },
+                                {
+                                  "$literal": ""
+                                },
+                                {
+                                  "$cond": [
+                                    {
+                                      "$or": [
+                                        {
+                                          "$gte": [
+                                            {
+                                              "$strLenCP": "$$baseStr"
+                                            },
+                                            "$$targetLen"
+                                          ]
+                                        },
+                                        {
+                                          "$eq": [
+                                            {
+                                              "$strLenCP": "$$padding"
+                                            },
+                                            {
+                                              "$literal": 0
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "$substrCP": [
+                                        "$$baseStr",
+                                        {
+                                          "$literal": 0
+                                        },
+                                        "$$targetLen"
+                                      ]
+                                    },
+                                    {
+                                      "$concat": [
+                                        "$$baseStr",
+                                        {
+                                          "$substrCP": [
+                                            {
+                                              "$reduce": {
+                                                "in": {
+                                                  "$concat": [
+                                                    "$$value",
+                                                    "$$padding"
+                                                  ]
+                                                },
+                                                "initialValue": {
+                                                  "$literal": ""
+                                                },
+                                                "input": {
+                                                  "$range": [
+                                                    {
+                                                      "$literal": 0
+                                                    },
+                                                    {
+                                                      "$ceil": {
+                                                        "$divide": [
+                                                          {
+                                                            "$subtract": [
+                                                              "$$targetLen",
+                                                              {
+                                                                "$strLenCP": "$$baseStr"
+                                                              }
+                                                            ]
+                                                          },
+                                                          {
+                                                            "$strLenCP": "$$padding"
+                                                          }
+                                                        ]
+                                                      }
+                                                    }
+                                                  ]
+                                                }
+                                              }
+                                            },
+                                            {
+                                              "$literal": 0
+                                            },
+                                            {
+                                              "$subtract": [
+                                                "$$targetLen",
+                                                {
+                                                  "$strLenCP": "$$baseStr"
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            "vars": {
+                              "baseStr": "x",
+                              "padding": "abcdef",
+                              "targetLen": 3
+                            }
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+                """);
+    }
+
+    @Test
     void testSubstring() {
         assertQueryResult(
                 "select substring(s, 2) from Item",
@@ -1494,15 +2767,37 @@ public class StringFunctionIntegrationTests extends AbstractQueryIntegrationTest
                                     "$$str",
                                     "$$adjustedStart",
                                     {
-                                      "$add": [
-                                        "$$len",
-                                        {
-                                          "$subtract": [
-                                            "$$start",
-                                            "$$adjustedStart"
+                                      "$let": {
+                                        "in": {
+                                          "$cond": [
+                                            {
+                                              "$lt": [
+                                                "$$x",
+                                                {
+                                                  "$literal": 0
+                                                }
+                                              ]
+                                            },
+                                            {
+                                              "$literal": 0
+                                            },
+                                            "$$x"
                                           ]
+                                        },
+                                        "vars": {
+                                          "x": {
+                                            "$add": [
+                                              "$$len",
+                                              {
+                                                "$subtract": [
+                                                  "$$start",
+                                                  "$$adjustedStart"
+                                                ]
+                                              }
+                                            ]
+                                          }
                                         }
-                                      ]
+                                      }
                                     }
                                   ]
                                 },
@@ -1631,15 +2926,37 @@ public class StringFunctionIntegrationTests extends AbstractQueryIntegrationTest
                                     "$$str",
                                     "$$adjustedStart",
                                     {
-                                      "$add": [
-                                        "$$len",
-                                        {
-                                          "$subtract": [
-                                            "$$start",
-                                            "$$adjustedStart"
+                                      "$let": {
+                                        "in": {
+                                          "$cond": [
+                                            {
+                                              "$lt": [
+                                                "$$x",
+                                                {
+                                                  "$literal": 0
+                                                }
+                                              ]
+                                            },
+                                            {
+                                              "$literal": 0
+                                            },
+                                            "$$x"
                                           ]
+                                        },
+                                        "vars": {
+                                          "x": {
+                                            "$add": [
+                                              "$$len",
+                                              {
+                                                "$subtract": [
+                                                  "$$start",
+                                                  "$$adjustedStart"
+                                                ]
+                                              }
+                                            ]
+                                          }
                                         }
-                                      ]
+                                      }
                                     }
                                   ]
                                 },
@@ -1704,15 +3021,37 @@ public class StringFunctionIntegrationTests extends AbstractQueryIntegrationTest
                                     "$$str",
                                     "$$adjustedStart",
                                     {
-                                      "$add": [
-                                        "$$len",
-                                        {
-                                          "$subtract": [
-                                            "$$start",
-                                            "$$adjustedStart"
+                                      "$let": {
+                                        "in": {
+                                          "$cond": [
+                                            {
+                                              "$lt": [
+                                                "$$x",
+                                                {
+                                                  "$literal": 0
+                                                }
+                                              ]
+                                            },
+                                            {
+                                              "$literal": 0
+                                            },
+                                            "$$x"
                                           ]
+                                        },
+                                        "vars": {
+                                          "x": {
+                                            "$add": [
+                                              "$$len",
+                                              {
+                                                "$subtract": [
+                                                  "$$start",
+                                                  "$$adjustedStart"
+                                                ]
+                                              }
+                                            ]
+                                          }
                                         }
-                                      ]
+                                      }
                                     }
                                   ]
                                 },
@@ -1741,6 +3080,101 @@ public class StringFunctionIntegrationTests extends AbstractQueryIntegrationTest
                               "start": {
                                 "$subtract": [
                                   0,
+                                  {
+                                    "$literal": 1
+                                  }
+                                ]
+                              },
+                              "str": "$s"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+                """);
+    }
+
+    @Test
+    void testSubstringNegative() {
+        assertQueryResult(
+                "select substring(s, -5, 2) from Item",
+                "",
+                """
+                {
+                  "aggregate": "items",
+                  "pipeline": [
+                    {
+                      "$project": {
+                        "#c_1": {
+                          "$let": {
+                            "in": {
+                              "$let": {
+                                "in": {
+                                  "$substrCP": [
+                                    "$$str",
+                                    "$$adjustedStart",
+                                    {
+                                      "$let": {
+                                        "in": {
+                                          "$cond": [
+                                            {
+                                              "$lt": [
+                                                "$$x",
+                                                {
+                                                  "$literal": 0
+                                                }
+                                              ]
+                                            },
+                                            {
+                                              "$literal": 0
+                                            },
+                                            "$$x"
+                                          ]
+                                        },
+                                        "vars": {
+                                          "x": {
+                                            "$add": [
+                                              "$$len",
+                                              {
+                                                "$subtract": [
+                                                  "$$start",
+                                                  "$$adjustedStart"
+                                                ]
+                                              }
+                                            ]
+                                          }
+                                        }
+                                      }
+                                    }
+                                  ]
+                                },
+                                "vars": {
+                                  "adjustedStart": {
+                                    "$cond": [
+                                      {
+                                        "$lt": [
+                                          "$$start",
+                                          {
+                                            "$literal": 0
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "$literal": 0
+                                      },
+                                      "$$start"
+                                    ]
+                                  }
+                                }
+                              }
+                            },
+                            "vars": {
+                              "len": 2,
+                              "start": {
+                                "$subtract": [
+                                  -5,
                                   {
                                     "$literal": 1
                                   }

--- a/src/integrationTest/java/com/mongodb/hibernate/query/function/string/StringFunctionIntegrationTests.java
+++ b/src/integrationTest/java/com/mongodb/hibernate/query/function/string/StringFunctionIntegrationTests.java
@@ -1,0 +1,243 @@
+/*
+ * Copyright 2025-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.hibernate.query.function.string;
+
+import com.mongodb.hibernate.junit.MongoExtension;
+import com.mongodb.hibernate.query.AbstractQueryIntegrationTests;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.util.Objects;
+import org.hibernate.query.sqm.produce.function.FunctionArgumentException;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.hibernate.testing.orm.junit.SessionFactory;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@SessionFactory(exportSchema = false)
+@DomainModel(annotatedClasses = {StringFunctionIntegrationTests.Item.class})
+@ExtendWith(MongoExtension.class)
+public class StringFunctionIntegrationTests extends AbstractQueryIntegrationTests {
+    private static final String COLLECTION_NAME = "items";
+    private static final Item HELLO = new Item(1, " Hello ", "_Hello_");
+
+    private void assertQueryResult(String hql, Object expected) {
+        getSessionFactoryScope().inTransaction(session -> {
+            var selectionQuery = session.createSelectionQuery(hql, Object[].class);
+            var resultList = selectionQuery.getResultList();
+            Assertions.assertEquals(1, resultList.size());
+            Assertions.assertEquals(1, resultList.get(0).length);
+            Assertions.assertEquals(expected, resultList.get(0)[0]);
+        });
+    }
+
+    @BeforeEach
+    void beforeEach() {
+        getSessionFactoryScope().inTransaction(session -> {
+            session.persist(HELLO);
+        });
+    }
+
+    @Test
+    void testCharacterLength() {
+        assertQueryResult("select length(s) from Item", 7);
+    }
+
+    @Test
+    void testConcat() {
+        assertQueryResult("select s||s from Item", " Hello  Hello ");
+    }
+
+    @Test
+    void testConcatCoerce() {
+        assertQueryResult("select s||3 from Item", " Hello 3");
+    }
+
+    @Test
+    void testConcatLiteral() {
+        assertQueryResult("select concat(s, '!') from Item", " Hello !");
+    }
+
+    @Test
+    void testLocate() {
+        assertQueryResult("select locate('o', s) from Item", 6);
+    }
+
+    @Test
+    void testLocateMissing() {
+        assertQueryResult("select locate('z', s) from Item", 0);
+    }
+
+    @Test
+    void testLocateOffset() {
+        assertQueryResult("select locate('H', s, 1, 2) from Item", 2);
+    }
+
+    @Test
+    void testLocateOffsetMissing() {
+        assertQueryResult("select locate('o', s, 1, 2) from Item", 0);
+    }
+
+    @Test
+    void testLower() {
+        assertQueryResult("select lower(s) from Item", " hello ");
+    }
+
+    @Test
+    void testLeftTrim() {
+        assertQueryResult("select ltrim(s) from Item", "Hello ");
+    }
+
+    @Test
+    void testLeftTrimChars() {
+        assertQueryResult("select ltrim(u, '_') from Item", "Hello_");
+    }
+
+    @Test
+    void testReplaceAll() {
+        assertQueryResult("select replace_all(s, ' ', '_') from Item", "_Hello_");
+    }
+
+    @Test
+    void testReplaceOne() {
+        assertQueryResult("select replace_one(s, ' ', '_') from Item", "_Hello ");
+    }
+
+    @Test
+    void testRightTrim() {
+        assertQueryResult("select rtrim(s) from Item", " Hello");
+    }
+
+    @Test
+    void testRightTrimChars() {
+        assertQueryResult("select rtrim(u, '_') from Item", "_Hello");
+    }
+
+    @Test
+    void testRightTrimWrongType() {
+        assertSelectQueryFailure(
+                "select rtrim(u, 3) from Item",
+                String.class,
+                FunctionArgumentException.class,
+                "Parameter 2 of function 'rtrim()' has type 'STRING', but argument is of type 'java.lang.Integer' mapped to 'INTEGER'");
+    }
+
+    @Test
+    void testSubstring() {
+        assertQueryResult("select substring(s, 2) from Item", "Hello ");
+    }
+
+    @Test
+    void testSubstringLen() {
+        assertQueryResult("select substring(s, 3, 2) from Item", "el");
+    }
+
+    @Test
+    void testTrim() {
+        assertQueryResult("select trim(s) from Item", "Hello");
+    }
+
+    @Test
+    void testTrimLeading() {
+        assertQueryResult("select trim(leading from s) from Item", "Hello ");
+    }
+
+    @Test
+    void testTrimTrailing() {
+        assertQueryResult("select trim(trailing from s) from Item", " Hello");
+    }
+
+    @Test
+    void testTrimBoth() {
+        assertQueryResult("select trim(both from s) from Item", "Hello");
+    }
+
+    @Test
+    void testTrimLeadingNonWS() {
+        assertQueryResult("select trim(leading '_' from u) from Item", "Hello_");
+    }
+
+    @Test
+    void testTrimTrailingNonWS() {
+        assertQueryResult("select trim(trailing '_' from u) from Item", "_Hello");
+    }
+
+    @Test
+    void testTrimBothNonWS() {
+        assertQueryResult("select trim(both '_' from u) from Item", "Hello");
+    }
+
+    @Test
+    void testUpper() {
+        assertQueryResult("select upper(s) from Item", " HELLO ");
+    }
+
+    @Test
+    void testSubstringWrongType() {
+        assertSelectQueryFailure(
+                "select substring(3, s) from Item",
+                String.class,
+                FunctionArgumentException.class,
+                "Parameter 1 of function 'substring()' has type 'STRING', but argument is of type 'java.lang.Integer' mapped to 'INTEGER'");
+    }
+
+    @Test
+    void testUpperWrongType() {
+        assertSelectQueryFailure(
+                "select upper(3) from Item",
+                String.class,
+                FunctionArgumentException.class,
+                "Parameter 1 of function 'upper()' has type 'STRING', but argument is of type 'java.lang.Integer' mapped to 'INTEGER'");
+    }
+
+    @Entity(name = "Item")
+    @Table(name = COLLECTION_NAME)
+    static class Item {
+        @Id
+        int id;
+
+        String s;
+        String u;
+
+        Item() {}
+
+        Item(int id, String s, String u) {
+            this.id = id;
+            this.s = s;
+            this.u = u;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (o == null || getClass() != o.getClass()) return false;
+            Item item = (Item) o;
+            return id == item.id && Objects.equals(s, item.s) && Objects.equals(u, item.u);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(id, s, u);
+        }
+
+        @Override
+        public String toString() {
+            return "Item{" + "id=" + id + ", s='" + s + '\'' + ", u='" + u + '\'' + '}';
+        }
+    }
+}

--- a/src/integrationTest/java/com/mongodb/hibernate/query/mutation/UpdatingIntegrationTests.java
+++ b/src/integrationTest/java/com/mongodb/hibernate/query/mutation/UpdatingIntegrationTests.java
@@ -160,6 +160,90 @@ class UpdatingIntegrationTests extends AbstractQueryIntegrationTests {
     }
 
     @Test
+    void testFunctionExpressionAssignment() {
+        var hql = "update Book b set b.title = upper(b.title) where b.id = 1";
+        assertMutationQuery(
+                hql,
+                query -> {},
+                1,
+                """
+                {
+                    "update": "books",
+                    "updates": [
+                        {
+                            "q": {"_id": {"$eq": {"$numberInt": "1"}}},
+                            "u": [{"$set": {"title": {"$toUpper": "$title"}}}],
+                            "multi": true
+                        }
+                    ]
+                }
+                """,
+                booksCollection,
+                List.of(
+                        BsonDocument.parse(
+                                """
+                                {
+                                  "_id": 1,
+                                  "title": "WAR & PEACE",
+                                  "outOfStock": true,
+                                  "publishYear": 1869,
+                                  "isbn13": null,
+                                  "discount": null,
+                                  "price": null
+                                }
+                                """),
+                        BsonDocument.parse(
+                                """
+                                {
+                                  "_id": 2,
+                                  "title": "Crime and Punishment",
+                                  "outOfStock": false,
+                                  "publishYear": 1866,
+                                  "isbn13": null,
+                                  "discount": null,
+                                  "price": null
+                                }
+                                """),
+                        BsonDocument.parse(
+                                """
+                                {
+                                  "_id": 3,
+                                  "title": "Anna Karenina",
+                                  "outOfStock": false,
+                                  "publishYear": 1877,
+                                  "isbn13": null,
+                                  "discount": null,
+                                  "price": null
+                                }
+                                """),
+                        BsonDocument.parse(
+                                """
+                                {
+                                  "_id": 4,
+                                  "title": "The Brothers Karamazov",
+                                  "outOfStock": false,
+                                  "publishYear": 1880,
+                                  "isbn13": null,
+                                  "discount": null,
+                                  "price": null
+                                }
+                                """),
+                        BsonDocument.parse(
+                                """
+                                {
+                                  "_id": 5,
+                                  "title": "War & Peace",
+                                  "outOfStock": false,
+                                  "publishYear": 2025,
+                                  "isbn13": null,
+                                  "discount": null,
+                                  "price": null
+                                }
+                                """)),
+                Set.of(Book.COLLECTION_NAME));
+    }
+
+    @Test
     void testUpdateWithZeroMutationCount() {
         assertMutationQuery(
                 "update Book set outOfStock = false where publishYear < :year",
@@ -339,15 +423,6 @@ class UpdatingIntegrationTests extends AbstractQueryIntegrationTests {
 
     @Nested
     class Unsupported implements MongoServiceRegistryProducer {
-        @Test
-        void testFunctionExpressionAssignment() {
-            var hql = "update Book b set b.title = upper(b.title) where b.id = 1";
-            assertMutationQueryFailure(
-                    hql,
-                    query -> {},
-                    FeatureNotSupportedException.class,
-                    "TODO-HIBERNATE-196 https://jira.mongodb.org/browse/HIBERNATE-196");
-        }
 
         @Test
         void testCaseExpressionAssignment() {

--- a/src/main/java/com/mongodb/hibernate/internal/dialect/MongoDialect.java
+++ b/src/main/java/com/mongodb/hibernate/internal/dialect/MongoDialect.java
@@ -17,11 +17,8 @@
 package com.mongodb.hibernate.internal.dialect;
 
 import static com.mongodb.hibernate.internal.MongoConstants.MONGO_DBMS_NAME;
-import static com.mongodb.hibernate.internal.dialect.function.FunctionParameterDefinition.orDefault;
 import static com.mongodb.hibernate.internal.dialect.function.FunctionParameterDefinition.orMissing;
 import static com.mongodb.hibernate.internal.dialect.function.FunctionParameterDefinition.required;
-import static com.mongodb.hibernate.internal.dialect.function.MongoExpressionPositionalFunction.allModifications;
-import static com.mongodb.hibernate.internal.dialect.function.MongoExpressionPositionalFunction.offsetToEnd;
 import static com.mongodb.hibernate.internal.dialect.function.MongoExpressionPositionalFunction.swap;
 import static java.lang.String.format;
 
@@ -34,6 +31,7 @@ import com.mongodb.hibernate.internal.dialect.function.MongoExpressionUnaryFunct
 import com.mongodb.hibernate.internal.dialect.function.MongoExpressionVariadicFunction;
 import com.mongodb.hibernate.internal.dialect.function.MongoPadFunction;
 import com.mongodb.hibernate.internal.dialect.function.MongoRepeatFunction;
+import com.mongodb.hibernate.internal.dialect.function.MongoSubstringFunction;
 import com.mongodb.hibernate.internal.dialect.function.MongoTrimFunction;
 import com.mongodb.hibernate.internal.dialect.function.array.MongoArrayConstructorFunction;
 import com.mongodb.hibernate.internal.dialect.function.array.MongoArrayContainsFunction;
@@ -54,7 +52,6 @@ import java.util.Collection;
 import java.util.function.Function;
 import java.util.stream.Stream;
 import org.bson.BsonDocument;
-import org.bson.BsonInt32;
 import org.bson.BsonString;
 import org.hibernate.JDBCException;
 import org.hibernate.boot.Metadata;
@@ -334,11 +331,10 @@ public sealed class MongoDialect extends Dialect permits TestMongoDialect {
                         typeConfiguration,
                         StandardBasicTypes.INTEGER,
                         FunctionParameterDefinition::addOne,
-                        allModifications(swap(0, 1), offsetToEnd(2, 3)),
+                        swap(0, 1),
                         required(FunctionParameterType.STRING),
                         required(FunctionParameterType.STRING),
-                        orMissing(FunctionParameterType.INTEGER).map(FunctionParameterDefinition::subtractOne),
-                        orMissing(FunctionParameterType.INTEGER)));
+                        orMissing(FunctionParameterType.INTEGER).map(FunctionParameterDefinition::subtractOne)));
         functionRegistry.register(
                 "lower",
                 new MongoExpressionUnaryFunction(
@@ -360,16 +356,7 @@ public sealed class MongoDialect extends Dialect permits TestMongoDialect {
                         required("find", FunctionParameterType.STRING),
                         required("replacement", FunctionParameterType.STRING)));
         functionRegistry.register("rpad", new MongoPadFunction(typeConfiguration, false));
-        functionRegistry.register(
-                "substring",
-                new MongoExpressionPositionalFunction(
-                        "substring",
-                        "$substrCP",
-                        typeConfiguration,
-                        StandardBasicTypes.STRING,
-                        required(FunctionParameterType.STRING),
-                        required(FunctionParameterType.INTEGER).map(FunctionParameterDefinition::subtractOne),
-                        orDefault(new BsonInt32(Integer.MAX_VALUE))));
+        functionRegistry.register("substring", new MongoSubstringFunction(typeConfiguration));
         functionRegistry.register("trim", new MongoTrimFunction(typeConfiguration));
         functionRegistry.register("unnest", new MongoUnnestFunction());
         functionRegistry.register(

--- a/src/main/java/com/mongodb/hibernate/internal/dialect/MongoDialect.java
+++ b/src/main/java/com/mongodb/hibernate/internal/dialect/MongoDialect.java
@@ -17,14 +17,27 @@
 package com.mongodb.hibernate.internal.dialect;
 
 import static com.mongodb.hibernate.internal.MongoConstants.MONGO_DBMS_NAME;
+import static com.mongodb.hibernate.internal.dialect.function.FunctionParameterDefinition.orDefault;
+import static com.mongodb.hibernate.internal.dialect.function.FunctionParameterDefinition.orMissing;
+import static com.mongodb.hibernate.internal.dialect.function.FunctionParameterDefinition.required;
+import static com.mongodb.hibernate.internal.dialect.function.MongoExpressionPositionalFunction.allModifications;
+import static com.mongodb.hibernate.internal.dialect.function.MongoExpressionPositionalFunction.offsetToEnd;
+import static com.mongodb.hibernate.internal.dialect.function.MongoExpressionPositionalFunction.swap;
 import static java.lang.String.format;
 
 import com.mongodb.hibernate.internal.FeatureNotSupportedException;
+import com.mongodb.hibernate.internal.dialect.function.FunctionParameterDefinition;
+import com.mongodb.hibernate.internal.dialect.function.MongoExpressionNamedFunction;
+import com.mongodb.hibernate.internal.dialect.function.MongoExpressionPositionalFunction;
+import com.mongodb.hibernate.internal.dialect.function.MongoExpressionUnaryFunction;
+import com.mongodb.hibernate.internal.dialect.function.MongoExpressionVariadicFunction;
+import com.mongodb.hibernate.internal.dialect.function.MongoTrimFunction;
 import com.mongodb.hibernate.internal.dialect.function.array.MongoArrayConstructorFunction;
 import com.mongodb.hibernate.internal.dialect.function.array.MongoArrayContainsFunction;
 import com.mongodb.hibernate.internal.dialect.function.array.MongoArrayIncludesFunction;
 import com.mongodb.hibernate.internal.dialect.function.array.MongoUnnestFunction;
 import com.mongodb.hibernate.internal.translate.MongoTranslatorFactory;
+import com.mongodb.hibernate.internal.translate.mongoast.AstUnaryOperatorExpression;
 import com.mongodb.hibernate.internal.type.MongoArrayJdbcType;
 import com.mongodb.hibernate.internal.type.MongoStructJdbcType;
 import com.mongodb.hibernate.internal.type.ObjectIdJavaType;
@@ -35,6 +48,8 @@ import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.Calendar;
 import java.util.Collection;
+import java.util.function.Function;
+import org.bson.BsonInt32;
 import org.hibernate.JDBCException;
 import org.hibernate.boot.model.FunctionContributions;
 import org.hibernate.boot.model.TypeContributions;
@@ -49,6 +64,7 @@ import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.exception.spi.SQLExceptionConversionDelegate;
 import org.hibernate.persister.entity.mutation.EntityMutationTarget;
+import org.hibernate.query.sqm.produce.function.FunctionParameterType;
 import org.hibernate.service.ServiceRegistry;
 import org.hibernate.sql.ast.SqlAstTranslatorFactory;
 import org.hibernate.sql.ast.spi.SqlAppender;
@@ -57,6 +73,7 @@ import org.hibernate.sql.model.ValuesAnalysis;
 import org.hibernate.sql.model.internal.OptionalTableUpdate;
 import org.hibernate.sql.model.jdbc.OptionalTableUpdateOperation;
 import org.hibernate.type.SqlTypes;
+import org.hibernate.type.StandardBasicTypes;
 import org.hibernate.type.descriptor.jdbc.TimestampUtcAsInstantJdbcType;
 import org.hibernate.type.descriptor.sql.internal.DdlTypeImpl;
 import org.jspecify.annotations.Nullable;
@@ -274,12 +291,111 @@ public sealed class MongoDialect extends Dialect permits TestMongoDialect {
         var functionRegistry = functionContributions.getFunctionRegistry();
         var typeConfiguration = functionContributions.getTypeConfiguration();
         functionRegistry.register("array", new MongoArrayConstructorFunction(false));
-        functionRegistry.register("array_list", new MongoArrayConstructorFunction(true));
         functionRegistry.register("array_contains", new MongoArrayContainsFunction(false, typeConfiguration));
         functionRegistry.register("array_contains_nullable", new MongoArrayContainsFunction(true, typeConfiguration));
         functionRegistry.register("array_includes", new MongoArrayIncludesFunction(false, typeConfiguration));
         functionRegistry.register("array_includes_nullable", new MongoArrayIncludesFunction(true, typeConfiguration));
+        functionRegistry.register("array_list", new MongoArrayConstructorFunction(true));
+        functionRegistry.register(
+                "character_length",
+                new MongoExpressionUnaryFunction(
+                        "character_length",
+                        "$strLenCP",
+                        typeConfiguration,
+                        StandardBasicTypes.INTEGER,
+                        FunctionParameterType.STRING));
+        functionRegistry.register(
+                "concat",
+                new MongoExpressionVariadicFunction(
+                        "concat",
+                        "$concat",
+                        typeConfiguration,
+                        StandardBasicTypes.STRING,
+                        Function.identity(),
+                        FunctionParameterType.ANY,
+                        input -> new AstUnaryOperatorExpression("$toString", input)));
+        functionRegistry.register(
+                "locate",
+                new MongoExpressionPositionalFunction(
+                        "locate",
+                        "$indexOfCP",
+                        typeConfiguration,
+                        StandardBasicTypes.INTEGER,
+                        FunctionParameterDefinition::addOne,
+                        allModifications(swap(0, 1), offsetToEnd(2, 3)),
+                        required(FunctionParameterType.STRING),
+                        required(FunctionParameterType.STRING),
+                        orMissing(FunctionParameterType.INTEGER).map(FunctionParameterDefinition::subtractOne),
+                        orMissing(FunctionParameterType.INTEGER)));
+        functionRegistry.register(
+                "lower",
+                new MongoExpressionUnaryFunction(
+                        "lower",
+                        "$toLower",
+                        typeConfiguration,
+                        StandardBasicTypes.STRING,
+                        FunctionParameterType.STRING));
+        functionRegistry.register(
+                "ltrim",
+                new MongoExpressionNamedFunction(
+                        "ltrim",
+                        "$ltrim",
+                        typeConfiguration,
+                        StandardBasicTypes.STRING,
+                        required("input", FunctionParameterType.STRING),
+                        orMissing("chars", FunctionParameterType.STRING)));
+        functionRegistry.register(
+                "replace_all",
+                new MongoExpressionNamedFunction(
+                        "replace_all",
+                        "$replaceAll",
+                        typeConfiguration,
+                        StandardBasicTypes.STRING,
+                        required("input", FunctionParameterType.STRING),
+                        required("find", FunctionParameterType.STRING),
+                        required("replacement", FunctionParameterType.STRING)));
+        functionRegistry.register(
+                "replace_one",
+                new MongoExpressionNamedFunction(
+                        "replace_one",
+                        "$replaceOne",
+                        typeConfiguration,
+                        StandardBasicTypes.STRING,
+                        required("input", FunctionParameterType.STRING),
+                        required("find", FunctionParameterType.STRING),
+                        required("replacement", FunctionParameterType.STRING)));
+        functionRegistry.register(
+                "rtrim",
+                new MongoExpressionNamedFunction(
+                        "rtrim",
+                        "$rtrim",
+                        typeConfiguration,
+                        StandardBasicTypes.STRING,
+                        required("input", FunctionParameterType.STRING),
+                        orMissing("chars", FunctionParameterType.STRING)));
+        functionRegistry.register(
+                "substring",
+                new MongoExpressionPositionalFunction(
+                        "substring",
+                        "$substrCP",
+                        typeConfiguration,
+                        StandardBasicTypes.STRING,
+                        required(FunctionParameterType.STRING),
+                        required(FunctionParameterType.INTEGER).map(FunctionParameterDefinition::subtractOne),
+                        orDefault(new BsonInt32(Integer.MAX_VALUE))));
+        functionRegistry.register("trim", new MongoTrimFunction(typeConfiguration));
         functionRegistry.register("unnest", new MongoUnnestFunction());
+        functionRegistry.register(
+                "upper",
+                new MongoExpressionUnaryFunction(
+                        "upper",
+                        "$toUpper",
+                        typeConfiguration,
+                        StandardBasicTypes.STRING,
+                        FunctionParameterType.STRING));
+        functionRegistry.registerAlternateKey("char_length", "character_length");
+        functionRegistry.registerAlternateKey("length", "character_length");
+        functionRegistry.registerAlternateKey("replace", "replace_all");
     }
 
     /** @mongoCme The {@link MutationOperation} returned from this method does not have to be thread-safe. */

--- a/src/main/java/com/mongodb/hibernate/internal/dialect/MongoDialect.java
+++ b/src/main/java/com/mongodb/hibernate/internal/dialect/MongoDialect.java
@@ -334,7 +334,9 @@ public sealed class MongoDialect extends Dialect permits TestMongoDialect {
                         swap(0, 1),
                         required(FunctionParameterType.STRING),
                         required(FunctionParameterType.STRING),
-                        orMissing(FunctionParameterType.INTEGER).map(FunctionParameterDefinition::subtractOne)));
+                        orMissing(FunctionParameterType.INTEGER)
+                                .map(FunctionParameterDefinition::subtractOne)
+                                .map(FunctionParameterDefinition::atLeastZero)));
         functionRegistry.register(
                 "lower",
                 new MongoExpressionUnaryFunction(

--- a/src/main/java/com/mongodb/hibernate/internal/dialect/MongoDialect.java
+++ b/src/main/java/com/mongodb/hibernate/internal/dialect/MongoDialect.java
@@ -32,6 +32,8 @@ import com.mongodb.hibernate.internal.dialect.function.MongoExpressionNamedFunct
 import com.mongodb.hibernate.internal.dialect.function.MongoExpressionPositionalFunction;
 import com.mongodb.hibernate.internal.dialect.function.MongoExpressionUnaryFunction;
 import com.mongodb.hibernate.internal.dialect.function.MongoExpressionVariadicFunction;
+import com.mongodb.hibernate.internal.dialect.function.MongoPadFunction;
+import com.mongodb.hibernate.internal.dialect.function.MongoRepeatFunction;
 import com.mongodb.hibernate.internal.dialect.function.MongoTrimFunction;
 import com.mongodb.hibernate.internal.dialect.function.array.MongoArrayConstructorFunction;
 import com.mongodb.hibernate.internal.dialect.function.array.MongoArrayContainsFunction;
@@ -345,44 +347,19 @@ public sealed class MongoDialect extends Dialect permits TestMongoDialect {
                         typeConfiguration,
                         StandardBasicTypes.STRING,
                         FunctionParameterType.STRING));
+        functionRegistry.register("lpad", new MongoPadFunction(typeConfiguration, true));
+        functionRegistry.register("repeat", new MongoRepeatFunction(typeConfiguration));
         functionRegistry.register(
-                "ltrim",
+                "replace",
                 new MongoExpressionNamedFunction(
-                        "ltrim",
-                        "$ltrim",
-                        typeConfiguration,
-                        StandardBasicTypes.STRING,
-                        required("input", FunctionParameterType.STRING),
-                        orMissing("chars", FunctionParameterType.STRING)));
-        functionRegistry.register(
-                "replace_all",
-                new MongoExpressionNamedFunction(
-                        "replace_all",
+                        "replace",
                         "$replaceAll",
                         typeConfiguration,
                         StandardBasicTypes.STRING,
                         required("input", FunctionParameterType.STRING),
                         required("find", FunctionParameterType.STRING),
                         required("replacement", FunctionParameterType.STRING)));
-        functionRegistry.register(
-                "replace_one",
-                new MongoExpressionNamedFunction(
-                        "replace_one",
-                        "$replaceOne",
-                        typeConfiguration,
-                        StandardBasicTypes.STRING,
-                        required("input", FunctionParameterType.STRING),
-                        required("find", FunctionParameterType.STRING),
-                        required("replacement", FunctionParameterType.STRING)));
-        functionRegistry.register(
-                "rtrim",
-                new MongoExpressionNamedFunction(
-                        "rtrim",
-                        "$rtrim",
-                        typeConfiguration,
-                        StandardBasicTypes.STRING,
-                        required("input", FunctionParameterType.STRING),
-                        orMissing("chars", FunctionParameterType.STRING)));
+        functionRegistry.register("rpad", new MongoPadFunction(typeConfiguration, false));
         functionRegistry.register(
                 "substring",
                 new MongoExpressionPositionalFunction(
@@ -405,7 +382,6 @@ public sealed class MongoDialect extends Dialect permits TestMongoDialect {
                         FunctionParameterType.STRING));
         functionRegistry.registerAlternateKey("char_length", "character_length");
         functionRegistry.registerAlternateKey("length", "character_length");
-        functionRegistry.registerAlternateKey("replace", "replace_all");
     }
 
     /** @mongoCme The {@link MutationOperation} returned from this method does not have to be thread-safe. */

--- a/src/main/java/com/mongodb/hibernate/internal/dialect/function/ExpressionFunction.java
+++ b/src/main/java/com/mongodb/hibernate/internal/dialect/function/ExpressionFunction.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2026-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.hibernate.internal.dialect.function;
+
+public interface ExpressionFunction {}

--- a/src/main/java/com/mongodb/hibernate/internal/dialect/function/FunctionParameterDefinition.java
+++ b/src/main/java/com/mongodb/hibernate/internal/dialect/function/FunctionParameterDefinition.java
@@ -22,11 +22,17 @@ import com.mongodb.hibernate.internal.MongoAssertions;
 import com.mongodb.hibernate.internal.translate.AbstractMqlTranslator;
 import com.mongodb.hibernate.internal.translate.mongoast.AstArithmeticExpressionOperator;
 import com.mongodb.hibernate.internal.translate.mongoast.AstBinaryOperatorExpression;
+import com.mongodb.hibernate.internal.translate.mongoast.AstComparisonExpressionOperator;
 import com.mongodb.hibernate.internal.translate.mongoast.AstExpression;
+import com.mongodb.hibernate.internal.translate.mongoast.AstLetBindingExpression;
 import com.mongodb.hibernate.internal.translate.mongoast.AstLiteral;
 import com.mongodb.hibernate.internal.translate.mongoast.AstLiteralExpression;
+import com.mongodb.hibernate.internal.translate.mongoast.AstPositionalOperatorExpression;
+import com.mongodb.hibernate.internal.translate.mongoast.AstVariableExpression;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.TreeMap;
 import java.util.function.Function;
 import java.util.stream.Stream;
 import org.bson.BsonInt32;
@@ -207,6 +213,27 @@ public abstract sealed class FunctionParameterDefinition<N>
      */
     public final FunctionParameterDefinition<N> map(Function<? super AstExpression, ? extends AstExpression> mapper) {
         return new Mapped<>(this, mapper);
+    }
+
+    /**
+     * Ensures that an input value, which must be a number, is greater than zero
+     *
+     * @param input the expression to clamp
+     * @return an expression which returns the original value or zero if the original value is less than zero
+     */
+    public static AstExpression atLeastZero(AstExpression input) {
+        // All variables are bound, so we don't need to worry about aliasing
+        return new AstLetBindingExpression(
+                new AstPositionalOperatorExpression(
+                        "$cond",
+                        List.of(
+                                new AstBinaryOperatorExpression(
+                                        AstComparisonExpressionOperator.LT,
+                                        new AstVariableExpression("x"),
+                                        new AstLiteralExpression(new AstLiteral(new BsonInt32(0)))),
+                                new AstLiteralExpression(new AstLiteral(new BsonInt32(0))),
+                                new AstVariableExpression("x"))),
+                new TreeMap<>(Map.of("x", input)));
     }
 
     interface RelativePositionChecker {

--- a/src/main/java/com/mongodb/hibernate/internal/dialect/function/FunctionParameterDefinition.java
+++ b/src/main/java/com/mongodb/hibernate/internal/dialect/function/FunctionParameterDefinition.java
@@ -1,0 +1,469 @@
+/*
+ * Copyright 2026-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.hibernate.internal.dialect.function;
+
+import static com.mongodb.hibernate.internal.translate.AstVisitorValueDescriptor.EXPRESSION;
+
+import com.mongodb.hibernate.internal.translate.AbstractMqlTranslator;
+import com.mongodb.hibernate.internal.translate.mongoast.AstArithmeticExpressionOperator;
+import com.mongodb.hibernate.internal.translate.mongoast.AstBinaryOperatorExpression;
+import com.mongodb.hibernate.internal.translate.mongoast.AstExpression;
+import com.mongodb.hibernate.internal.translate.mongoast.AstLiteral;
+import com.mongodb.hibernate.internal.translate.mongoast.AstLiteralExpression;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Stream;
+import org.bson.BsonInt32;
+import org.bson.BsonValue;
+import org.hibernate.query.sqm.produce.function.ArgumentTypesValidator;
+import org.hibernate.query.sqm.produce.function.ArgumentsValidator;
+import org.hibernate.query.sqm.produce.function.FunctionArgumentTypeResolver;
+import org.hibernate.query.sqm.produce.function.FunctionParameterType;
+import org.hibernate.query.sqm.produce.function.StandardArgumentsValidators;
+import org.hibernate.query.sqm.produce.function.StandardFunctionArgumentTypeResolvers;
+import org.hibernate.sql.ast.SqlAstTranslator;
+import org.hibernate.sql.ast.tree.SqlAstNode;
+import org.hibernate.type.spi.TypeConfiguration;
+
+/**
+ * Defines a parameter to a {@link MongoExpressionPositionalFunction} or {@link MongoExpressionNamedFunction}
+ *
+ * @param <N> the name for this function; normally {@link String} for {@link MongoExpressionNamedFunction} and
+ *     {@link Void} for {@link MongoExpressionPositionalFunction}
+ */
+public abstract sealed class FunctionParameterDefinition<N>
+        permits FunctionParameterDefinition.Default,
+                FunctionParameterDefinition.Mapped,
+                FunctionParameterDefinition.Missing,
+                FunctionParameterDefinition.Required {
+    /**
+     * Utility function that transforms an operation into one that returns one more than its original output
+     *
+     * <p>This is provided to help adjust indices as Mongo uses zero-based string indices and SQL/HQL uses one-based
+     * string indices
+     *
+     * @param input the expression to transform
+     * @return an expression that returns one more than the provided expression
+     */
+    public static AstExpression addOne(AstExpression input) {
+        return new AstBinaryOperatorExpression(
+                AstArithmeticExpressionOperator.ADD, input, new AstLiteralExpression(new AstLiteral(new BsonInt32(1))));
+    }
+    /**
+     * Utility function that transforms an operation into one that returns one less than its original output
+     *
+     * <p>This is provided to help adjust indices as Mongo uses zero-based string indices and SQL/HQL uses one-based
+     * string indices
+     *
+     * @param input the expression to transform
+     * @return an expression that returns one less than the provided expression
+     */
+    public static AstExpression subtractOne(AstExpression input) {
+        return new AstBinaryOperatorExpression(
+                AstArithmeticExpressionOperator.SUBTRACT,
+                input,
+                new AstLiteralExpression(new AstLiteral(new BsonInt32(1))));
+    }
+
+    /**
+     * Define a required parameter that has a particular type
+     *
+     * @param type the type of the parameter
+     * @return a parameter definition
+     * @see MongoExpressionPositionalFunction
+     */
+    @SuppressWarnings("NullAway")
+    public static FunctionParameterDefinition<Void> required(FunctionParameterType type) {
+        return new Required<>(null, type);
+    }
+
+    /**
+     * Define a required parameter that has a particular type
+     *
+     * @param name the property name that should be emitted in the MQL
+     * @param type the type of the parameter
+     * @return a parameter definition
+     * @see MongoExpressionNamedFunction
+     */
+    public static FunctionParameterDefinition<String> required(String name, FunctionParameterType type) {
+        return new Required<>(name, type);
+    }
+
+    /**
+     * Define an optional parameter that will have a default value inserted if not provided in the HQL
+     *
+     * <p>Note that the type of this parameter is inferred to match the type of the default value provided.
+     *
+     * @param defaultValue the default value to insert if a matching argument is not supplied in the HQL
+     * @return a parameter definition
+     * @see MongoExpressionPositionalFunction
+     */
+    @SuppressWarnings("NullAway")
+    public static FunctionParameterDefinition<Void> orDefault(BsonValue defaultValue) {
+        return new Default<>(null, defaultValue);
+    }
+
+    /**
+     * Define an optional parameter that will have a default value inserted if not provided in the HQL
+     *
+     * <p>Note that the type of this parameter is inferred to match the type of the default value provided.
+     *
+     * @param name the property name that should be emitted in the MQL
+     * @param defaultValue the default value to insert if a matching argument is not supplied in the HQL
+     * @return a parameter definition
+     * @see MongoExpressionNamedFunction
+     */
+    public static FunctionParameterDefinition<String> orDefault(String name, BsonValue defaultValue) {
+        return new Default<>(name, defaultValue);
+    }
+
+    /**
+     * Define an optional parameter that will be omitted if not provided in the HQL
+     *
+     * @param type the type of the parameter
+     * @return a parameter definition
+     * @see MongoExpressionNamedFunction
+     */
+    @SuppressWarnings("NullAway")
+    public static Missing<Void> orMissing(FunctionParameterType type) {
+        return new Missing<>(null, type);
+    }
+
+    /**
+     * Define an optional parameter that will be omitted if not provided in the HQL
+     *
+     * @param name the property name that should be emitted in the MQL
+     * @param type the type of the parameter
+     * @return a parameter definition
+     * @see MongoExpressionNamedFunction
+     */
+    public static Missing<String> orMissing(String name, FunctionParameterType type) {
+        return new Missing<>(name, type);
+    }
+
+    @SafeVarargs
+    @SuppressWarnings("varargs")
+    static <N> ArgumentsValidator argumentsValidatorFromParameters(
+            RelativePositionChecker position, FunctionParameterDefinition<N>... parameters) {
+        var types = new FunctionParameterType[parameters.length];
+        for (var i = 0; i < parameters.length; i++) {
+            parameters[i].check(position);
+            types[i] = parameters[i].type();
+        }
+        return new ArgumentTypesValidator(StandardArgumentsValidators.between(position.min(), position.max()), types);
+    }
+
+    @SafeVarargs
+    @SuppressWarnings("varargs")
+    static <N> FunctionArgumentTypeResolver typeResolverFromParameters(
+            TypeConfiguration typeConfiguration, FunctionParameterDefinition<N>... parameters) {
+        return StandardFunctionArgumentTypeResolvers.byArgument(Stream.of(parameters)
+                .map(parameter ->
+                        StandardFunctionArgumentTypeResolvers.impliedOrInvariant(typeConfiguration, parameter.type()))
+                .toArray(FunctionArgumentTypeResolver[]::new));
+    }
+
+    @SuppressWarnings("varargs")
+    static <N> void processArguments(
+            FunctionParameterDefinition<N>[] parameters,
+            List<? extends SqlAstNode> arguments,
+            SqlAstTranslator<?> walker,
+            ArgumentCollector<N> collector) {
+        var translator = AbstractMqlTranslator.cast(walker);
+        for (var index = 0; index < parameters.length; index++) {
+            final var parameter = parameters[index];
+            if (index < arguments.size()) {
+                collector.append(
+                        parameter.name(),
+                        parameter.asNode(translator.acceptAndYield(arguments.get(index), EXPRESSION)));
+            } else {
+                parameter.asNode().ifPresent(expression -> collector.append(parameter.name(), expression));
+            }
+        }
+    }
+
+    abstract N name();
+
+    abstract FunctionParameterType type();
+
+    abstract Optional<AstExpression> asNode();
+
+    abstract AstExpression asNode(AstExpression expression);
+
+    abstract void check(RelativePositionChecker position);
+
+    /**
+     * Transforms the user-provided value before passing it into the function
+     *
+     * <p>This is provided to allow adjusting the input value in the case that the MQL operator does not exactly match
+     * the semantics of the SQL/HQL function. In particular, this is meant to help adjust string indices as MQL uses
+     * zero-based strings and SQL uses one-based strings.
+     *
+     * <p>Default values are <em>not</em> transformed; they are left as originally provided
+     *
+     * @param mapper the transformation to apply to the value
+     * @return a parameter definition that will transform the input
+     */
+    public final FunctionParameterDefinition<N> map(Function<? super AstExpression, ? extends AstExpression> mapper) {
+        return new Mapped<>(this, mapper);
+    }
+
+    interface RelativePositionChecker {
+        void incrementRequired();
+
+        void incrementDefault();
+
+        void incrementMissing();
+
+        int max();
+
+        int min();
+    }
+
+    interface ArgumentCollector<N> {
+        void append(N name, AstExpression node);
+    }
+
+    static final class PositionalCheck implements RelativePositionChecker {
+        private int required;
+        private int withDefault;
+        private int missing;
+
+        @Override
+        public void incrementRequired() {
+            if (withDefault > 0 || missing > 0) {
+                throw new IllegalArgumentException(
+                        "Cannot have required parameters after default or missing parameters");
+            }
+            required++;
+        }
+
+        @Override
+        public void incrementDefault() {
+            if (missing > 0) {
+                throw new IllegalArgumentException("Cannot have default parameters after missing parameters");
+            }
+            withDefault++;
+        }
+
+        @Override
+        public void incrementMissing() {
+            missing++;
+        }
+
+        @Override
+        public int max() {
+            return required + withDefault + missing;
+        }
+
+        @Override
+        public int min() {
+            return required;
+        }
+    }
+
+    static final class NamedCheck implements RelativePositionChecker {
+        private int required;
+        private int other;
+
+        @Override
+        public void incrementRequired() {
+            if (other > 0) {
+                throw new IllegalArgumentException(
+                        "Cannot have required parameters after default or missing parameters");
+            }
+            required++;
+        }
+
+        @Override
+        public void incrementDefault() {
+            other++;
+        }
+
+        @Override
+        public void incrementMissing() {
+            other++;
+        }
+
+        @Override
+        public int max() {
+            return required + other;
+        }
+
+        @Override
+        public int min() {
+            return required;
+        }
+    }
+
+    static final class Default<N> extends FunctionParameterDefinition<N> {
+
+        private final N name;
+        private final BsonValue defaultValue;
+
+        Default(N name, BsonValue defaultValue) {
+            super();
+            this.name = name;
+            this.defaultValue = defaultValue;
+        }
+
+        @Override
+        N name() {
+            return name;
+        }
+
+        @Override
+        FunctionParameterType type() {
+            return switch (defaultValue.getBsonType()) {
+                case DOUBLE, DECIMAL128 -> FunctionParameterType.NUMERIC;
+                case STRING -> FunctionParameterType.STRING;
+                case BINARY -> FunctionParameterType.BINARY;
+                case BOOLEAN -> FunctionParameterType.BOOLEAN;
+                case DATE_TIME, TIMESTAMP -> FunctionParameterType.TEMPORAL;
+                case INT32, INT64 -> FunctionParameterType.INTEGER;
+                default ->
+                    throw new IllegalArgumentException(
+                            "No SQL Type corresponding to BSON type %s".formatted(defaultValue.getBsonType()));
+            };
+        }
+
+        @Override
+        Optional<AstExpression> asNode() {
+            return Optional.of(new AstLiteralExpression(new AstLiteral(defaultValue)));
+        }
+
+        @Override
+        AstExpression asNode(AstExpression expression) {
+            return expression;
+        }
+
+        @Override
+        void check(RelativePositionChecker position) {
+            position.incrementDefault();
+        }
+    }
+
+    static final class Required<N> extends FunctionParameterDefinition<N> {
+
+        private final N name;
+        private final FunctionParameterType type;
+
+        public Required(N name, FunctionParameterType type) {
+            super();
+
+            this.name = name;
+            this.type = type;
+        }
+
+        @Override
+        N name() {
+            return name;
+        }
+
+        @Override
+        FunctionParameterType type() {
+            return type;
+        }
+
+        @Override
+        Optional<AstExpression> asNode() {
+            throw new IllegalStateException("Hibernate did not supply required value");
+        }
+
+        @Override
+        AstExpression asNode(AstExpression expression) {
+            return expression;
+        }
+
+        @Override
+        void check(RelativePositionChecker position) {
+            position.incrementRequired();
+        }
+    }
+
+    static final class Mapped<N> extends FunctionParameterDefinition<N> {
+        private final Function<? super AstExpression, ? extends AstExpression> mapper;
+        private final FunctionParameterDefinition<N> inner;
+
+        Mapped(FunctionParameterDefinition<N> inner, Function<? super AstExpression, ? extends AstExpression> mapper) {
+            super();
+            this.inner = inner;
+            this.mapper = mapper;
+        }
+
+        @Override
+        N name() {
+            return inner.name();
+        }
+
+        @Override
+        FunctionParameterType type() {
+            return inner.type();
+        }
+
+        @Override
+        Optional<AstExpression> asNode() {
+            return inner.asNode();
+        }
+
+        @Override
+        AstExpression asNode(AstExpression expression) {
+            return mapper.apply(inner.asNode(expression));
+        }
+
+        @Override
+        void check(RelativePositionChecker position) {
+            inner.check(position);
+        }
+    }
+
+    public static final class Missing<N> extends FunctionParameterDefinition<N> {
+        private final N name;
+        private final FunctionParameterType type;
+
+        public Missing(N name, FunctionParameterType type) {
+            this.name = name;
+            this.type = type;
+        }
+
+        @Override
+        N name() {
+            return name;
+        }
+
+        @Override
+        FunctionParameterType type() {
+            return type;
+        }
+
+        @Override
+        Optional<AstExpression> asNode() {
+            return Optional.empty();
+        }
+
+        @Override
+        AstExpression asNode(AstExpression expression) {
+            return expression;
+        }
+
+        @Override
+        void check(RelativePositionChecker position) {
+            position.incrementMissing();
+        }
+    }
+}

--- a/src/main/java/com/mongodb/hibernate/internal/dialect/function/FunctionParameterDefinition.java
+++ b/src/main/java/com/mongodb/hibernate/internal/dialect/function/FunctionParameterDefinition.java
@@ -22,17 +22,12 @@ import com.mongodb.hibernate.internal.MongoAssertions;
 import com.mongodb.hibernate.internal.translate.AbstractMqlTranslator;
 import com.mongodb.hibernate.internal.translate.mongoast.AstArithmeticExpressionOperator;
 import com.mongodb.hibernate.internal.translate.mongoast.AstBinaryOperatorExpression;
-import com.mongodb.hibernate.internal.translate.mongoast.AstComparisonExpressionOperator;
 import com.mongodb.hibernate.internal.translate.mongoast.AstExpression;
-import com.mongodb.hibernate.internal.translate.mongoast.AstLetBindingExpression;
 import com.mongodb.hibernate.internal.translate.mongoast.AstLiteral;
 import com.mongodb.hibernate.internal.translate.mongoast.AstLiteralExpression;
 import com.mongodb.hibernate.internal.translate.mongoast.AstPositionalOperatorExpression;
-import com.mongodb.hibernate.internal.translate.mongoast.AstVariableExpression;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
-import java.util.TreeMap;
 import java.util.function.Function;
 import java.util.stream.Stream;
 import org.bson.BsonInt32;
@@ -223,17 +218,8 @@ public abstract sealed class FunctionParameterDefinition<N>
      */
     public static AstExpression atLeastZero(AstExpression input) {
         // All variables are bound, so we don't need to worry about aliasing
-        return new AstLetBindingExpression(
-                new AstPositionalOperatorExpression(
-                        "$cond",
-                        List.of(
-                                new AstBinaryOperatorExpression(
-                                        AstComparisonExpressionOperator.LT,
-                                        new AstVariableExpression("x"),
-                                        new AstLiteralExpression(new AstLiteral(new BsonInt32(0)))),
-                                new AstLiteralExpression(new AstLiteral(new BsonInt32(0))),
-                                new AstVariableExpression("x"))),
-                new TreeMap<>(Map.of("x", input)));
+        return new AstPositionalOperatorExpression(
+                "$max", List.of(input, new AstLiteralExpression(new AstLiteral(new BsonInt32(0)))));
     }
 
     interface RelativePositionChecker {

--- a/src/main/java/com/mongodb/hibernate/internal/dialect/function/FunctionParameterDefinition.java
+++ b/src/main/java/com/mongodb/hibernate/internal/dialect/function/FunctionParameterDefinition.java
@@ -18,6 +18,7 @@ package com.mongodb.hibernate.internal.dialect.function;
 
 import static com.mongodb.hibernate.internal.translate.AstVisitorValueDescriptor.EXPRESSION;
 
+import com.mongodb.hibernate.internal.MongoAssertions;
 import com.mongodb.hibernate.internal.translate.AbstractMqlTranslator;
 import com.mongodb.hibernate.internal.translate.mongoast.AstArithmeticExpressionOperator;
 import com.mongodb.hibernate.internal.translate.mongoast.AstBinaryOperatorExpression;
@@ -119,20 +120,6 @@ public abstract sealed class FunctionParameterDefinition<N>
     }
 
     /**
-     * Define an optional parameter that will have a default value inserted if not provided in the HQL
-     *
-     * <p>Note that the type of this parameter is inferred to match the type of the default value provided.
-     *
-     * @param name the property name that should be emitted in the MQL
-     * @param defaultValue the default value to insert if a matching argument is not supplied in the HQL
-     * @return a parameter definition
-     * @see MongoExpressionNamedFunction
-     */
-    public static FunctionParameterDefinition<String> orDefault(String name, BsonValue defaultValue) {
-        return new Default<>(name, defaultValue);
-    }
-
-    /**
      * Define an optional parameter that will be omitted if not provided in the HQL
      *
      * @param type the type of the parameter
@@ -140,7 +127,7 @@ public abstract sealed class FunctionParameterDefinition<N>
      * @see MongoExpressionNamedFunction
      */
     @SuppressWarnings("NullAway")
-    public static Missing<Void> orMissing(FunctionParameterType type) {
+    public static FunctionParameterDefinition<Void> orMissing(FunctionParameterType type) {
         return new Missing<>(null, type);
     }
 
@@ -152,7 +139,7 @@ public abstract sealed class FunctionParameterDefinition<N>
      * @return a parameter definition
      * @see MongoExpressionNamedFunction
      */
-    public static Missing<String> orMissing(String name, FunctionParameterType type) {
+    public static FunctionParameterDefinition<String> orMissing(String name, FunctionParameterType type) {
         return new Missing<>(name, type);
     }
 
@@ -178,7 +165,6 @@ public abstract sealed class FunctionParameterDefinition<N>
                 .toArray(FunctionArgumentTypeResolver[]::new));
     }
 
-    @SuppressWarnings("varargs")
     static <N> void processArguments(
             FunctionParameterDefinition<N>[] parameters,
             List<? extends SqlAstNode> arguments,
@@ -186,7 +172,7 @@ public abstract sealed class FunctionParameterDefinition<N>
             ArgumentCollector<N> collector) {
         var translator = AbstractMqlTranslator.cast(walker);
         for (var index = 0; index < parameters.length; index++) {
-            final var parameter = parameters[index];
+            var parameter = parameters[index];
             if (index < arguments.size()) {
                 collector.append(
                         parameter.name(),
@@ -246,18 +232,13 @@ public abstract sealed class FunctionParameterDefinition<N>
 
         @Override
         public void incrementRequired() {
-            if (withDefault > 0 || missing > 0) {
-                throw new IllegalArgumentException(
-                        "Cannot have required parameters after default or missing parameters");
-            }
+            MongoAssertions.assertFalse(withDefault > 0 || missing > 0);
             required++;
         }
 
         @Override
         public void incrementDefault() {
-            if (missing > 0) {
-                throw new IllegalArgumentException("Cannot have default parameters after missing parameters");
-            }
+            MongoAssertions.assertFalse(missing > 0);
             withDefault++;
         }
 
@@ -283,10 +264,7 @@ public abstract sealed class FunctionParameterDefinition<N>
 
         @Override
         public void incrementRequired() {
-            if (other > 0) {
-                throw new IllegalArgumentException(
-                        "Cannot have required parameters after default or missing parameters");
-            }
+            MongoAssertions.assertFalse(other > 0);
             required++;
         }
 
@@ -432,7 +410,7 @@ public abstract sealed class FunctionParameterDefinition<N>
         }
     }
 
-    public static final class Missing<N> extends FunctionParameterDefinition<N> {
+    static final class Missing<N> extends FunctionParameterDefinition<N> {
         private final N name;
         private final FunctionParameterType type;
 

--- a/src/main/java/com/mongodb/hibernate/internal/dialect/function/MongoExpressionNamedFunction.java
+++ b/src/main/java/com/mongodb/hibernate/internal/dialect/function/MongoExpressionNamedFunction.java
@@ -103,7 +103,7 @@ public final class MongoExpressionNamedFunction extends AbstractSqmSelfRendering
             ReturnableType<?> returnType,
             SqlAstTranslator<?> walker) {
         var translator = AbstractMqlTranslator.cast(walker);
-        final var namedArguments = new TreeMap<String, AstExpression>();
+        var namedArguments = new TreeMap<String, AstExpression>();
         FunctionParameterDefinition.processArguments(parameters, arguments, walker, namedArguments::put);
         translator.yield(EXPRESSION, outputMapper.apply(new AstNamedOperatorExpression(mongoOperator, namedArguments)));
     }

--- a/src/main/java/com/mongodb/hibernate/internal/dialect/function/MongoExpressionNamedFunction.java
+++ b/src/main/java/com/mongodb/hibernate/internal/dialect/function/MongoExpressionNamedFunction.java
@@ -69,8 +69,7 @@ public final class MongoExpressionNamedFunction extends AbstractSqmSelfRendering
      * @param mongoOperator the operator in Mongo, including the leading <code>$</code>
      * @param typeConfiguration the type information of the Hibernate context
      * @param returnType the type that this function will return
-     * @param outputMapper allows wrapping the generated output with additional operations; this is intended to provide
-     *     a mechanism that
+     * @param outputMapper allows wrapping the generated output with additional operations
      * @param parameters a list of parameters accepted by the function; this can include required or optional arguments,
      *     but the required arguments must be first
      * @see FunctionParameterDefinition#addOne(AstExpression)

--- a/src/main/java/com/mongodb/hibernate/internal/dialect/function/MongoExpressionNamedFunction.java
+++ b/src/main/java/com/mongodb/hibernate/internal/dialect/function/MongoExpressionNamedFunction.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2026-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.hibernate.internal.dialect.function;
+
+import static com.mongodb.hibernate.internal.translate.AstVisitorValueDescriptor.EXPRESSION;
+
+import com.mongodb.hibernate.internal.translate.AbstractMqlTranslator;
+import com.mongodb.hibernate.internal.translate.mongoast.AstExpression;
+import com.mongodb.hibernate.internal.translate.mongoast.AstNamedOperatorExpression;
+import java.util.List;
+import java.util.Objects;
+import java.util.TreeMap;
+import java.util.function.Function;
+import org.hibernate.metamodel.model.domain.ReturnableType;
+import org.hibernate.query.sqm.function.AbstractSqmSelfRenderingFunctionDescriptor;
+import org.hibernate.query.sqm.produce.function.StandardFunctionReturnTypeResolvers;
+import org.hibernate.sql.ast.SqlAstTranslator;
+import org.hibernate.sql.ast.spi.SqlAppender;
+import org.hibernate.sql.ast.tree.SqlAstNode;
+import org.hibernate.type.BasicTypeReference;
+import org.hibernate.type.spi.TypeConfiguration;
+
+/** Defines a HQL function that maps to a Mongo operator where the parameters are included as a document */
+public final class MongoExpressionNamedFunction extends AbstractSqmSelfRenderingFunctionDescriptor
+        implements ExpressionFunction {
+
+    private final String mongoOperator;
+    private final FunctionParameterDefinition<String>[] parameters;
+    private final Function<? super AstExpression, ? extends AstExpression> outputMapper;
+
+    /**
+     * Create a new function definition
+     *
+     * @param hqlName the name for the function in HQL
+     * @param mongoOperator the operator in Mongo, including the leading <code>$</code>
+     * @param typeConfiguration the type information of the Hibernate context
+     * @param returnType the type that this function will return
+     * @param parameters a list of parameters accepted by the function; this can include required or optional arguments,
+     *     but the required arguments must be first
+     */
+    @SafeVarargs
+    public MongoExpressionNamedFunction(
+            String hqlName,
+            String mongoOperator,
+            TypeConfiguration typeConfiguration,
+            BasicTypeReference<?> returnType,
+            FunctionParameterDefinition<String>... parameters) {
+        this(hqlName, mongoOperator, typeConfiguration, returnType, Function.identity(), parameters);
+    }
+
+    /**
+     * Create a new function definition
+     *
+     * @param hqlName the name for the function in HQL
+     * @param mongoOperator the operator in Mongo, including the leading <code>$</code>
+     * @param typeConfiguration the type information of the Hibernate context
+     * @param returnType the type that this function will return
+     * @param outputMapper allows wrapping the generated output with additional operations; this is intended to provide
+     *     a mechanism that
+     * @param parameters a list of parameters accepted by the function; this can include required or optional arguments,
+     *     but the required arguments must be first
+     * @see FunctionParameterDefinition#addOne(AstExpression)
+     * @see FunctionParameterDefinition#subtractOne(AstExpression)
+     */
+    @SafeVarargs
+    @SuppressWarnings("varargs")
+    public MongoExpressionNamedFunction(
+            String hqlName,
+            String mongoOperator,
+            TypeConfiguration typeConfiguration,
+            BasicTypeReference<?> returnType,
+            Function<? super AstExpression, ? extends AstExpression> outputMapper,
+            FunctionParameterDefinition<String>... parameters) {
+        super(
+                hqlName,
+                FunctionParameterDefinition.argumentsValidatorFromParameters(
+                        new FunctionParameterDefinition.NamedCheck(), parameters),
+                StandardFunctionReturnTypeResolvers.invariant(Objects.requireNonNull(
+                        typeConfiguration.getBasicTypeRegistry().resolve(returnType))),
+                FunctionParameterDefinition.typeResolverFromParameters(typeConfiguration, parameters));
+        this.mongoOperator = mongoOperator;
+        this.outputMapper = outputMapper;
+        this.parameters = parameters;
+    }
+
+    @Override
+    public void render(
+            SqlAppender sqlAppender,
+            List<? extends SqlAstNode> arguments,
+            ReturnableType<?> returnType,
+            SqlAstTranslator<?> walker) {
+        var translator = AbstractMqlTranslator.cast(walker);
+        final var namedArguments = new TreeMap<String, AstExpression>();
+        FunctionParameterDefinition.processArguments(parameters, arguments, walker, namedArguments::put);
+        translator.yield(EXPRESSION, outputMapper.apply(new AstNamedOperatorExpression(mongoOperator, namedArguments)));
+    }
+}

--- a/src/main/java/com/mongodb/hibernate/internal/dialect/function/MongoExpressionPositionalFunction.java
+++ b/src/main/java/com/mongodb/hibernate/internal/dialect/function/MongoExpressionPositionalFunction.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2026-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.hibernate.internal.dialect.function;
+
+import static com.mongodb.hibernate.internal.translate.AstVisitorValueDescriptor.EXPRESSION;
+
+import com.mongodb.hibernate.internal.translate.AbstractMqlTranslator;
+import com.mongodb.hibernate.internal.translate.mongoast.AstArithmeticExpressionOperator;
+import com.mongodb.hibernate.internal.translate.mongoast.AstBinaryOperatorExpression;
+import com.mongodb.hibernate.internal.translate.mongoast.AstExpression;
+import com.mongodb.hibernate.internal.translate.mongoast.AstPositionalOperatorExpression;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
+import org.hibernate.metamodel.model.domain.ReturnableType;
+import org.hibernate.query.sqm.function.AbstractSqmSelfRenderingFunctionDescriptor;
+import org.hibernate.query.sqm.produce.function.StandardFunctionReturnTypeResolvers;
+import org.hibernate.sql.ast.SqlAstTranslator;
+import org.hibernate.sql.ast.spi.SqlAppender;
+import org.hibernate.sql.ast.tree.SqlAstNode;
+import org.hibernate.type.BasicTypeReference;
+import org.hibernate.type.spi.TypeConfiguration;
+
+/** Defines a HQL function that maps to a Mongo operator where the parameters are included as an array */
+public final class MongoExpressionPositionalFunction extends AbstractSqmSelfRenderingFunctionDescriptor
+        implements ExpressionFunction {
+    public static final ArgumentModifier NONE = (arguments) -> {};
+    private final String mongoOperator;
+    private final ArgumentModifier modifier;
+    private final FunctionParameterDefinition<Void>[] parameters;
+    private final Function<? super AstExpression, ? extends AstExpression> outputMapper;
+
+    /**
+     * Create a new function definition
+     *
+     * @param hqlName the name for the function in HQL
+     * @param mongoOperator the operator in Mongo, including the leading <code>$</code>
+     * @param typeConfiguration the type information of the Hibernate context
+     * @param returnType the type that this function will return
+     * @param parameters a list of parameters accepted by the function; this can include required or optional arguments,
+     *     but the required arguments must be first, the ones with default parameters second, and ones that can be
+     *     missing last
+     */
+    @SafeVarargs
+    public MongoExpressionPositionalFunction(
+            String hqlName,
+            String mongoOperator,
+            TypeConfiguration typeConfiguration,
+            BasicTypeReference<?> returnType,
+            FunctionParameterDefinition<Void>... parameters) {
+        this(hqlName, mongoOperator, typeConfiguration, returnType, Function.identity(), NONE, parameters);
+    }
+    /**
+     * Create a new function definition
+     *
+     * @param hqlName the name for the function in HQL
+     * @param mongoOperator the operator in Mongo, including the leading <code>$</code>
+     * @param typeConfiguration the type information of the Hibernate context
+     * @param returnType the type that this function will return
+     * @param modifier modifies the argument list before generating MQL; this happens after all argument pre-processing
+     *     is complete
+     * @param outputMapper allows wrapping the generated output with additional operations; this is intended to provide
+     *     a mechanism that
+     * @param parameters a list of parameters accepted by the function; this can include required or optional arguments,
+     *     but the required arguments must be first, the ones with default parameters second, and ones that can be
+     *     missing last
+     * @see FunctionParameterDefinition#addOne(AstExpression)
+     * @see FunctionParameterDefinition#subtractOne(AstExpression)
+     */
+    @SafeVarargs
+    @SuppressWarnings("varargs")
+    public MongoExpressionPositionalFunction(
+            String hqlName,
+            String mongoOperator,
+            TypeConfiguration typeConfiguration,
+            BasicTypeReference<?> returnType,
+            Function<? super AstExpression, ? extends AstExpression> outputMapper,
+            ArgumentModifier modifier,
+            FunctionParameterDefinition<Void>... parameters) {
+        super(
+                hqlName,
+                FunctionParameterDefinition.argumentsValidatorFromParameters(
+                        new FunctionParameterDefinition.PositionalCheck(), parameters),
+                StandardFunctionReturnTypeResolvers.invariant(Objects.requireNonNull(
+                        typeConfiguration.getBasicTypeRegistry().resolve(returnType))),
+                FunctionParameterDefinition.typeResolverFromParameters(typeConfiguration, parameters));
+        this.mongoOperator = mongoOperator;
+        this.modifier = modifier;
+        this.outputMapper = outputMapper;
+        this.parameters = parameters;
+    }
+
+    /**
+     * Applies a series of modifications in sequence
+     *
+     * @param modifiers the modifications to apply
+     * @return an modifier that applies all modifications
+     */
+    public static ArgumentModifier allModifications(ArgumentModifier... modifiers) {
+        return arguments -> {
+            for (final var modifier : modifiers) {
+                modifier.mutate(arguments);
+            }
+        };
+    }
+
+    /**
+     * Changes a length parameter into an end position
+     *
+     * @param start the position of the start argument
+     * @param length the position of the length argument
+     * @return an argument modifier that replaces the length argument with an end position by adding the start argument
+     *     to that position; the start argument is unmodified
+     */
+    public static ArgumentModifier offsetToEnd(int start, int length) {
+        return arguments -> {
+            if (start < arguments.size() && length < arguments.size()) {
+                final var end = new AstBinaryOperatorExpression(
+                        AstArithmeticExpressionOperator.ADD, arguments.get(start), arguments.get(length));
+                arguments.set(length, end);
+            }
+        };
+    }
+
+    /**
+     * Swaps two arguments
+     *
+     * @param a the index of the first argument
+     * @param b the index of the second argument
+     * @return a manipulator that swaps two arguments
+     */
+    public static ArgumentModifier swap(int a, int b) {
+        if (a == b) {
+            return NONE;
+        }
+        return (arguments) -> Collections.swap(arguments, a, b);
+    }
+
+    @Override
+    public void render(
+            SqlAppender sqlAppender,
+            List<? extends SqlAstNode> arguments,
+            ReturnableType<?> returnType,
+            SqlAstTranslator<?> walker) {
+        var translator = AbstractMqlTranslator.cast(walker);
+        var translatedArguments = new ArrayList<AstExpression>();
+        FunctionParameterDefinition.processArguments(
+                parameters, arguments, walker, (name, node) -> translatedArguments.add(node));
+        modifier.mutate(translatedArguments);
+        translator.yield(
+                EXPRESSION,
+                outputMapper.apply(new AstPositionalOperatorExpression(mongoOperator, translatedArguments)));
+    }
+
+    /** Perform arbitrary manipulation of arguments */
+    public interface ArgumentModifier {
+        /**
+         * Manipulates the argument list
+         *
+         * @param arguments the arguments to modify
+         */
+        void mutate(List<AstExpression> arguments);
+    }
+}

--- a/src/main/java/com/mongodb/hibernate/internal/dialect/function/MongoExpressionPositionalFunction.java
+++ b/src/main/java/com/mongodb/hibernate/internal/dialect/function/MongoExpressionPositionalFunction.java
@@ -75,8 +75,7 @@ public final class MongoExpressionPositionalFunction extends AbstractSqmSelfRend
      * @param returnType the type that this function will return
      * @param modifier modifies the argument list before generating MQL; this happens after all argument pre-processing
      *     is complete
-     * @param outputMapper allows wrapping the generated output with additional operations; this is intended to provide
-     *     a mechanism that
+     * @param outputMapper allows wrapping the generated output with additional operations
      * @param parameters a list of parameters accepted by the function; this can include required or optional arguments,
      *     but the required arguments must be first, the ones with default parameters second, and ones that can be
      *     missing last

--- a/src/main/java/com/mongodb/hibernate/internal/dialect/function/MongoExpressionPositionalFunction.java
+++ b/src/main/java/com/mongodb/hibernate/internal/dialect/function/MongoExpressionPositionalFunction.java
@@ -19,8 +19,6 @@ package com.mongodb.hibernate.internal.dialect.function;
 import static com.mongodb.hibernate.internal.translate.AstVisitorValueDescriptor.EXPRESSION;
 
 import com.mongodb.hibernate.internal.translate.AbstractMqlTranslator;
-import com.mongodb.hibernate.internal.translate.mongoast.AstArithmeticExpressionOperator;
-import com.mongodb.hibernate.internal.translate.mongoast.AstBinaryOperatorExpression;
 import com.mongodb.hibernate.internal.translate.mongoast.AstExpression;
 import com.mongodb.hibernate.internal.translate.mongoast.AstPositionalOperatorExpression;
 import java.util.ArrayList;
@@ -103,38 +101,6 @@ public final class MongoExpressionPositionalFunction extends AbstractSqmSelfRend
         this.modifier = modifier;
         this.outputMapper = outputMapper;
         this.parameters = parameters;
-    }
-
-    /**
-     * Applies a series of modifications in sequence
-     *
-     * @param modifiers the modifications to apply
-     * @return an modifier that applies all modifications
-     */
-    public static ArgumentModifier allModifications(ArgumentModifier... modifiers) {
-        return arguments -> {
-            for (final var modifier : modifiers) {
-                modifier.mutate(arguments);
-            }
-        };
-    }
-
-    /**
-     * Changes a length parameter into an end position
-     *
-     * @param start the position of the start argument
-     * @param length the position of the length argument
-     * @return an argument modifier that replaces the length argument with an end position by adding the start argument
-     *     to that position; the start argument is unmodified
-     */
-    public static ArgumentModifier offsetToEnd(int start, int length) {
-        return arguments -> {
-            if (start < arguments.size() && length < arguments.size()) {
-                final var end = new AstBinaryOperatorExpression(
-                        AstArithmeticExpressionOperator.ADD, arguments.get(start), arguments.get(length));
-                arguments.set(length, end);
-            }
-        };
     }
 
     /**

--- a/src/main/java/com/mongodb/hibernate/internal/dialect/function/MongoExpressionUnaryFunction.java
+++ b/src/main/java/com/mongodb/hibernate/internal/dialect/function/MongoExpressionUnaryFunction.java
@@ -67,8 +67,7 @@ public final class MongoExpressionUnaryFunction extends AbstractSqmSelfRendering
      * @param mongoOperator the operator in Mongo, including the leading <code>$</code>
      * @param typeConfiguration the type information of the Hibernate context
      * @param returnType the type that this function will return
-     * @param outputMapper allows wrapping the generated output with additional operations; this is intended to provide
-     *     a mechanism that
+     * @param outputMapper allows wrapping the generated output with additional operations
      * @param parameterType the type of the single argument to this function
      * @see FunctionParameterDefinition#addOne(AstExpression)
      * @see FunctionParameterDefinition#subtractOne(AstExpression)

--- a/src/main/java/com/mongodb/hibernate/internal/dialect/function/MongoExpressionUnaryFunction.java
+++ b/src/main/java/com/mongodb/hibernate/internal/dialect/function/MongoExpressionUnaryFunction.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2026-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.hibernate.internal.dialect.function;
+
+import static com.mongodb.hibernate.internal.translate.AstVisitorValueDescriptor.EXPRESSION;
+
+import com.mongodb.hibernate.internal.translate.AbstractMqlTranslator;
+import com.mongodb.hibernate.internal.translate.mongoast.AstExpression;
+import com.mongodb.hibernate.internal.translate.mongoast.AstUnaryOperatorExpression;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
+import org.hibernate.metamodel.model.domain.ReturnableType;
+import org.hibernate.query.sqm.function.AbstractSqmSelfRenderingFunctionDescriptor;
+import org.hibernate.query.sqm.produce.function.ArgumentTypesValidator;
+import org.hibernate.query.sqm.produce.function.FunctionParameterType;
+import org.hibernate.query.sqm.produce.function.StandardArgumentsValidators;
+import org.hibernate.query.sqm.produce.function.StandardFunctionArgumentTypeResolvers;
+import org.hibernate.query.sqm.produce.function.StandardFunctionReturnTypeResolvers;
+import org.hibernate.sql.ast.SqlAstTranslator;
+import org.hibernate.sql.ast.spi.SqlAppender;
+import org.hibernate.sql.ast.tree.SqlAstNode;
+import org.hibernate.type.BasicTypeReference;
+import org.hibernate.type.spi.TypeConfiguration;
+
+/** Defines a HQL function that maps to a Mongo operator where a single parameters is included as the attribute value */
+public final class MongoExpressionUnaryFunction extends AbstractSqmSelfRenderingFunctionDescriptor
+        implements ExpressionFunction {
+
+    private final Function<? super AstExpression, ? extends AstExpression> outputMapper;
+    private final String mongoOperator;
+    /**
+     * Create a new function definition
+     *
+     * @param hqlName the name for the function in HQL
+     * @param mongoOperator the operator in Mongo, including the leading <code>$</code>
+     * @param typeConfiguration the type information of the Hibernate context
+     * @param returnType the type that this function will return
+     * @param parameterType the type of the single argument to this function
+     */
+    public MongoExpressionUnaryFunction(
+            String hqlName,
+            String mongoOperator,
+            TypeConfiguration typeConfiguration,
+            BasicTypeReference<?> returnType,
+            FunctionParameterType parameterType) {
+        this(hqlName, mongoOperator, typeConfiguration, returnType, Function.identity(), parameterType);
+    }
+    /**
+     * Create a new function definition
+     *
+     * @param hqlName the name for the function in HQL
+     * @param mongoOperator the operator in Mongo, including the leading <code>$</code>
+     * @param typeConfiguration the type information of the Hibernate context
+     * @param returnType the type that this function will return
+     * @param outputMapper allows wrapping the generated output with additional operations; this is intended to provide
+     *     a mechanism that
+     * @param parameterType the type of the single argument to this function
+     * @see FunctionParameterDefinition#addOne(AstExpression)
+     * @see FunctionParameterDefinition#subtractOne(AstExpression)
+     */
+    public MongoExpressionUnaryFunction(
+            String hqlName,
+            String mongoOperator,
+            TypeConfiguration typeConfiguration,
+            BasicTypeReference<?> returnType,
+            Function<? super AstExpression, ? extends AstExpression> outputMapper,
+            FunctionParameterType parameterType) {
+        super(
+                hqlName,
+                new ArgumentTypesValidator(StandardArgumentsValidators.exactly(1), parameterType),
+                StandardFunctionReturnTypeResolvers.invariant(Objects.requireNonNull(
+                        typeConfiguration.getBasicTypeRegistry().resolve(returnType))),
+                StandardFunctionArgumentTypeResolvers.impliedOrInvariant(typeConfiguration, parameterType));
+        this.mongoOperator = mongoOperator;
+        this.outputMapper = outputMapper;
+    }
+
+    @Override
+    public void render(
+            SqlAppender sqlAppender,
+            List<? extends SqlAstNode> arguments,
+            ReturnableType<?> returnType,
+            SqlAstTranslator<?> walker) {
+        var translator = AbstractMqlTranslator.cast(walker);
+        if (arguments.size() != 1) {
+            throw new IllegalArgumentException("Only one argument can be supplied");
+        }
+        translator.yield(
+                EXPRESSION,
+                outputMapper.apply(new AstUnaryOperatorExpression(
+                        mongoOperator, translator.acceptAndYield(arguments.get(0), EXPRESSION))));
+    }
+}

--- a/src/main/java/com/mongodb/hibernate/internal/dialect/function/MongoExpressionVariadicFunction.java
+++ b/src/main/java/com/mongodb/hibernate/internal/dialect/function/MongoExpressionVariadicFunction.java
@@ -92,7 +92,7 @@ public final class MongoExpressionVariadicFunction extends AbstractSqmSelfRender
             Function<? super AstExpression, ? extends AstExpression> inputMapper) {
         super(
                 hqlName,
-                new ArgumentTypesValidator(StandardArgumentsValidators.NONE, parameterType),
+                new ArgumentTypesValidator(StandardArgumentsValidators.min(1), parameterType),
                 StandardFunctionReturnTypeResolvers.invariant(Objects.requireNonNull(
                         typeConfiguration.getBasicTypeRegistry().resolve(returnType))),
                 StandardFunctionArgumentTypeResolvers.impliedOrInvariant(typeConfiguration, parameterType));

--- a/src/main/java/com/mongodb/hibernate/internal/dialect/function/MongoExpressionVariadicFunction.java
+++ b/src/main/java/com/mongodb/hibernate/internal/dialect/function/MongoExpressionVariadicFunction.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2026-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.hibernate.internal.dialect.function;
+
+import static com.mongodb.hibernate.internal.translate.AstVisitorValueDescriptor.EXPRESSION;
+
+import com.mongodb.hibernate.internal.translate.AbstractMqlTranslator;
+import com.mongodb.hibernate.internal.translate.mongoast.AstExpression;
+import com.mongodb.hibernate.internal.translate.mongoast.AstPositionalOperatorExpression;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
+import org.hibernate.metamodel.model.domain.ReturnableType;
+import org.hibernate.query.sqm.function.AbstractSqmSelfRenderingFunctionDescriptor;
+import org.hibernate.query.sqm.produce.function.ArgumentTypesValidator;
+import org.hibernate.query.sqm.produce.function.FunctionParameterType;
+import org.hibernate.query.sqm.produce.function.StandardArgumentsValidators;
+import org.hibernate.query.sqm.produce.function.StandardFunctionArgumentTypeResolvers;
+import org.hibernate.query.sqm.produce.function.StandardFunctionReturnTypeResolvers;
+import org.hibernate.sql.ast.SqlAstTranslator;
+import org.hibernate.sql.ast.spi.SqlAppender;
+import org.hibernate.sql.ast.tree.SqlAstNode;
+import org.hibernate.type.BasicTypeReference;
+import org.hibernate.type.spi.TypeConfiguration;
+
+/** Defines a variadic HQL function that maps to a Mongo operator where the parameters are a heterogeneous array */
+public final class MongoExpressionVariadicFunction extends AbstractSqmSelfRenderingFunctionDescriptor
+        implements ExpressionFunction {
+
+    private final String mongoOperator;
+    private final Function<? super AstExpression, ? extends AstExpression> outputMapper;
+    private final Function<? super AstExpression, ? extends AstExpression> inputMapper;
+
+    /**
+     * Create a new function definition
+     *
+     * @param hqlName the name for the function in HQL
+     * @param mongoOperator the operator in Mongo, including the leading <code>$</code>
+     * @param typeConfiguration the type information of the Hibernate context
+     * @param returnType the type that this function will return
+     * @param parameterType the type of the variadic arguments
+     */
+    public MongoExpressionVariadicFunction(
+            String hqlName,
+            String mongoOperator,
+            TypeConfiguration typeConfiguration,
+            BasicTypeReference<?> returnType,
+            FunctionParameterType parameterType) {
+        this(
+                hqlName,
+                mongoOperator,
+                typeConfiguration,
+                returnType,
+                Function.identity(),
+                parameterType,
+                Function.identity());
+    }
+    /**
+     * Create a new function definition
+     *
+     * @param hqlName the name for the function in HQL
+     * @param mongoOperator the operator in Mongo, including the leading <code>$</code>
+     * @param typeConfiguration the type information of the Hibernate context
+     * @param returnType the type that this function will return
+     * @param outputMapper allows wrapping the generated output with additional operations
+     * @param parameterType the type of the variadic arguments
+     * @param inputMapper allows wrapping the arguments with additional operations
+     * @see FunctionParameterDefinition#addOne(AstExpression)
+     * @see FunctionParameterDefinition#subtractOne(AstExpression)
+     */
+    public MongoExpressionVariadicFunction(
+            String hqlName,
+            String mongoOperator,
+            TypeConfiguration typeConfiguration,
+            BasicTypeReference<?> returnType,
+            Function<? super AstExpression, ? extends AstExpression> outputMapper,
+            FunctionParameterType parameterType,
+            Function<? super AstExpression, ? extends AstExpression> inputMapper) {
+        super(
+                hqlName,
+                new ArgumentTypesValidator(StandardArgumentsValidators.NONE, parameterType),
+                StandardFunctionReturnTypeResolvers.invariant(Objects.requireNonNull(
+                        typeConfiguration.getBasicTypeRegistry().resolve(returnType))),
+                StandardFunctionArgumentTypeResolvers.impliedOrInvariant(typeConfiguration, parameterType));
+        this.mongoOperator = mongoOperator;
+        this.outputMapper = outputMapper;
+        this.inputMapper = inputMapper;
+    }
+
+    @Override
+    public void render(
+            SqlAppender sqlAppender,
+            List<? extends SqlAstNode> arguments,
+            ReturnableType<?> returnType,
+            SqlAstTranslator<?> walker) {
+        var translator = AbstractMqlTranslator.cast(walker);
+        var translatedArguments = arguments.stream()
+                .<AstExpression>map(argument -> inputMapper.apply(translator.acceptAndYield(argument, EXPRESSION)))
+                .toList();
+        translator.yield(
+                EXPRESSION,
+                outputMapper.apply(new AstPositionalOperatorExpression(mongoOperator, translatedArguments)));
+    }
+}

--- a/src/main/java/com/mongodb/hibernate/internal/dialect/function/MongoPadFunction.java
+++ b/src/main/java/com/mongodb/hibernate/internal/dialect/function/MongoPadFunction.java
@@ -85,7 +85,7 @@ public final class MongoPadFunction extends AbstractSqmSelfRenderingFunctionDesc
         var translator = AbstractMqlTranslator.cast(walker);
         var padding = arguments.size() < 3
                 ? new AstLiteralExpression(new AstLiteral(new BsonString(" ")))
-                : new AstUnaryOperatorExpression("$toString", translator.acceptAndYield(arguments.get(2), EXPRESSION));
+                : translator.acceptAndYield(arguments.get(2), EXPRESSION);
         // All parameters are processed in the binding so that variables won't shadow anything outside, so fresh names
         // aren't required
         var paddingLength = new AstBinaryOperatorExpression(

--- a/src/main/java/com/mongodb/hibernate/internal/dialect/function/MongoPadFunction.java
+++ b/src/main/java/com/mongodb/hibernate/internal/dialect/function/MongoPadFunction.java
@@ -21,9 +21,12 @@ import static com.mongodb.hibernate.internal.translate.AstVisitorValueDescriptor
 import com.mongodb.hibernate.internal.translate.AbstractMqlTranslator;
 import com.mongodb.hibernate.internal.translate.mongoast.AstArithmeticExpressionOperator;
 import com.mongodb.hibernate.internal.translate.mongoast.AstBinaryOperatorExpression;
+import com.mongodb.hibernate.internal.translate.mongoast.AstComparisonExpressionOperator;
 import com.mongodb.hibernate.internal.translate.mongoast.AstLetBindingExpression;
 import com.mongodb.hibernate.internal.translate.mongoast.AstLiteral;
 import com.mongodb.hibernate.internal.translate.mongoast.AstLiteralExpression;
+import com.mongodb.hibernate.internal.translate.mongoast.AstLogicalOperator;
+import com.mongodb.hibernate.internal.translate.mongoast.AstLogicalOperatorExpression;
 import com.mongodb.hibernate.internal.translate.mongoast.AstNamedOperatorExpression;
 import com.mongodb.hibernate.internal.translate.mongoast.AstPositionalOperatorExpression;
 import com.mongodb.hibernate.internal.translate.mongoast.AstUnaryOperatorExpression;
@@ -85,43 +88,90 @@ public final class MongoPadFunction extends AbstractSqmSelfRenderingFunctionDesc
                 : new AstUnaryOperatorExpression("$toString", translator.acceptAndYield(arguments.get(2), EXPRESSION));
         // All parameters are processed in the binding so that variables won't shadow anything outside, so fresh names
         // aren't required
-        final var repeats = new AstUnaryOperatorExpression(
-                "$floor",
+        var paddingLength = new AstBinaryOperatorExpression(
+                AstArithmeticExpressionOperator.SUBTRACT,
+                new AstVariableExpression("targetLen"),
+                new AstUnaryOperatorExpression("$strLenCP", new AstVariableExpression("baseStr")));
+        var repeats = new AstUnaryOperatorExpression(
+                "$ceil",
                 new AstBinaryOperatorExpression(
                         AstArithmeticExpressionOperator.DIVIDE,
-                        new AstBinaryOperatorExpression(
-                                AstArithmeticExpressionOperator.SUBTRACT,
-                                new AstVariableExpression("targetLen"),
-                                new AstUnaryOperatorExpression("$strLenCP", new AstVariableExpression("baseStr"))),
+                        paddingLength,
                         new AstUnaryOperatorExpression("$strLenCP", new AstVariableExpression("padding"))));
-        translator.yield(
-                EXPRESSION,
-                new AstLetBindingExpression(
+        var baseStr = new AstVariableExpression("baseStr");
+        var combinedPadding = new AstPositionalOperatorExpression(
+                "$substrCP",
+                List.of(
                         new AstNamedOperatorExpression(
                                 "$reduce",
                                 new TreeMap<>(Map.of(
-                                        "initialValue", new AstVariableExpression("baseStr"),
+                                        "initialValue",
+                                        new AstLiteralExpression(new AstLiteral(new BsonString(""))),
                                         "in",
-                                                new AstPositionalOperatorExpression(
-                                                        "$concat",
-                                                        left
-                                                                ? List.of(
-                                                                        new AstVariableExpression("padding"),
-                                                                        new AstVariableExpression("value"))
-                                                                : List.of(
-                                                                        new AstVariableExpression("value"),
-                                                                        new AstVariableExpression("padding"))),
+                                        new AstPositionalOperatorExpression(
+                                                "$concat",
+                                                left
+                                                        ? List.of(
+                                                                new AstVariableExpression("padding"),
+                                                                new AstVariableExpression("value"))
+                                                        : List.of(
+                                                                new AstVariableExpression("value"),
+                                                                new AstVariableExpression("padding"))),
                                         "input",
-                                                new AstPositionalOperatorExpression(
-                                                        "$range",
-                                                        List.of(
-                                                                new AstLiteralExpression(
-                                                                        new AstLiteral(new BsonInt32(0))),
-                                                                repeats))))),
+                                        new AstPositionalOperatorExpression(
+                                                "$range",
+                                                List.of(
+                                                        new AstLiteralExpression(new AstLiteral(new BsonInt32(0))),
+                                                        repeats))))),
+                        new AstLiteralExpression(new AstLiteral(new BsonInt32(0))),
+                        paddingLength));
+
+        translator.yield(
+                EXPRESSION,
+                new AstLetBindingExpression(
+                        new AstPositionalOperatorExpression(
+                                "$cond",
+                                List.of(
+                                        new AstBinaryOperatorExpression(
+                                                AstComparisonExpressionOperator.LTE,
+                                                new AstVariableExpression("targetLen"),
+                                                new AstLiteralExpression(new AstLiteral(new BsonInt32(0)))),
+                                        new AstLiteralExpression(new AstLiteral(new BsonString(""))),
+                                        new AstPositionalOperatorExpression(
+                                                "$cond",
+                                                List.of(
+                                                        new AstLogicalOperatorExpression(
+                                                                AstLogicalOperator.OR,
+                                                                List.of(
+                                                                        new AstBinaryOperatorExpression(
+                                                                                AstComparisonExpressionOperator.GTE,
+                                                                                new AstUnaryOperatorExpression(
+                                                                                        "$strLenCP", baseStr),
+                                                                                new AstVariableExpression("targetLen")),
+                                                                        new AstBinaryOperatorExpression(
+                                                                                AstComparisonExpressionOperator.EQ,
+                                                                                new AstUnaryOperatorExpression(
+                                                                                        "$strLenCP",
+                                                                                        new AstVariableExpression(
+                                                                                                "padding")),
+                                                                                new AstLiteralExpression(
+                                                                                        new AstLiteral(
+                                                                                                new BsonInt32(0)))))),
+                                                        new AstPositionalOperatorExpression(
+                                                                "$substrCP",
+                                                                List.of(
+                                                                        new AstVariableExpression("baseStr"),
+                                                                        new AstLiteralExpression(
+                                                                                new AstLiteral(new BsonInt32(0))),
+                                                                        new AstVariableExpression("targetLen"))),
+                                                        new AstPositionalOperatorExpression(
+                                                                "$concat",
+                                                                left
+                                                                        ? List.of(combinedPadding, baseStr)
+                                                                        : List.of(baseStr, combinedPadding)))))),
                         new TreeMap<>(Map.of(
                                 "baseStr",
-                                new AstUnaryOperatorExpression(
-                                        "$toString", translator.acceptAndYield(arguments.get(0), EXPRESSION)),
+                                translator.acceptAndYield(arguments.get(0), EXPRESSION),
                                 "targetLen",
                                 translator.acceptAndYield(arguments.get(1), EXPRESSION),
                                 "padding",

--- a/src/main/java/com/mongodb/hibernate/internal/dialect/function/MongoPadFunction.java
+++ b/src/main/java/com/mongodb/hibernate/internal/dialect/function/MongoPadFunction.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2026-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.hibernate.internal.dialect.function;
+
+import static com.mongodb.hibernate.internal.translate.AstVisitorValueDescriptor.EXPRESSION;
+
+import com.mongodb.hibernate.internal.translate.AbstractMqlTranslator;
+import com.mongodb.hibernate.internal.translate.mongoast.AstArithmeticExpressionOperator;
+import com.mongodb.hibernate.internal.translate.mongoast.AstBinaryOperatorExpression;
+import com.mongodb.hibernate.internal.translate.mongoast.AstLetBindingExpression;
+import com.mongodb.hibernate.internal.translate.mongoast.AstLiteral;
+import com.mongodb.hibernate.internal.translate.mongoast.AstLiteralExpression;
+import com.mongodb.hibernate.internal.translate.mongoast.AstNamedOperatorExpression;
+import com.mongodb.hibernate.internal.translate.mongoast.AstPositionalOperatorExpression;
+import com.mongodb.hibernate.internal.translate.mongoast.AstUnaryOperatorExpression;
+import com.mongodb.hibernate.internal.translate.mongoast.AstVariableExpression;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.TreeMap;
+import org.bson.BsonInt32;
+import org.bson.BsonString;
+import org.hibernate.metamodel.model.domain.ReturnableType;
+import org.hibernate.query.sqm.function.AbstractSqmSelfRenderingFunctionDescriptor;
+import org.hibernate.query.sqm.produce.function.ArgumentTypesValidator;
+import org.hibernate.query.sqm.produce.function.FunctionParameterType;
+import org.hibernate.query.sqm.produce.function.StandardArgumentsValidators;
+import org.hibernate.query.sqm.produce.function.StandardFunctionArgumentTypeResolvers;
+import org.hibernate.query.sqm.produce.function.StandardFunctionReturnTypeResolvers;
+import org.hibernate.sql.ast.SqlAstTranslator;
+import org.hibernate.sql.ast.spi.SqlAppender;
+import org.hibernate.sql.ast.tree.SqlAstNode;
+import org.hibernate.type.StandardBasicTypes;
+import org.hibernate.type.spi.TypeConfiguration;
+
+public final class MongoPadFunction extends AbstractSqmSelfRenderingFunctionDescriptor implements ExpressionFunction {
+
+    private final boolean left;
+
+    // We bind lpad and rpad because, while the query language defines the behavior for pad, it bases that on the
+    // expectation of having lpad and rpad functions
+    public MongoPadFunction(TypeConfiguration typeConfiguration, boolean left) {
+        super(
+                left ? "lpad" : "rpad",
+                new ArgumentTypesValidator(
+                        StandardArgumentsValidators.between(2, 3),
+                        FunctionParameterType.STRING,
+                        FunctionParameterType.INTEGER,
+                        FunctionParameterType.STRING),
+                StandardFunctionReturnTypeResolvers.invariant(Objects.requireNonNull(
+                        typeConfiguration.getBasicTypeRegistry().resolve(StandardBasicTypes.STRING))),
+                StandardFunctionArgumentTypeResolvers.byArgument(
+                        StandardFunctionArgumentTypeResolvers.impliedOrInvariant(
+                                typeConfiguration, FunctionParameterType.STRING),
+                        StandardFunctionArgumentTypeResolvers.impliedOrInvariant(
+                                typeConfiguration, FunctionParameterType.INTEGER),
+                        StandardFunctionArgumentTypeResolvers.impliedOrInvariant(
+                                typeConfiguration, FunctionParameterType.STRING)));
+        this.left = left;
+    }
+
+    @Override
+    public void render(
+            SqlAppender sqlAppender,
+            List<? extends SqlAstNode> arguments,
+            ReturnableType<?> returnType,
+            SqlAstTranslator<?> walker) {
+        var translator = AbstractMqlTranslator.cast(walker);
+        var padding = arguments.size() < 3
+                ? new AstLiteralExpression(new AstLiteral(new BsonString(" ")))
+                : new AstUnaryOperatorExpression("$toString", translator.acceptAndYield(arguments.get(2), EXPRESSION));
+        // All parameters are processed in the binding so that variables won't shadow anything outside, so fresh names
+        // aren't required
+        final var repeats = new AstUnaryOperatorExpression(
+                "$floor",
+                new AstBinaryOperatorExpression(
+                        AstArithmeticExpressionOperator.DIVIDE,
+                        new AstBinaryOperatorExpression(
+                                AstArithmeticExpressionOperator.SUBTRACT,
+                                new AstVariableExpression("targetLen"),
+                                new AstUnaryOperatorExpression("$strLenCP", new AstVariableExpression("baseStr"))),
+                        new AstUnaryOperatorExpression("$strLenCP", new AstVariableExpression("padding"))));
+        translator.yield(
+                EXPRESSION,
+                new AstLetBindingExpression(
+                        new AstNamedOperatorExpression(
+                                "$reduce",
+                                new TreeMap<>(Map.of(
+                                        "initialValue", new AstVariableExpression("baseStr"),
+                                        "in",
+                                                new AstPositionalOperatorExpression(
+                                                        "$concat",
+                                                        left
+                                                                ? List.of(
+                                                                        new AstVariableExpression("padding"),
+                                                                        new AstVariableExpression("value"))
+                                                                : List.of(
+                                                                        new AstVariableExpression("value"),
+                                                                        new AstVariableExpression("padding"))),
+                                        "input",
+                                                new AstPositionalOperatorExpression(
+                                                        "$range",
+                                                        List.of(
+                                                                new AstLiteralExpression(
+                                                                        new AstLiteral(new BsonInt32(0))),
+                                                                repeats))))),
+                        new TreeMap<>(Map.of(
+                                "baseStr",
+                                new AstUnaryOperatorExpression(
+                                        "$toString", translator.acceptAndYield(arguments.get(0), EXPRESSION)),
+                                "targetLen",
+                                translator.acceptAndYield(arguments.get(1), EXPRESSION),
+                                "padding",
+                                padding))));
+    }
+}

--- a/src/main/java/com/mongodb/hibernate/internal/dialect/function/MongoRepeatFunction.java
+++ b/src/main/java/com/mongodb/hibernate/internal/dialect/function/MongoRepeatFunction.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2026-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.hibernate.internal.dialect.function;
+
+import static com.mongodb.hibernate.internal.translate.AstVisitorValueDescriptor.EXPRESSION;
+
+import com.mongodb.hibernate.internal.translate.AbstractMqlTranslator;
+import com.mongodb.hibernate.internal.translate.mongoast.AstLetBindingExpression;
+import com.mongodb.hibernate.internal.translate.mongoast.AstLiteral;
+import com.mongodb.hibernate.internal.translate.mongoast.AstLiteralExpression;
+import com.mongodb.hibernate.internal.translate.mongoast.AstNamedOperatorExpression;
+import com.mongodb.hibernate.internal.translate.mongoast.AstPositionalOperatorExpression;
+import com.mongodb.hibernate.internal.translate.mongoast.AstVariableExpression;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.TreeMap;
+import org.bson.BsonInt32;
+import org.bson.BsonString;
+import org.hibernate.metamodel.model.domain.ReturnableType;
+import org.hibernate.query.sqm.function.AbstractSqmSelfRenderingFunctionDescriptor;
+import org.hibernate.query.sqm.produce.function.ArgumentTypesValidator;
+import org.hibernate.query.sqm.produce.function.FunctionParameterType;
+import org.hibernate.query.sqm.produce.function.StandardArgumentsValidators;
+import org.hibernate.query.sqm.produce.function.StandardFunctionArgumentTypeResolvers;
+import org.hibernate.query.sqm.produce.function.StandardFunctionReturnTypeResolvers;
+import org.hibernate.sql.ast.SqlAstTranslator;
+import org.hibernate.sql.ast.spi.SqlAppender;
+import org.hibernate.sql.ast.tree.SqlAstNode;
+import org.hibernate.type.StandardBasicTypes;
+import org.hibernate.type.spi.TypeConfiguration;
+
+public final class MongoRepeatFunction extends AbstractSqmSelfRenderingFunctionDescriptor
+        implements ExpressionFunction {
+
+    public MongoRepeatFunction(TypeConfiguration typeConfiguration) {
+        super(
+                "repeat",
+                new ArgumentTypesValidator(
+                        StandardArgumentsValidators.exactly(2),
+                        FunctionParameterType.STRING,
+                        FunctionParameterType.INTEGER),
+                StandardFunctionReturnTypeResolvers.invariant(Objects.requireNonNull(
+                        typeConfiguration.getBasicTypeRegistry().resolve(StandardBasicTypes.STRING))),
+                StandardFunctionArgumentTypeResolvers.byArgument(
+                        StandardFunctionArgumentTypeResolvers.impliedOrInvariant(
+                                typeConfiguration, FunctionParameterType.STRING),
+                        StandardFunctionArgumentTypeResolvers.impliedOrInvariant(
+                                typeConfiguration, FunctionParameterType.INTEGER)));
+    }
+
+    @Override
+    public void render(
+            SqlAppender sqlAppender,
+            List<? extends SqlAstNode> arguments,
+            ReturnableType<?> returnType,
+            SqlAstTranslator<?> walker) {
+        var translator = AbstractMqlTranslator.cast(walker);
+        // All parameters are processed in the binding so that variables won't shadow anything outside, so fresh names
+        // aren't required
+        translator.yield(
+                EXPRESSION,
+                new AstLetBindingExpression(
+                        new AstNamedOperatorExpression(
+                                "$reduce",
+                                new TreeMap<>(Map.of(
+                                        "initialValue", new AstLiteralExpression(new AstLiteral(new BsonString(""))),
+                                        "in",
+                                                new AstPositionalOperatorExpression(
+                                                        "$concat",
+                                                        List.of(
+                                                                new AstVariableExpression("value"),
+                                                                new AstVariableExpression("repeatStr"))),
+                                        "input",
+                                                new AstPositionalOperatorExpression(
+                                                        "$range",
+                                                        List.of(
+                                                                new AstLiteralExpression(
+                                                                        new AstLiteral(new BsonInt32(0))),
+                                                                new AstVariableExpression("count")))))),
+                        new TreeMap<>(Map.of(
+                                "repeatStr",
+                                translator.acceptAndYield(arguments.get(0), EXPRESSION),
+                                "count",
+                                translator.acceptAndYield(arguments.get(1), EXPRESSION)))));
+    }
+}

--- a/src/main/java/com/mongodb/hibernate/internal/dialect/function/MongoSubstringFunction.java
+++ b/src/main/java/com/mongodb/hibernate/internal/dialect/function/MongoSubstringFunction.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2026-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.hibernate.internal.dialect.function;
+
+import static com.mongodb.hibernate.internal.dialect.function.FunctionParameterDefinition.subtractOne;
+import static com.mongodb.hibernate.internal.translate.AstVisitorValueDescriptor.EXPRESSION;
+
+import com.mongodb.hibernate.internal.translate.AbstractMqlTranslator;
+import com.mongodb.hibernate.internal.translate.mongoast.AstArithmeticExpressionOperator;
+import com.mongodb.hibernate.internal.translate.mongoast.AstBinaryOperatorExpression;
+import com.mongodb.hibernate.internal.translate.mongoast.AstComparisonExpressionOperator;
+import com.mongodb.hibernate.internal.translate.mongoast.AstExpression;
+import com.mongodb.hibernate.internal.translate.mongoast.AstLetBindingExpression;
+import com.mongodb.hibernate.internal.translate.mongoast.AstLiteral;
+import com.mongodb.hibernate.internal.translate.mongoast.AstLiteralExpression;
+import com.mongodb.hibernate.internal.translate.mongoast.AstPositionalOperatorExpression;
+import com.mongodb.hibernate.internal.translate.mongoast.AstVariableExpression;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.TreeMap;
+import org.bson.BsonInt32;
+import org.hibernate.metamodel.model.domain.ReturnableType;
+import org.hibernate.query.sqm.function.AbstractSqmSelfRenderingFunctionDescriptor;
+import org.hibernate.query.sqm.produce.function.ArgumentTypesValidator;
+import org.hibernate.query.sqm.produce.function.FunctionParameterType;
+import org.hibernate.query.sqm.produce.function.StandardArgumentsValidators;
+import org.hibernate.query.sqm.produce.function.StandardFunctionArgumentTypeResolvers;
+import org.hibernate.query.sqm.produce.function.StandardFunctionReturnTypeResolvers;
+import org.hibernate.sql.ast.SqlAstTranslator;
+import org.hibernate.sql.ast.spi.SqlAppender;
+import org.hibernate.sql.ast.tree.SqlAstNode;
+import org.hibernate.type.StandardBasicTypes;
+import org.hibernate.type.spi.TypeConfiguration;
+
+public final class MongoSubstringFunction extends AbstractSqmSelfRenderingFunctionDescriptor
+        implements ExpressionFunction {
+
+    public MongoSubstringFunction(TypeConfiguration typeConfiguration) {
+        super(
+                "substring",
+                new ArgumentTypesValidator(
+                        StandardArgumentsValidators.between(2, 3),
+                        FunctionParameterType.STRING,
+                        FunctionParameterType.INTEGER,
+                        FunctionParameterType.INTEGER),
+                StandardFunctionReturnTypeResolvers.invariant(Objects.requireNonNull(
+                        typeConfiguration.getBasicTypeRegistry().resolve(StandardBasicTypes.STRING))),
+                StandardFunctionArgumentTypeResolvers.byArgument(
+                        StandardFunctionArgumentTypeResolvers.impliedOrInvariant(
+                                typeConfiguration, FunctionParameterType.STRING),
+                        StandardFunctionArgumentTypeResolvers.impliedOrInvariant(
+                                typeConfiguration, FunctionParameterType.INTEGER),
+                        StandardFunctionArgumentTypeResolvers.impliedOrInvariant(
+                                typeConfiguration, FunctionParameterType.INTEGER)));
+    }
+
+    @Override
+    public void render(
+            SqlAppender sqlAppender,
+            List<? extends SqlAstNode> arguments,
+            ReturnableType<?> returnType,
+            SqlAstTranslator<?> walker) {
+        var translator = AbstractMqlTranslator.cast(walker);
+        // All parameters are processed in the binding so that variables won't shadow anything outside, so fresh names
+        // aren't required
+        var vars = new TreeMap<>(Map.of(
+                "str",
+                translator.acceptAndYield(arguments.get(0), EXPRESSION),
+                "start",
+                subtractOne(translator.acceptAndYield(arguments.get(1), EXPRESSION))));
+        AstExpression length;
+        if (arguments.size() == 3) {
+            vars.put("len", translator.acceptAndYield(arguments.get(2), EXPRESSION));
+            length = new AstBinaryOperatorExpression(
+                    AstArithmeticExpressionOperator.ADD,
+                    new AstVariableExpression("len"),
+                    new AstBinaryOperatorExpression(
+                            AstArithmeticExpressionOperator.SUBTRACT,
+                            new AstVariableExpression("start"),
+                            new AstVariableExpression("adjustedStart")));
+        } else {
+            length = new AstLiteralExpression(new AstLiteral(new BsonInt32(Integer.MAX_VALUE)));
+        }
+
+        translator.yield(
+                EXPRESSION,
+                new AstLetBindingExpression(
+                        new AstLetBindingExpression(
+                                new AstPositionalOperatorExpression(
+                                        "$substrCP",
+                                        List.of(
+                                                new AstVariableExpression("str"),
+                                                new AstVariableExpression("adjustedStart"),
+                                                length)),
+                                new TreeMap<>(Map.of(
+                                        "adjustedStart",
+                                        new AstPositionalOperatorExpression(
+                                                "$cond",
+                                                List.of(
+                                                        new AstBinaryOperatorExpression(
+                                                                AstComparisonExpressionOperator.LT,
+                                                                new AstVariableExpression("start"),
+                                                                new AstLiteralExpression(
+                                                                        new AstLiteral(new BsonInt32(0)))),
+                                                        new AstLiteralExpression(new AstLiteral(new BsonInt32(0))),
+                                                        new AstVariableExpression("start")))))),
+                        vars));
+    }
+}

--- a/src/main/java/com/mongodb/hibernate/internal/dialect/function/MongoSubstringFunction.java
+++ b/src/main/java/com/mongodb/hibernate/internal/dialect/function/MongoSubstringFunction.java
@@ -16,6 +16,7 @@
 
 package com.mongodb.hibernate.internal.dialect.function;
 
+import static com.mongodb.hibernate.internal.dialect.function.FunctionParameterDefinition.atLeastZero;
 import static com.mongodb.hibernate.internal.dialect.function.FunctionParameterDefinition.subtractOne;
 import static com.mongodb.hibernate.internal.translate.AstVisitorValueDescriptor.EXPRESSION;
 
@@ -86,13 +87,13 @@ public final class MongoSubstringFunction extends AbstractSqmSelfRenderingFuncti
         AstExpression length;
         if (arguments.size() == 3) {
             vars.put("len", translator.acceptAndYield(arguments.get(2), EXPRESSION));
-            length = new AstBinaryOperatorExpression(
+            length = atLeastZero(new AstBinaryOperatorExpression(
                     AstArithmeticExpressionOperator.ADD,
                     new AstVariableExpression("len"),
                     new AstBinaryOperatorExpression(
                             AstArithmeticExpressionOperator.SUBTRACT,
                             new AstVariableExpression("start"),
-                            new AstVariableExpression("adjustedStart")));
+                            new AstVariableExpression("adjustedStart"))));
         } else {
             length = new AstLiteralExpression(new AstLiteral(new BsonInt32(Integer.MAX_VALUE)));
         }

--- a/src/main/java/com/mongodb/hibernate/internal/dialect/function/MongoTrimFunction.java
+++ b/src/main/java/com/mongodb/hibernate/internal/dialect/function/MongoTrimFunction.java
@@ -26,6 +26,7 @@ import java.util.Objects;
 import java.util.TreeMap;
 import org.hibernate.metamodel.model.domain.ReturnableType;
 import org.hibernate.query.sqm.function.AbstractSqmSelfRenderingFunctionDescriptor;
+import org.hibernate.query.sqm.produce.function.ArgumentTypesValidator;
 import org.hibernate.query.sqm.produce.function.FunctionParameterType;
 import org.hibernate.query.sqm.produce.function.StandardArgumentsValidators;
 import org.hibernate.query.sqm.produce.function.StandardFunctionArgumentTypeResolvers;
@@ -42,7 +43,11 @@ public final class MongoTrimFunction extends AbstractSqmSelfRenderingFunctionDes
     public MongoTrimFunction(TypeConfiguration typeConfiguration) {
         super(
                 "trim",
-                StandardArgumentsValidators.between(2, 3),
+                new ArgumentTypesValidator(
+                        StandardArgumentsValidators.between(2, 3),
+                        FunctionParameterType.TRIM_SPEC,
+                        FunctionParameterType.STRING,
+                        FunctionParameterType.STRING),
                 StandardFunctionReturnTypeResolvers.invariant(Objects.requireNonNull(
                         typeConfiguration.getBasicTypeRegistry().resolve(StandardBasicTypes.STRING))),
                 StandardFunctionArgumentTypeResolvers.byArgument(

--- a/src/main/java/com/mongodb/hibernate/internal/dialect/function/MongoTrimFunction.java
+++ b/src/main/java/com/mongodb/hibernate/internal/dialect/function/MongoTrimFunction.java
@@ -44,7 +44,7 @@ public final class MongoTrimFunction extends AbstractSqmSelfRenderingFunctionDes
         super(
                 "trim",
                 new ArgumentTypesValidator(
-                        StandardArgumentsValidators.between(2, 3),
+                        StandardArgumentsValidators.exactly(3),
                         FunctionParameterType.TRIM_SPEC,
                         FunctionParameterType.STRING,
                         FunctionParameterType.STRING),
@@ -66,15 +66,9 @@ public final class MongoTrimFunction extends AbstractSqmSelfRenderingFunctionDes
             ReturnableType<?> returnType,
             SqlAstTranslator<?> walker) {
         var translator = AbstractMqlTranslator.cast(walker);
-        if (arguments.size() != 2 && arguments.size() != 3) {
-            throw new IllegalArgumentException("Invalid number of arguments to trim");
-        }
-        final var namedArguments = new TreeMap<String, AstExpression>();
-        namedArguments.put("input", translator.acceptAndYield(arguments.get(arguments.size() - 1), EXPRESSION));
-
-        if (arguments.size() == 3) {
-            namedArguments.put("chars", translator.acceptAndYield(arguments.get(1), EXPRESSION));
-        }
+        var namedArguments = new TreeMap<String, AstExpression>();
+        namedArguments.put("chars", translator.acceptAndYield(arguments.get(1), EXPRESSION));
+        namedArguments.put("input", translator.acceptAndYield(arguments.get(2), EXPRESSION));
 
         translator.yield(
                 EXPRESSION,

--- a/src/main/java/com/mongodb/hibernate/internal/dialect/function/MongoTrimFunction.java
+++ b/src/main/java/com/mongodb/hibernate/internal/dialect/function/MongoTrimFunction.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2026-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.hibernate.internal.dialect.function;
+
+import static com.mongodb.hibernate.internal.translate.AstVisitorValueDescriptor.EXPRESSION;
+
+import com.mongodb.hibernate.internal.translate.AbstractMqlTranslator;
+import com.mongodb.hibernate.internal.translate.mongoast.AstExpression;
+import com.mongodb.hibernate.internal.translate.mongoast.AstNamedOperatorExpression;
+import java.util.List;
+import java.util.Objects;
+import java.util.TreeMap;
+import org.hibernate.metamodel.model.domain.ReturnableType;
+import org.hibernate.query.sqm.function.AbstractSqmSelfRenderingFunctionDescriptor;
+import org.hibernate.query.sqm.produce.function.FunctionParameterType;
+import org.hibernate.query.sqm.produce.function.StandardArgumentsValidators;
+import org.hibernate.query.sqm.produce.function.StandardFunctionArgumentTypeResolvers;
+import org.hibernate.query.sqm.produce.function.StandardFunctionReturnTypeResolvers;
+import org.hibernate.sql.ast.SqlAstTranslator;
+import org.hibernate.sql.ast.spi.SqlAppender;
+import org.hibernate.sql.ast.tree.SqlAstNode;
+import org.hibernate.sql.ast.tree.expression.TrimSpecification;
+import org.hibernate.type.StandardBasicTypes;
+import org.hibernate.type.spi.TypeConfiguration;
+
+public final class MongoTrimFunction extends AbstractSqmSelfRenderingFunctionDescriptor implements ExpressionFunction {
+
+    public MongoTrimFunction(TypeConfiguration typeConfiguration) {
+        super(
+                "trim",
+                StandardArgumentsValidators.between(2, 3),
+                StandardFunctionReturnTypeResolvers.invariant(Objects.requireNonNull(
+                        typeConfiguration.getBasicTypeRegistry().resolve(StandardBasicTypes.STRING))),
+                StandardFunctionArgumentTypeResolvers.byArgument(
+                        StandardFunctionArgumentTypeResolvers.impliedOrInvariant(
+                                typeConfiguration, FunctionParameterType.TRIM_SPEC),
+                        StandardFunctionArgumentTypeResolvers.impliedOrInvariant(
+                                typeConfiguration, FunctionParameterType.STRING),
+                        StandardFunctionArgumentTypeResolvers.impliedOrInvariant(
+                                typeConfiguration, FunctionParameterType.STRING)));
+    }
+
+    @Override
+    public void render(
+            SqlAppender sqlAppender,
+            List<? extends SqlAstNode> arguments,
+            ReturnableType<?> returnType,
+            SqlAstTranslator<?> walker) {
+        var translator = AbstractMqlTranslator.cast(walker);
+        if (arguments.size() != 2 && arguments.size() != 3) {
+            throw new IllegalArgumentException("Invalid number of arguments to trim");
+        }
+        final var namedArguments = new TreeMap<String, AstExpression>();
+        namedArguments.put("input", translator.acceptAndYield(arguments.get(arguments.size() - 1), EXPRESSION));
+
+        if (arguments.size() == 3) {
+            namedArguments.put("chars", translator.acceptAndYield(arguments.get(1), EXPRESSION));
+        }
+
+        translator.yield(
+                EXPRESSION,
+                new AstNamedOperatorExpression(
+                        switch (((TrimSpecification) arguments.get(0)).getSpecification()) {
+                            case LEADING -> "$ltrim";
+                            case TRAILING -> "$rtrim";
+                            case BOTH -> "$trim";
+                        },
+                        namedArguments));
+    }
+}

--- a/src/main/java/com/mongodb/hibernate/internal/translate/AbstractMqlTranslator.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/AbstractMqlTranslator.java
@@ -52,6 +52,7 @@ import static java.lang.String.format;
 import static org.hibernate.query.common.FetchClauseType.ROWS_ONLY;
 
 import com.mongodb.hibernate.internal.FeatureNotSupportedException;
+import com.mongodb.hibernate.internal.dialect.function.ExpressionFunction;
 import com.mongodb.hibernate.internal.dialect.function.array.MongoUnnestFunction;
 import com.mongodb.hibernate.internal.service.StandardServiceRegistryScopedState;
 import com.mongodb.hibernate.internal.translate.mongoast.AstArithmeticExpressionOperator;
@@ -1265,14 +1266,17 @@ public abstract class AbstractMqlTranslator<T extends JdbcOperation> implements 
 
     @Override
     public void visitSelfRenderingExpression(SelfRenderingExpression selfRenderingExpression) {
-        if (!(selfRenderingExpression instanceof SelfRenderingFunctionSqlAstExpression)) {
+        if (selfRenderingExpression instanceof SelfRenderingFunctionSqlAstExpression<?> sqlAstExpression) {
+            if (astVisitorValueHolder.expects(EXPRESSION)
+                    && !(sqlAstExpression.getFunctionRenderer() instanceof ExpressionFunction)) {
+                // a function call as an operand within an aggregation expression is not yet supported
+                throw new FeatureNotSupportedException(
+                        "TODO-HIBERNATE-196 https://jira.mongodb.org/browse/HIBERNATE-196");
+            }
+            selfRenderingExpression.renderToSql(FeatureNotSupportedSqlAppender.INSTANCE, this, sessionFactory);
+        } else {
             throw new FeatureNotSupportedException("Only function expressions are supported");
         }
-        if (astVisitorValueHolder.expects(EXPRESSION)) {
-            // a function call as an operand within an aggregation expression is not yet supported
-            throw new FeatureNotSupportedException("TODO-HIBERNATE-196 https://jira.mongodb.org/browse/HIBERNATE-196");
-        }
-        selfRenderingExpression.renderToSql(FeatureNotSupportedSqlAppender.INSTANCE, this, sessionFactory);
     }
 
     @Override

--- a/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/AstLetBindingExpression.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/AstLetBindingExpression.java
@@ -21,8 +21,7 @@ import java.util.function.Consumer;
 import org.bson.BsonWriter;
 import org.hibernate.sql.exec.spi.JdbcParameterBinder;
 
-/** @hidden */
-@SuppressWarnings("MissingSummary")
+/** Define an expression with locally bound variables */
 public record AstLetBindingExpression(AstExpression in, SortedMap<String, AstExpression> vars)
         implements AstExpression {
 

--- a/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/AstLetBindingExpression.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/AstLetBindingExpression.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2025-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.hibernate.internal.translate.mongoast;
+
+import java.util.SortedMap;
+import java.util.function.Consumer;
+import org.bson.BsonWriter;
+import org.hibernate.sql.exec.spi.JdbcParameterBinder;
+
+/** @hidden */
+@SuppressWarnings("MissingSummary")
+public record AstLetBindingExpression(AstExpression in, SortedMap<String, AstExpression> vars)
+        implements AstExpression {
+
+    @Override
+    public void render(BsonWriter writer, Consumer<JdbcParameterBinder> binderConsumer) {
+        writer.writeStartDocument();
+        writer.writeName("$let");
+        {
+            writer.writeStartDocument();
+            writer.writeStartDocument("vars");
+            for (var v : vars.entrySet()) {
+                writer.writeName(v.getKey());
+                v.getValue().render(writer, binderConsumer);
+            }
+            writer.writeEndDocument();
+            writer.writeName("in");
+            in.render(writer, binderConsumer);
+            writer.writeEndDocument();
+        }
+        writer.writeEndDocument();
+    }
+}

--- a/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/AstNamedOperatorExpression.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/AstNamedOperatorExpression.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2026-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.hibernate.internal.translate.mongoast;
+
+import java.util.Map;
+import org.bson.BsonWriter;
+
+/**
+ * A general-purpose Mongo operator that includes arguments as a document
+ *
+ * @param operator the name of the operator, including the <code>$</code>
+ * @param arguments a map of name-argument pairs that will be converted into a document
+ */
+public record AstNamedOperatorExpression(String operator, Map<String, AstExpression> arguments)
+        implements AstExpression {
+    @Override
+    public void render(BsonWriter writer) {
+        writer.writeStartDocument();
+        {
+            writer.writeStartDocument(operator);
+            for (final var argument : arguments.entrySet()) {
+                writer.writeName(argument.getKey());
+                argument.getValue().render(writer);
+            }
+            writer.writeEndDocument();
+        }
+        writer.writeEndDocument();
+    }
+}

--- a/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/AstPositionalOperatorExpression.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/AstPositionalOperatorExpression.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2026-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.hibernate.internal.translate.mongoast;
+
+import java.util.List;
+import org.bson.BsonWriter;
+
+/**
+ * A general-purpose Mongo operator that includes the arguments as an array
+ *
+ * @param operator the name of the operator, including the <code>$</code>
+ * @param arguments a list of arguments that will be converted into an array
+ */
+public record AstPositionalOperatorExpression(String operator, List<AstExpression> arguments) implements AstExpression {
+    @Override
+    public void render(BsonWriter writer) {
+        writer.writeStartDocument();
+        {
+            writer.writeStartArray(operator);
+            for (final var argument : arguments) {
+                argument.render(writer);
+            }
+            writer.writeEndArray();
+        }
+        writer.writeEndDocument();
+    }
+}

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -117,7 +117,6 @@ module com.mongodb.hibernate {
     requires transitive org.mongodb.driver.core;
     requires transitive org.mongodb.driver.sync.client;
     requires org.jspecify;
-    requires jdk.compiler;
 
     provides ServiceContributor with
             StandardServiceRegistryScopedState.ServiceContributor;

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -117,6 +117,7 @@ module com.mongodb.hibernate {
     requires transitive org.mongodb.driver.core;
     requires transitive org.mongodb.driver.sync.client;
     requires org.jspecify;
+    requires jdk.compiler;
 
     provides ServiceContributor with
             StandardServiceRegistryScopedState.ServiceContributor;

--- a/src/test/java/com/mongodb/hibernate/internal/translate/mongoast/AstLetBindingExpressionTests.java
+++ b/src/test/java/com/mongodb/hibernate/internal/translate/mongoast/AstLetBindingExpressionTests.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2025-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.hibernate.internal.translate.mongoast;
+
+import static com.mongodb.hibernate.internal.translate.mongoast.AstNodeAssertions.assertExpressionRendering;
+
+import java.util.Map;
+import java.util.TreeMap;
+import org.bson.BsonInt32;
+import org.junit.jupiter.api.Test;
+
+class AstLetBindingExpressionTests {
+
+    @Test
+    void testRendering() {
+        var let = new AstLetBindingExpression(
+                new AstVariableExpression("x"),
+                new TreeMap<>(Map.of("x", new AstValueExpression(new AstLiteral(new BsonInt32(2))))));
+        assertExpressionRendering(
+                """
+                {"": {"$let": {"vars": {"x": {"$numberInt": "2"}}, "in": "$$x"}}}\
+                """,
+                let);
+    }
+}

--- a/src/test/java/com/mongodb/hibernate/internal/translate/mongoast/AstNamedOperatorExpressionTests.java
+++ b/src/test/java/com/mongodb/hibernate/internal/translate/mongoast/AstNamedOperatorExpressionTests.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2025-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.hibernate.internal.translate.mongoast;
+
+import static com.mongodb.hibernate.internal.translate.mongoast.AstNodeAssertions.assertExpressionRendering;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class AstNamedOperatorExpressionTests {
+
+    @Test
+    void testRendering() {
+        var operation = new AstNamedOperatorExpression(
+                "$op", Map.of("a", new AstFieldPathExpression("x"), "b", new AstFieldPathExpression("y")));
+        assertExpressionRendering(
+                """
+                {"": {"$op": {"b": "$y", "a": "$x"}}}\
+                """, operation);
+    }
+}

--- a/src/test/java/com/mongodb/hibernate/internal/translate/mongoast/AstPositionalOperatorExpressionTests.java
+++ b/src/test/java/com/mongodb/hibernate/internal/translate/mongoast/AstPositionalOperatorExpressionTests.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2025-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.hibernate.internal.translate.mongoast;
+
+import static com.mongodb.hibernate.internal.translate.mongoast.AstNodeAssertions.assertExpressionRendering;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class AstPositionalOperatorExpressionTests {
+
+    @Test
+    void testRendering() {
+        var operation = new AstPositionalOperatorExpression(
+                "$op", List.of(new AstFieldPathExpression("x"), new AstFieldPathExpression("y")));
+        assertExpressionRendering("""
+                {"": {"$op": ["$x", "$y"]}}\
+                """, operation);
+    }
+}


### PR DESCRIPTION
Adds HQL functions for most string operations, including concatenation. Also, build out infrastructure for binding Mongo operators as functions.