### PR TITLE
docs: add ARCHITECTURE.md and a PR review skill

### DIFF
--- a/.claude/skills/add-hql-to-mql-translation/SKILL.md
+++ b/.claude/skills/add-hql-to-mql-translation/SKILL.md
@@ -9,6 +9,23 @@ This guidance covers domain-specific investigation steps and conventions for add
 
 ---
 
+## Before designing
+
+Read `ARCHITECTURE.md`. It defines the contracts this work has to satisfy --- visitor dispatch and the
+descriptor protocol, the two filter languages, clause-position parity, pipeline stage order, the
+failure contract --- and the phases below assume them rather than restating them.
+
+Then design in this order, because each step constrains the next:
+
+1. **The aggregation expression.** `$project` accepts nothing else, and `$expr` wraps it in `$match`.
+2. **Both clause positions**, `SELECT` and `WHERE`.
+3. **Only then**, whether a find-syntax form is worth adding for the field-versus-value case.
+
+`.claude/skills/reviewing-pull-requests/SKILL.md` is the review counterpart; reading it tells you what
+evidence your PR will be asked for.
+
+---
+
 ## Phase 1: Investigate Before Brainstorming
 
 Do this before brainstorming.
@@ -36,9 +53,14 @@ Extract source from the Hibernate sources JAR at `~/.gradle/caches/.../hibernate
 
 ### 1c. Enumerate all shapes
 
-Build a complete table: every combination of the construct that's syntactically valid in HQL. Mark each ✅ (translatable) or ❌ (throw). For ❌ shapes, identify which ticket will track implementation.
+Build a complete table: every combination of the construct that's syntactically valid in HQL. Mark each ✅ (translatable) or ❌ (throw). Split the ❌ shapes: those we intend to support later need a tracking ticket, while those MQL cannot express are permanent and need none — just a throw whose message says why.
 
-**File Jira tickets for every ❌ shape before writing any code.** Use real ticket numbers in throw messages from day one — no literal `HIBERNATE-NNN` placeholders where `NNN` hasn't been replaced with an actual number. File the Jira tickets first, then reference them in the code. The codebase convention uses a `TODO-` prefix on these strings to signal the feature is not yet implemented; follow that convention for new throws (e.g. `"TODO-HIBERNATE-161 https://jira.mongodb.org/browse/HIBERNATE-161"`). File against project HIBERNATE at https://jira.mongodb.org/browse/HIBERNATE using the `jira` CLI.
+**Clause position is one of the combinations.** Enumerate the construct in `SELECT` and in `WHERE`
+separately --- and, where it applies, in `ORDER BY`, mutation `SET`, and as a predicate operand
+(`like`, `in`, `is null`). Each is a distinct row needing its own ✅/❌, because each is a distinct
+translator branch. A shape table that only covers projections will pass review as incomplete.
+
+**File Jira tickets before writing any code, for every ❌ shape you intend to support later.** Use real ticket numbers in throw messages from day one — no literal `HIBERNATE-NNN` placeholders where `NNN` hasn't been replaced with an actual number. A shape that is permanently out of reach gets a bare message instead, naming the MQL limitation; do not invent a ticket to satisfy the convention. File the Jira tickets first, then reference them in the code. The codebase convention uses a `TODO-` prefix on these strings to signal the feature is not yet implemented; follow that convention for new throws, pairing the ticket key with its browse URL (`"TODO-HIBERNATE-NNN https://jira.mongodb.org/browse/HIBERNATE-NNN"`). File against project HIBERNATE at https://jira.mongodb.org/browse/HIBERNATE using the `jira` CLI.
 
 ---
 
@@ -70,7 +92,7 @@ The plan must follow this task order:
 
 - Positive tests: `assertSelectionQuery(hql, resultType, expectedMql, expectedResults, expectedAffectedCollections)` — always assert the full MQL pipeline string, the full result set, and the full set of affected collections
 - When the `$project` fields are unknown upfront (e.g. JOIN FETCH): use `assertActualCommandsInOrder` with `/* FILL IN after first test run */`; upgrade to full `assertSelectionQuery` once the actual MQL is known
-- Negative tests: `assertSelectQueryFailure(hql, resultType, FeatureNotSupportedException.class, "TODO-HIBERNATE-161 ...")` — use the real ticket number, following the `TODO-HIBERNATE-NNN` codebase convention
+- Negative tests: `assertSelectQueryFailure(hql, resultType, FeatureNotSupportedException.class, "TODO-HIBERNATE-NNN ...")` — substitute the real ticket number, following the `TODO-HIBERNATE-NNN` codebase convention
 - Positive tests live in a descriptively named `@Nested` class with `@BeforeEach` seed data; negative tests live at the outer class level for one-off cases or in `@Nested class Unsupported` when there are several.
 - Every non-trivial code path (loop iterations, recursive calls, each instanceof branch) must be covered by a positive or negative test
 

--- a/.claude/skills/reviewing-pull-requests/DdlProbeTests.java.template
+++ b/.claude/skills/reviewing-pull-requests/DdlProbeTests.java.template
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2026-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// THROWAWAY REVIEW PROBE for schema / DDL / index work --- delete before finishing. Never commit.
+// Copy to src/integrationTest/java/com/mongodb/hibernate/query/ZzDdlProbeTests.java
+// Run: ./gradlew :integrationTest --tests ZzDdlProbeTests      (leading colon is required)
+// Read: grep -ohE 'PROBE\|[^<]*' build/test-results/integrationTest/TEST-*ZzDdlProbeTests.xml
+//
+// Why this differs from ProbeTests.java.template: schema export happens at SessionFactory BUILD
+// time, not per query. So this builds an independent registry + SessionFactory per probe rather
+// than reusing one shared, pre-built factory. It deliberately does NOT extend
+// AbstractQueryIntegrationTests and does not need MongoServiceRegistryProducer, because it never
+// goes through Hibernate's test framework for registry construction.
+//
+// Like the query probe, it owns its CommandListener rather than using the test framework's --- see
+// that template's header for the "(none of 0 captured)" troubleshooting note.
+
+package com.mongodb.hibernate.query;
+
+import com.mongodb.event.CommandListener;
+import com.mongodb.event.CommandStartedEvent;
+import com.mongodb.hibernate.cfg.spi.MongoConfigurationContributor;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.bson.BsonDocument;
+import org.hibernate.boot.MetadataSources;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.junit.jupiter.api.Test;
+
+class ZzDdlProbeTests {
+
+    /** Handshake and session chatter that drowns out the commands under review. */
+    private static final List<String> NOISE = List.of("buildInfo", "hello", "ping", "endSessions");
+
+    /** The probe's own listener. A fresh one per probe, so no cross-probe contamination. */
+    static final class ProbeCommandListener implements CommandListener {
+        private final List<BsonDocument> commands = Collections.synchronizedList(new ArrayList<>());
+
+        @Override
+        public void commandStarted(CommandStartedEvent event) {
+            commands.add(event.getCommand().clone());
+        }
+
+        List<BsonDocument> started() {
+            return List.copyOf(commands);
+        }
+    }
+
+    /**
+     * Builds a SessionFactory with the given schema-generation action and reports which commands the
+     * server actually received.
+     *
+     * @param action {@code jakarta.persistence.schema-generation.database.action} --- one of
+     *     {@code create}, {@code drop-and-create}, {@code create-drop}, {@code drop}, {@code none}
+     */
+    private static void probe(String label, String action, Class<?> entityClass) {
+        var listener = new ProbeCommandListener();
+        var registry = new StandardServiceRegistryBuilder()
+                .applySettings(Map.of(
+                        "hibernate.hbm2ddl.auto", "none",
+                        "jakarta.persistence.schema-generation.database.action", action))
+                .addService(
+                        MongoConfigurationContributor.class,
+                        (MongoConfigurationContributor) configurator ->
+                                configurator.applyToMongoClientSettings(b -> b.addCommandListener(listener)))
+                .build();
+        try {
+            // close() is what triggers the drop half of create-drop, so let try-with-resources run.
+            try (var sessionFactory = new MetadataSources()
+                    .addAnnotatedClass(entityClass)
+                    .buildMetadata(registry)
+                    .buildSessionFactory()) {
+                sessionFactory.openSession().close();
+            }
+            System.out.println("PROBE|" + label + "|OK|" + summarize(listener));
+        } catch (Throwable t) {
+            var root = t;
+            while (root.getCause() != null) {
+                root = root.getCause();
+            }
+            System.out.println("PROBE|" + label + "|THREW|" + root.getClass().getSimpleName() + ": "
+                    + root.getMessage() + "|after=" + summarize(listener));
+        }
+    }
+
+    private static String summarize(ProbeCommandListener listener) {
+        var all = listener.started();
+        var interesting = all.stream()
+                .filter(command -> !NOISE.contains(command.getFirstKey()))
+                .map(command -> command.getFirstKey() + "=" + command.toJson())
+                .toList();
+        // Always report the raw capture count. "(none of 0 captured)" means the listener was never
+        // installed --- a broken harness, not a quiet export. "(none of 4 captured)" means it worked
+        // and no schema command was actually emitted, which is itself a finding worth reporting.
+        return interesting.isEmpty()
+                ? "(none of " + all.size() + " captured)"
+                : String.join(" ;; ", interesting);
+    }
+
+    @Test
+    void probes() {
+        // One line per row of the schema/DDL matrix in SKILL.md. Keep labels stable so the
+        // parent-commit run diffs cleanly against the PR run.
+        probe("create", "create", Indexed.class);
+        probe("drop-and-create", "drop-and-create", Indexed.class);
+        probe("create-drop", "create-drop", Indexed.class);
+        probe("drop-alone", "drop", Indexed.class);
+        probe("idempotent-second-create", "create", Indexed.class);
+        probe("descending-column", "create", Descending.class);
+        probe("column-unique-idiom", "create", ColumnUnique.class);
+    }
+
+    @Entity(name = "Indexed")
+    @Table(name = "probe_indexed", indexes = @Index(name = "idx_t", columnList = "title"))
+    static class Indexed {
+        @Id
+        int id;
+
+        String title;
+    }
+
+    /** Column order must survive into the index key as -1, not be silently flattened to 1. */
+    @Entity(name = "Descending")
+    @Table(name = "probe_desc", indexes = @Index(name = "idx_desc", columnList = "title DESC"))
+    static class Descending {
+        @Id
+        int id;
+
+        String title;
+    }
+
+    /** The bare-@Column idiom, which Hibernate may never materialize as a UniqueKey at all. */
+    @Entity(name = "ColumnUnique")
+    @Table(name = "probe_col_unique")
+    static class ColumnUnique {
+        @Id
+        int id;
+
+        @jakarta.persistence.Column(unique = true)
+        String isbn;
+    }
+}

--- a/.claude/skills/reviewing-pull-requests/ProbeTests.java.template
+++ b/.claude/skills/reviewing-pull-requests/ProbeTests.java.template
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2026-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// THROWAWAY REVIEW PROBE for query / translation work --- delete before finishing. Never commit.
+// Copy to src/integrationTest/java/com/mongodb/hibernate/query/ZzProbeTests.java
+// Run:  ./gradlew :integrationTest --tests ZzProbeTests      (leading colon is required)
+// Read: grep -oh 'PROBE|.*' build/test-results/integrationTest/TEST-*ZzProbeTests.xml | sed 's/&quot;/"/g'
+//
+// This is deliberately self-contained: it registers its OWN CommandListener through the public
+// MongoConfigurationContributor SPI and builds its own registry and SessionFactory, rather than
+// borrowing the integration-test framework's listener, whose shape and lifetime change over time.
+//
+// Run ONE probe class at a time. The suite runs test classes concurrently, and System.out from two
+// concurrent classes is interleaved and misattributed between XML report files.
+//
+// If every probe reports "(none of 0 captured)", the listener was never installed --- fix that before
+// trusting any result. The usual cause is a competing MongoConfigurationContributor: Hibernate's
+// ServiceRegistry holds ONE instance per service interface and the last registration wins, and
+// auto-discovered ServiceContributors are applied inside build(), i.e. AFTER the explicit addService
+// below. So a contributor on the test classpath silently replaces this one, and only its listener is
+// installed. Suppressing that contributor for the probe run is the fix; restore it afterwards.
+
+package com.mongodb.hibernate.query;
+
+import com.mongodb.event.CommandListener;
+import com.mongodb.event.CommandStartedEvent;
+import com.mongodb.hibernate.cfg.spi.MongoConfigurationContributor;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.bson.BsonDocument;
+import org.hibernate.SessionFactory;
+import org.hibernate.boot.MetadataSources;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.junit.jupiter.api.Test;
+
+class ZzProbeTests {
+
+    /** Handshake and session chatter that drowns out the commands under review. */
+    private static final List<String> NOISE = List.of("buildInfo", "hello", "ping", "endSessions");
+
+    /** The probe's own listener. Owned here so the probe survives test-framework churn. */
+    static final class ProbeCommandListener implements CommandListener {
+        private final List<BsonDocument> commands = Collections.synchronizedList(new ArrayList<>());
+
+        @Override
+        public void commandStarted(CommandStartedEvent event) {
+            commands.add(event.getCommand().clone());
+        }
+
+        List<BsonDocument> started() {
+            return List.copyOf(commands);
+        }
+
+        void clear() {
+            commands.clear();
+        }
+    }
+
+    @Test
+    void probes() {
+        var listener = new ProbeCommandListener();
+        var registry = new StandardServiceRegistryBuilder()
+                .applySettings(Map.of("hibernate.hbm2ddl.auto", "none"))
+                .addService(
+                        MongoConfigurationContributor.class,
+                        (MongoConfigurationContributor) configurator ->
+                                configurator.applyToMongoClientSettings(b -> b.addCommandListener(listener)))
+                .build();
+        try (var sessionFactory = new MetadataSources()
+                .addAnnotatedClass(Thing.class)
+                .buildMetadata(registry)
+                .buildSessionFactory()) {
+            // Probe collections outlive the JVM and are shared across branches and worktrees, so
+            // clear before seeding or the next run dies on a duplicate _id.
+            sessionFactory.inTransaction(
+                    session -> session.createMutationQuery("delete from Thing").executeUpdate());
+            sessionFactory.inTransaction(session -> session.persist(new Thing(1, " Hello ", 7, null)));
+
+            // Every construct gets probed in BOTH clause positions --- see the SELECT/WHERE parity
+            // section of SKILL.md. The emitted form matters, not just success:
+            //   field-vs-value  -> compact find syntax  {"n": {"$eq": 7}}
+            //   computed operand -> {"$expr": ...} inside $match
+            probe(sessionFactory, listener, "select-projection", "select upper(t.s) from Thing t");
+            probe(sessionFactory, listener, "where-find-syntax", "select t.id from Thing t where t.n = 7");
+            probe(sessionFactory, listener, "where-expr", "select t.id from Thing t where length(t.s) = 7");
+            probe(sessionFactory, listener, "predicate-operand", "select t.id from Thing t where upper(t.s) like 'HEL%'");
+            probe(sessionFactory, listener, "order-by", "select t.id from Thing t order by length(t.s)");
+            probe(sessionFactory, listener, "nested", "select upper(lower(t.s)) from Thing t");
+            probe(sessionFactory, listener, "null-valued", "select upper(t.nullable) from Thing t");
+        }
+    }
+
+    /**
+     * Runs one HQL string and prints the outcome plus the real pipeline.
+     *
+     * <p>Catches {@link Throwable}, not {@link Exception}: an internal invariant violation surfaces
+     * as {@code AssertionError}, which is an {@code Error}. Catching only {@code Exception} hides
+     * exactly the defect class this harness exists to find.
+     */
+    private static void probe(
+            SessionFactory sessionFactory, ProbeCommandListener listener, String label, String hql) {
+        listener.clear();
+        try {
+            sessionFactory.inTransaction(session -> {
+                var rows = session.createSelectionQuery(hql, Object[].class).getResultList();
+                System.out.println("PROBE|" + label + "|OK|rows=" + rows.size() + "|" + summarize(listener));
+            });
+        } catch (Throwable t) {
+            var root = t;
+            while (root.getCause() != null) {
+                root = root.getCause();
+            }
+            System.out.println(
+                    "PROBE|" + label + "|THREW|" + root.getClass().getSimpleName() + ": " + root.getMessage() + "|");
+        }
+    }
+
+    private static String summarize(ProbeCommandListener listener) {
+        var all = listener.started();
+        var interesting = all.stream()
+                .filter(command -> !NOISE.contains(command.getFirstKey()))
+                .map(command -> command.containsKey("pipeline")
+                        ? command.getArray("pipeline").toString()
+                        : command.toJson())
+                .toList();
+        // Always report the raw capture count. "(none of 0 captured)" means the listener was never
+        // installed --- a broken harness, not a quiet query. "(none of 7 captured)" means it worked
+        // and the command genuinely was uninteresting.
+        return interesting.isEmpty()
+                ? "(none of " + all.size() + " captured)"
+                : String.join(" ;; ", interesting);
+    }
+
+    @Entity(name = "Thing")
+    @Table(name = "probe_things")
+    static class Thing {
+        @Id
+        int id;
+
+        String s;
+        int n;
+        String nullable;
+
+        Thing() {}
+
+        Thing(int id, String s, int n, String nullable) {
+            this.id = id;
+            this.s = s;
+            this.n = n;
+            this.nullable = nullable;
+        }
+    }
+}

--- a/.claude/skills/reviewing-pull-requests/SKILL.md
+++ b/.claude/skills/reviewing-pull-requests/SKILL.md
@@ -1,0 +1,236 @@
+---
+name: reviewing-pull-requests
+description: Use when reviewing a pull request, branch, or commit in this repository --- HQL/MQL translation, dialect, JDBC adapter, type system, or schema/DDL changes.
+---
+
+# Reviewing Pull Requests
+
+## Core principle
+
+**A claim about runtime behavior you did not execute is a hypothesis, not a finding.**
+
+This project translates one AST into another and dispatches on runtime value-descriptor matching.
+Whether a construct produces correct MQL, throws a clean `FeatureNotSupportedException`, or trips an
+internal assertion is decided by paths that reading a diff cannot settle. A review that stops at
+reading yields "this gate looks fragile"; a review that runs the code yields "this gate is already
+broken, here is the HQL that crashes it, and here is the parent commit behaving correctly".
+
+## The gate
+
+Every correctness claim in the review is labeled:
+
+- **Verified** --- you executed something and observed the result. Quote the input and the output.
+- **Unverified** --- reasoning only. Say so, in the finding itself.
+
+An unlabelled correctness claim is not ready to deliver. Design, naming, and dead-code findings need
+no execution; anything about *behavior* does.
+
+## Phase 1 --- Ground truth, not local inference
+
+- `gh pr checkout <n>` --- get the branch. Use this, not `git fetch origin <branch>`: PRs routinely
+  come from contributor forks, where that fails with `couldn't find remote ref`.
+- `gh pr view <n> --json title,body,files,commits` --- the author's own statement of scope. Read the
+  commit subjects too: a `DO-NOT-MERGE` or `fixup` commit that *narrows a test* is a finding in itself.
+- `jira issue view HIBERNATE-<n> --plain` --- real ticket scope and status for the PR's ticket *and*
+  for every ticket cited in a `TODO-HIBERNATE-NNN` throw the PR adds, keeps, or deletes. A throw that
+  now fires for a different reason than its ticket describes is a finding. Read the **comments**: an
+  unresolved "needs product input" question is worth surfacing before any code discussion.
+
+**Route by area.** For HQL-to-MQL translation PRs, the review checklist is the companion skill's
+standard: **REQUIRED:** use `add-hql-to-mql-translation`. Its Phase 1c shape table and its Phase 3
+step 5 coverage verification are what a reviewer checks the PR against --- hold the PR to that
+standard whether or not the author used the skill.
+
+## Phase 2 --- Establish a green baseline first
+
+```bash
+./gradlew build -x integrationTest
+./gradlew :integrationTest
+```
+
+Both must pass *before* you probe. Otherwise a failure you hit later is unattributable. Report the
+baseline in the review so readers know your findings came from untested shapes, not a broken branch.
+
+Integration tests need the local replica set (see AGENTS.md); confirm with
+`mongosh --quiet --eval 'db.hello().ok'`.
+
+## Phase 3 --- Probe, and diff against the parent commit
+
+Probing is never optional. The **parent-commit** half is what separates *pre-existing limitation*
+from *regression this PR introduced* --- the difference between a nitpick and a blocker.
+
+Pick the template that matches the PR:
+
+| PR touches | Template | Copy to |
+|---|---|---|
+| HQL / translation / query behaviour | `ProbeTests.java.template` | `src/integrationTest/java/com/mongodb/hibernate/query/ZzProbeTests.java` |
+| Schema export, DDL, indexes, JDBC admin commands | `DdlProbeTests.java.template` | `src/integrationTest/java/com/mongodb/hibernate/query/ZzDdlProbeTests.java` |
+
+Run it on the PR. **The leading colon is required** --- without it Gradle runs the task in the Spring
+Boot subprojects too and fails with `No tests found for given includes`.
+
+```bash
+./gradlew :integrationTest --tests ZzProbeTests
+grep -ohE 'PROBE\|[^<]*' build/test-results/integrationTest/TEST-*ZzProbeTests.xml
+```
+
+Then run the **same** probe file on the parent commit and diff the two outputs:
+
+```bash
+BASE=$(mktemp -d)/base
+git worktree add "$BASE" <parent-sha>
+mkdir -p "$BASE/src/integrationTest/java/com/mongodb/hibernate/query"
+cp src/integrationTest/java/com/mongodb/hibernate/query/ZzProbeTests.java \
+   "$BASE/src/integrationTest/java/com/mongodb/hibernate/query/"
+"$BASE/gradlew" -p "$BASE" :integrationTest --tests ZzProbeTests
+```
+
+Present the comparison as a table: shape | parent | PR | verdict. A cell going from a clean throw to
+`AssertionError` is a regression; from a clean throw to correct MQL is the intended feature.
+
+**How much parent run is warranted.** If the parent already implements the feature area, probe every
+shape on both sides --- that is where regressions hide. If the parent throws unconditionally for the
+whole area (the PR adds a wholly new capability, so there is no prior behavior to regress from), run
+**one** probe on the parent to confirm that unconditional throw, then spend the remaining effort on
+mapping-fidelity and lifecycle shapes on the PR side instead. Confirm the predicate; don't assume it.
+
+## What to probe --- the context matrices
+
+PRs habitually test one context and leave the rest working-but-unverified or silently broken. Each
+row below is a *different code path*, not a variation of the same one.
+
+### SELECT / WHERE parity --- check this on every translation PR
+
+`ARCHITECTURE.md` requires a construct to work in both clause positions where feasible, and specifies
+which `$match` form is correct for which operand shape. What a reviewer adds is the evidence:
+
+- **Probe both positions.** A `SELECT`-only implementation is incomplete, not done. If a position is
+  out of scope, look for the negative test and the ticket; silence is the finding.
+- **Read which form was emitted**, not just whether it worked. `$expr` where the compact field-vs-value
+  form was available is a finding; find syntax where the semantics need `$expr` is a correctness bug.
+- Probe a field-vs-value case and a computed-operand case **side by side** and compare the two
+  pipelines --- the query template ships with exactly that pair for this reason.
+
+### Query and translation contexts
+
+| Context | Reach it with | Emits |
+|---|---|---|
+| SELECT projection | `select f(x) from E` | `$project` |
+| WHERE, computed operand | `where f(x) = v` | `$expr` inside `$match` --- the normal case |
+| WHERE, field vs. value | `where t.n = v` | compact find syntax, `{"n": {"$eq": v}}` |
+| Predicate operand | `where f(x) like '...'`, `in`, `is null` | expects `FIELD_PATH`, not `EXPRESSION` |
+| ORDER BY / GROUP BY / HAVING | `order by f(x)` | often a tracked throw --- confirm which |
+| Mutation | `update E set a = f(x)`, `delete ... where f(x)` | update pipeline |
+| Composition | `f(g(x))`, `f(x) = f(y)`, `f(x) = column` | recursion |
+| Absent / null values | nullable column, missing field | server-side rejection |
+| Literal vs parameter | `f(x, 2)` vs `f(x, :p)` | constant folding, `$literal` wrapping |
+
+### Schema, DDL, and JDBC contexts
+
+Schema export runs at `SessionFactory`-build time, not per query, so it needs its own harness
+(`DdlProbeTests.java.template`). Assert the **actual command sent to the server** --- "the server
+accepted it" and "the server built what the mapping asked for" are different claims, and a mapping
+detail that is silently dropped throws nothing at all.
+
+| Context | Reach it with | Assert |
+|---|---|---|
+| Each export action | `schema-generation.database.action` = `create`, `drop-and-create`, `create-drop`, `drop` | which admin commands actually fire for each |
+| Lifecycle | `create-drop`, then close the `SessionFactory` | the drop command is really emitted, not just implemented |
+| Idempotency | run the same export twice | second run's commands and any error |
+| Mapping fidelity | `columnList = "c DESC"`, compound, nested paths, unique vs not | the emitted key document matches the mapping exactly |
+| Competing idioms | `@Column(unique = true)` vs `@Table(uniqueConstraints = ...)` | that Hibernate materializes the constraint at all --- inspect boot metadata, not just the command |
+| Naming | `@Table(name = , schema = )` | collection name in the command, including any prefix |
+
+**Both templates register their own `CommandListener`** through the public
+`MongoConfigurationContributor` SPI rather than borrowing the integration-test framework's, whose shape
+and lifetime change over time. Owning the listener keeps probes stable across that churn.
+
+Two operational rules:
+
+- **Run one probe class at a time.** The suite runs test classes concurrently, and `System.out` from
+  two concurrent classes is interleaved and misattributed between XML report files.
+- **Always read the capture count.** `(none of 0 captured)` means the listener was never installed ---
+  a broken harness telling you nothing. Usual cause: Hibernate's `ServiceRegistry` holds one instance
+  per service interface and the last registration wins, and auto-discovered `ServiceContributor`s are
+  applied inside `build()`, after an explicit `addService` --- so a contributor on the test classpath
+  replaces the probe's and only its listener is installed. `(none of 3 captured)` is the opposite:
+  capture worked and no interesting command was emitted, which is itself often the finding.
+
+**Widened-set heuristic.** When a change gates behaviour on an implicit set --- a package name, an
+`instanceof`, a registry, a annotation scan --- enumerate that set's *current* members and probe each
+one. The set includes classes the author never considered, and the compiler will not tell you.
+
+## Architecture conformance
+
+`ARCHITECTURE.md` states the binding rules --- translation goes through the visitor, state is carried
+in translator fields, which filter language belongs in `$match`, the failure contract. Read it before reviewing a
+translation PR. These are the diff symptoms that indicate a violation:
+
+- A new class that takes a `SqlAstNode` and inspects its type directly instead of calling
+  `acceptAndYield(node, DESCRIPTOR)` and letting dispatch happen.
+- A `render`-style method that recurses into child nodes itself rather than yielding each child.
+- A translation that works with **no existing `visitXxx` modified**, for a construct whose operands
+  can be arbitrary expressions. Correct output today is not a defence: a parallel descent cannot see
+  translator state and will diverge on the next change.
+- A new field on the translator, sitting alongside `elemMatchInnerAlias` and `letVariableCounter` ---
+  that is the *sanctioned* pattern, so it is a point in the PR's favour, not a smell.
+
+## Reading outcomes
+
+`ARCHITECTURE.md` defines what the exception types mean. This is what to *do* on seeing each:
+
+| Observed | Reviewer action |
+|---|---|
+| `FeatureNotSupportedException` with `TODO-HIBERNATE-NNN` | Open the ticket. Confirm it actually covers the shape that threw, and is still open. |
+| `FeatureNotSupportedException` with a bare message | Not automatically a finding. Ask whether the limitation is inherent to MQL --- then no ticket is wanted --- or something we mean to implement, in which case it is. |
+| `AssertionError` | Always a blocker: an internal invariant was violated. Report the exact HQL that reaches it. |
+| `JDBCException` from the server | The translator emitted MQL the server rejects. Look for a missing argument-type or nullability guard. |
+| Wrong MQL, correct result | Silent correctness risk. Assert the pipeline, not just the rows. |
+| Command sent, but a mapping detail is missing from it | Silently dropped mapping (e.g. `DESC` flattened to `1`). Worst category: no error, wrong database. |
+| No command at all, no error | The feature never engaged. Check whether Hibernate even materializes the metadata, before blaming the dialect. |
+
+## Review output
+
+Structure the review as: **Blockers** (verified correctness defects), then **Significant** (API and
+semantics decisions worth settling pre-merge), then **Code quality**. For each finding give the file
+and line, the evidence label, and --- for blockers --- the concrete input that fails. Close with what
+gates merge versus what can be a follow-up.
+
+## Rationalizations
+
+| Thought | Reality |
+|---|---|
+| "I read the diff carefully, that's a thorough review" | Reading found "fragile"; running found "already broken". Different outputs. |
+| "The full suite passes, so it works" | The suite tests what the author thought to test. Probe what they didn't. |
+| "It's obviously a regression, no need to run the parent" | Without the parent run you cannot tell regression from pre-existing limitation, and that distinction decides whether it blocks merge. |
+| "Writing a probe test is too much work for a review" | The template is beside this file. The run takes seconds once Gradle is warm. |
+| "This is a design PR, nothing to execute" | Then say Unverified. Don't dress reasoning up as a finding. |
+| "The author already says this part is untested, so I'll just repeat that" | Verify it. "Untested" and "unreachable dead code" are different findings with different remedies, and only a probe tells them apart. |
+| "The parent has no prior behaviour here, so probing is pointless" | The parent run is what *establishes* that. Confirm it with one probe, then redirect effort to mapping fidelity and lifecycle on the PR side. |
+| "The author didn't use the translation skill, so it doesn't apply" | The skill is the project's standard for the construct, not a personal workflow. Review against it regardless. |
+| "It works in SELECT, WHERE can be a follow-up" | Then it needs a negative test and a ticket. Untested-but-reachable is the failure mode this repo keeps hitting. |
+| "The MQL is correct, so the parallel descent is fine" | It is correct *today*, for the shapes tried. It cannot see translator state and will diverge from the visitor on the next change. |
+
+## Red flags --- stop
+
+- About to write "this looks like it could break" without having tried to break it.
+- About to call something a regression without a parent-commit run.
+- Probe catches `Exception` instead of `Throwable` --- it will silently miss every `AssertionError`.
+- Probe reports `(none of 0 captured)` --- the listener is not installed, so you are reading nothing
+  and concluding something. Fix the harness before trusting a single result.
+- Signed off on a translation without seeing its `$match` output next to its `$project` output.
+- Probe file, worktree, or a temporarily-suppressed framework file still present at the end.
+
+## Cleanup
+
+Delete the probe files, remove the worktree, drop any collections the probes created, and confirm the
+tree is clean before delivering:
+
+```bash
+rm -f src/integrationTest/java/com/mongodb/hibernate/query/ZzProbeTests.java \
+      src/integrationTest/java/com/mongodb/hibernate/query/ZzDdlProbeTests.java
+git worktree remove --force "$BASE"
+mongosh --quiet mongo-hibernate-test --eval \
+  'db.getCollectionNames().filter(n => n.startsWith("probe_")).forEach(n => db[n].drop())'
+git status --short && git worktree list
+```

--- a/.claude/skills/reviewing-pull-requests/SKILL.md
+++ b/.claude/skills/reviewing-pull-requests/SKILL.md
@@ -196,6 +196,11 @@ semantics decisions worth settling pre-merge), then **Code quality**. For each f
 and line, the evidence label, and --- for blockers --- the concrete input that fails. Close with what
 gates merge versus what can be a follow-up.
 
+For a blocker, characterize the failure far enough to name the mechanism --- which invariant broke,
+which branch emitted the wrong form --- and reach for `superpowers:systematic-debugging` when the cause
+is not obvious from the probe output. Then stop at the diagnosis: the fix belongs to the author, and a
+review that arrives with a patch instead of a mechanism is harder to act on, not easier.
+
 ## Rationalizations
 
 | Thought | Reality |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,9 +83,18 @@ curl -s -X PUT \
   "https://jira.mongodb.org/rest/agile/1.0/issue/rank"
 ```
 
-## Adding HQL-to-MQL Translation Support
+## Architecture Invariants
 
-@.claude/skills/add-hql-to-mql-translation/SKILL.md
+`ARCHITECTURE.md` documents the contracts that new code has to respect: visitor dispatch and the
+`AstVisitorValueDescriptor` protocol, why translation must not use a parallel recursive descent,
+compact find syntax vs. `$expr` in `$match`, clause-position parity, the aggregation stage order, and
+the `FeatureNotSupportedException` vs. `AssertionError` failure contract. Read it before designing or
+reviewing a translation change.
+
+## Task-Specific Skills
+
+- Adding HQL-to-MQL translation support --- `.claude/skills/add-hql-to-mql-translation/SKILL.md`
+- Reviewing a pull request --- `.claude/skills/reviewing-pull-requests/SKILL.md`
 
 ## Code Style
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,173 @@
+# Architecture
+
+How the MongoDB Extension for Hibernate ORM is put together, and the invariants that new code has to
+respect. `AGENTS.md` has the layer map and the build commands; this document covers the contracts that
+are easy to violate without the compiler noticing.
+
+It is the shared reference for two workflows that would otherwise each restate it:
+
+- Implementing a new HQL construct --- `.claude/skills/add-hql-to-mql-translation/SKILL.md`
+- Reviewing a pull request --- `.claude/skills/reviewing-pull-requests/SKILL.md`
+
+This document covers *how to build it*, not *what is currently supported*. The integration test suite
+is the source of truth for the latter: a construct is supported if a positive integration test
+exercises it.
+
+---
+
+## The "SQL" string is a MongoDB command
+
+Hibernate assumes a dialect renders statements to a SQL string, hands that string to JDBC, and lets
+the driver execute it. This project keeps the shape and changes the content: the string a translator
+or exporter produces is **an extended-JSON MongoDB command**, and the JDBC layer **parses** it rather
+than forwarding it verbatim.
+
+- Queries and mutations: the translators build a `mongoast` tree, which is serialized to Extended JSON
+  and carried as the statement string, then executed by `MongoStatement` / `MongoPreparedStatement`.
+- Schema DDL: an `Exporter` produces the same kind of string, which `MongoStatement.execute(String)`
+  decodes into a typed command object before calling the driver.
+
+Two consequences worth internalizing. A statement string that looks like valid MQL is not proof the
+feature works --- something still has to parse it on the far side. And "the server accepted it" is a
+weaker claim than "the emitted command matches the mapping", because a dropped detail throws nothing.
+
+## Translation goes through the visitor
+
+`AbstractMqlTranslator` walks Hibernate's SQL AST as a visitor. Values move between `visitXxx` methods
+through `AstVisitorValueHolder`, keyed by an `AstVisitorValueDescriptor` that names the kind of result
+the caller wants:
+
+| Descriptor | Yields | Visibility |
+|---|---|---|
+| `FIELD_PATH` | a field path string | public |
+| `VALUE` | `AstValue` --- a literal or parameter | public |
+| `EXPRESSION` | `AstExpression` --- an aggregation expression | public |
+| `FILTER` | `AstFilter` --- a query filter | public |
+| `COLLECTION_NAME`, `PROJECT_STAGE_SPECIFICATIONS`, `SORT_FIELDS`, `TUPLE`, `SELECT_RESULT`, `MUTATION_RESULT` | internal plumbing | package-private |
+
+The visibility column records the current state, not a designed boundary. The four public descriptors
+are simply the ones something outside `internal.translate` has needed so far --- today, the custom
+function descriptors in `internal.dialect.function`. If a new construct needs one of the others,
+widening its modifier is an ordinary change, not a workaround; reaching for a hand-rolled traversal
+because a descriptor is not visible is the wrong trade. Everything under `internal` stays
+implementation-private to the module either way.
+
+The protocol is: `acceptAndYield(node, DESCRIPTOR)` to get a child's translation; `yield(DESCRIPTOR,
+value)` to produce your own; `expects(DESCRIPTOR)` to ask what the caller wants when a node can
+legitimately translate more than one way (a comparison is a `FILTER` in a WHERE clause and an
+`EXPRESSION` in a projection).
+
+**Do not add a parallel recursive descent.** Walking the AST yourself --- your own `switch` over node
+types, your own child-recursion, your own argument loop --- to avoid modifying existing `visitXxx`
+methods produces code that cannot see the translator's state and silently diverges from the real
+visitor as it evolves. It also bypasses `expects(...)`, and with it the filter-form decision below.
+
+**Carrying state in translator fields is the sanctioned alternative.** Adding a field to
+`AbstractMqlTranslator` is normal practice here, not a smell; `elemMatchInnerAlias`,
+`letVariableCounter`, `projectionKeyMap`, and `joinedTableQualifiers` all exist for exactly this. When
+a construct needs context that the visited node cannot carry, add a field and modify the visitor.
+
+## Filter form: two languages in `$match`, one in `$project`
+
+Two MongoDB languages are in play, and only one of the two names below is MongoDB's own:
+
+- **Aggregation expressions** --- the [expression operator](https://www.mongodb.com/docs/manual/reference/operator/aggregation/)
+  language (`$toUpper`, `$strLenCP`, `$eq`-as-expression). This is MongoDB's term.
+- **Find syntax** --- the [query operator](https://www.mongodb.com/docs/manual/reference/operator/query/)
+  language of `db.collection.find()` filters and `$match` predicates. "Find syntax" is our shorthand;
+  MongoDB calls these query operators, so search the manual for that.
+- [`$expr`](https://www.mongodb.com/docs/manual/reference/operator/query/expr/) is the bridge that
+  admits an aggregation expression into the query language.
+
+`$project` accepts **only** aggregation expressions; there is no find-syntax alternative there. So any
+construct that can appear in a projection needs an aggregation-expression translation, full stop.
+
+`$match` accepts two languages:
+
+| Language | Example | Applies to |
+|---|---|---|
+| find syntax (query operators) | `{"n": {"$eq": 7}}` | the narrow set of shapes MongoDB's query language expresses directly |
+| `$expr` wrapping an aggregation expression | `{"$expr": {"$eq": [{"$strLenCP": "$s"}, 7]}}` | everything else --- which is most constructs |
+
+**Find syntax is the restricted language, not the general one.** It reaches a fixed set of query
+operators, and the repo has a dedicated `AstFilter` node per operator it uses
+(`AstComparisonFilterOperation`, `AstListComparisonFilterOperation`, `AstAllFilterOperation`,
+`AstElemMatchFilterOperation`, `AstTypeFilterOperation`, `AstRegularExpressionFilterOperation`). Prefer
+it where it applies, because it is more readily indexable. But as soon as an operand is computed rather
+than a plain field-versus-value comparison, find syntax cannot express it and `$expr` is the correct
+answer, not a fallback to apologize for.
+
+For a comparison specifically, the choice is made in `toFilter`:
+
+| Operand shape | Rendering | Path |
+|---|---|---|
+| field vs. value --- `t.n = 7` | `{"n": {"$eq": 7}}` | `isComparingFieldWithValue` → `toFieldValueFilter` |
+| computed operand --- `length(t.s) = 7` | `{"$expr": {"$eq": [{"$strLenCP": "$s"}, 7]}}` | falls through to `AstExprFilter` |
+
+So the design question for a new construct is: what is its aggregation expression --- needed for
+`$project`, and for `$expr` inside `$match` --- and separately, is there a find-syntax form worth
+taking for the field-versus-value case? Emitting `$expr` where the compact form was available costs
+indexability; emitting find syntax where the semantics need an expression is a correctness bug.
+
+## Clause-position parity
+
+A construct should work in both `SELECT` and `WHERE` so far as is feasible. These are different
+branches --- one emits into `$project`, the other into `$match` --- so support in one is not evidence
+of support in the other, and a projection-only implementation is incomplete rather than done.
+
+Where a position is genuinely out of scope, it needs a negative test asserting the throw and a Jira
+ticket, not silence. Reachable-but-untested is the recurring failure mode in this codebase.
+
+## Aggregation pipeline stage order
+
+`SELECT` translation assembles stages in a fixed order:
+
+```
+($lookup + $unwind)*  →  $match  →  $sort  →  $skip / $limit  →  $project
+```
+
+One `$lookup` + `$unwind` pair per join. Nested joins are emitted depth-first: a join hanging off an
+already-joined entity produces its pair immediately after its parent's, ahead of the parent's next
+sibling.
+
+New stages have to be placed deliberately within that sequence, not appended.
+
+## Failure contract
+
+The exception a construct throws is part of its contract, and the two kinds mean opposite things:
+
+| Thrown | Meaning |
+|---|---|
+| `FeatureNotSupportedException` with `TODO-HIBERNATE-NNN` and the Jira URL | A gap we intend to close. The `TODO-` prefix is the "not yet implemented" signal, and the ticket must actually describe the shape that throws. |
+| `FeatureNotSupportedException` with a bare message | A deliberate refusal, with nothing tracked and nothing promised. Some of these are permanent --- MQL cannot express the construct at all --- and those need no ticket. The message should carry enough reason for a reader to tell which. |
+| `AssertionError` from `MongoAssertions` (`assertTrue`, `assertNotNull`, `fail`) | An **internal invariant was violated** --- always a bug, never a legitimate response to user input. Most often a descriptor mismatch in `AstVisitorValueHolder.yield`. |
+
+A construct that reaches a bare `AssertionError` for valid HQL is a defect even if the HQL is
+something we do not intend to support: the correct behaviour is a `FeatureNotSupportedException`
+naming a ticket.
+
+## Schema DDL
+
+Schema export reuses the pattern above: the dialect renders a command, and the JDBC layer parses it.
+
+```
+Dialect exporter --- getIndexExporter() / getUniqueKeyExporter()
+        ↓  a createIndexes / dropIndexes command, carried as the statement string
+MongoStatement.execute(String)
+        ↓  decoded into a typed command
+MongoDB Java driver
+```
+
+Hibernate requests an `Exporter` per kind of `Exportable`, and each one's `getSqlCreateStrings` /
+`getSqlDropStrings` returns statement strings. `getTableExporter()` has nothing to render, because
+MongoDB creates collections implicitly and has no `CREATE TABLE` analogue.
+
+That absence determines which mappings can be honoured. Hibernate models some constraints as their own
+exportable --- `@Index` and `@Table(uniqueConstraints = ...)` --- and leaves others to be inlined into
+table DDL by the table exporter, `@Column(unique = true)` among them. Only the first group reaches an
+exporter here, so anything in the second group has to be handled off the exporter path to have any
+effect at all.
+
+Export runs at `SessionFactory` build time, driven by
+`jakarta.persistence.schema-generation.database.action` --- so it is exercised by building a factory,
+not by running HQL.


### PR DESCRIPTION
## What

Two additions, plus wiring:

- **`ARCHITECTURE.md`** --- a single home for the translator contracts that are easy to violate without the compiler noticing: visitor dispatch and the `AstVisitorValueDescriptor` protocol, why translation must not use a parallel recursive descent, which filter language belongs in `$match` versus `$project`, clause-position parity, the aggregation stage order, the failure contract, and how schema DDL reuses the "statement string is a parsed MongoDB command" pattern.
- **`.claude/skills/reviewing-pull-requests/`** --- a review workflow built on one rule: *a claim about runtime behavior you did not execute is a hypothesis, not a finding.* Ships two throwaway probe harnesses (query translation, and schema/DDL) plus a differential technique: run the same probe on the PR and on its parent commit, which is what separates a regression from a pre-existing limitation.
- `AGENTS.md` points at all three. The translation skill keeps its investigation/spec/TDD phases and now defers to `ARCHITECTURE.md` for the contracts instead of restating them.

## Why

A recent review illustrated the gap. Reading the diff produced "this capability gate looks fragile." Actually compiling and probing the same branch produced two live defects invisible from reading --- valid HQL reaching a bare `AssertionError` rather than a `FeatureNotSupportedException` --- and running the identical probe on the parent commit proved they were regressions rather than pre-existing limits. The skill encodes that difference.

## Notes for review

- Every command, path, and mechanism in these files was executed rather than asserted. Both templates were compiled and run at the documented paths; the differential worktree flow was exercised end to end; the `ServiceRegistry` last-registration-wins behavior was confirmed against the Hibernate 7.4.1 sources; the linked MongoDB manual URLs were checked for 200s.
- The probe templates own their `CommandListener` via the public `MongoConfigurationContributor` SPI rather than borrowing the integration-test framework's, so they survive changes to that framework.
- The `@`-include of the translation skill in `AGENTS.md` becomes a plain path, so its body loads on demand instead of in every session. If skill discovery turns out to need the force-load, that line is the thing to revert.
- No `src/` changes; `spotlessCheck` passes.