### PR TITLE
HIBERNATE-213: fix release publishing for the multi-module build

### DIFF
--- a/.evergreen/publish.sh
+++ b/.evergreen/publish.sh
@@ -9,7 +9,7 @@ set -o errexit  # Exit the script with error if any of the commands fail
 ############################################
 source java-config.sh
 
-RELEASE=${RELEASE:false}
+RELEASE=${RELEASE:-false}
 
 export ORG_GRADLE_PROJECT_nexusUsername=${NEXUS_USERNAME}
 export ORG_GRADLE_PROJECT_nexusPassword=${NEXUS_PASSWORD}
@@ -17,12 +17,12 @@ export ORG_GRADLE_PROJECT_signingKey="${SIGNING_KEY}"
 export ORG_GRADLE_PROJECT_signingPassword=${SIGNING_PASSWORD}
 
 if [ "$RELEASE" == "true" ]; then
-  TASK="publishArchives closeAndReleaseSonatypeStagingRepository"
+  TASKS=(publishArchives closeAndReleaseSonatypeStagingRepository)
 else
-  TASK="publishSnapshots"
+  TASKS=(publishSnapshots)
 fi
 
-SYSTEM_PROPERTIES="-Dorg.gradle.internal.publish.checksums.insecure=true"
+SYSTEM_PROPERTIES=(-Dorg.gradle.internal.publish.checksums.insecure=true)
 
 ./gradlew -version
-./gradlew ${SYSTEM_PROPERTIES} --stacktrace --info "${TASK}"
+./gradlew "${SYSTEM_PROPERTIES[@]}" --stacktrace --info "${TASKS[@]}"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,7 +15,6 @@
  */
 
 import java.time.Duration
-import java.util.concurrent.Callable
 import net.ltgt.gradle.errorprone.errorprone
 
 plugins {
@@ -214,10 +213,16 @@ val gitVersion: String by lazy {
 }
 
 // A plain `tasks.named(name)` below would resolve to the root project's task alone, leaving the
-// publications of the subprojects unpublished. The Callable defers looking at the projects until the task
+// publications of the subprojects unpublished. The Provider defers looking at the projects until the task
 // graph is built, by which point the subprojects have been evaluated and their plugins are visible.
-fun publishingTaskInEveryProject(name: String) = Callable {
-    allprojects.filter { it.pluginManager.hasPlugin("mongo-hibernate-publish") }.map { it.tasks.named(name) }
+fun publishingTaskInEveryProject(name: String) = provider {
+    val publishing = allprojects.filter { it.pluginManager.hasPlugin("mongo-hibernate-publish") }
+    val withPublications =
+        allprojects.filter { it.extensions.findByType<PublishingExtension>()?.publications?.isNotEmpty() == true }
+    require((withPublications - publishing.toSet()).isEmpty()) {
+        "Projects declare publications but don't apply mongo-hibernate-publish: ${withPublications - publishing.toSet()}"
+    }
+    publishing.map { it.tasks.named(name) }
 }
 
 // Publish snapshots

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,6 +15,7 @@
  */
 
 import java.time.Duration
+import java.util.concurrent.Callable
 import net.ltgt.gradle.errorprone.errorprone
 
 plugins {
@@ -212,14 +213,21 @@ val gitVersion: String by lazy {
         .getOrElse("UNKNOWN")
 }
 
+// A plain `tasks.named(name)` below would resolve to the root project's task alone, leaving the
+// publications of the subprojects unpublished. The Callable defers looking at the projects until the task
+// graph is built, by which point the subprojects have been evaluated and their plugins are visible.
+fun publishingTaskInEveryProject(name: String) = Callable {
+    allprojects.filter { it.pluginManager.hasPlugin("mongo-hibernate-publish") }.map { it.tasks.named(name) }
+}
+
 // Publish snapshots
 tasks.register("publishSnapshots") {
     group = "publishing"
     description = "Publishes snapshots to Sonatype"
 
     if (version.toString().endsWith("-SNAPSHOT")) {
-        dependsOn(tasks.named("publishAllPublicationsToLocalBuildRepository"))
-        dependsOn(tasks.named("publishToSonatype"))
+        dependsOn(publishingTaskInEveryProject("publishAllPublicationsToLocalBuildRepository"))
+        dependsOn(publishingTaskInEveryProject("publishToSonatype"))
     }
 }
 
@@ -248,8 +256,8 @@ tasks.register("publishArchives") {
         }
     }
     if (gitVersionMatch) {
-        dependsOn(tasks.named("publishAllPublicationsToLocalBuildRepository"))
-        dependsOn(tasks.named("publishToSonatype"))
+        dependsOn(publishingTaskInEveryProject("publishAllPublicationsToLocalBuildRepository"))
+        dependsOn(publishingTaskInEveryProject("publishToSonatype"))
     }
 }
 

--- a/buildSrc/src/main/kotlin/mongo-hibernate-java.gradle.kts
+++ b/buildSrc/src/main/kotlin/mongo-hibernate-java.gradle.kts
@@ -21,11 +21,7 @@ plugins {
     id("spotless-java-extension")
 }
 
-java {
-    toolchain { languageVersion = JavaLanguageVersion.of(17) } // Remember to update javadoc links
-    withJavadocJar()
-    withSourcesJar()
-}
+java { toolchain { languageVersion = JavaLanguageVersion.of(17) } } // Remember to update javadoc links
 
 tasks.withType<Test>().configureEach {
     useJUnitPlatform()

--- a/buildSrc/src/main/kotlin/mongo-hibernate-publish.gradle.kts
+++ b/buildSrc/src/main/kotlin/mongo-hibernate-publish.gradle.kts
@@ -19,6 +19,16 @@ plugins {
     id("signing")
 }
 
+// Maven Central rejects a release missing either jar, so the requirement lives with publishing rather than
+// with any one of the Java conventions a published module might or might not apply. Both are empty for a
+// module without source code, as they are for Spring Boot's own starters.
+pluginManager.withPlugin("java") {
+    extensions.configure<JavaPluginExtension> {
+        withJavadocJar()
+        withSourcesJar()
+    }
+}
+
 val localBuildRepo: Provider<Directory> = project.layout.buildDirectory.dir("repo")
 
 tasks.named<Delete>("clean") { delete.add(localBuildRepo) }


### PR DESCRIPTION
Fixes three defects in the release process.

1. publish.sh expanded the Gradle task list as `"${TASK}"`, making the two release task names a single argv element, so Gradle looked for one task named `"publishArchives closeAndReleaseSonatypeStagingRepository"`. A bash array expanded with `"${TASKS[@]}"` passes them separately. Snapshot publishing was unaffected because `publishSnapshots` is a single word, which is why this went unnoticed until the first release attempt. `SYSTEM_PROPERTIES` becomes an array for the same reason, and RELEASE now uses `${RELEASE:-false}`.

2. `publishArchives` and `publishSnapshots` declared `dependsOn(tasks.named(...))`, which resolves to the root project's tasks alone, so the publications of the Spring Boot modules were never uploaded and the build still passed. Both lifecycle tasks now depend on the equivalent task in every project that applies `mongo-hibernate-publish`.

3. The starter module applies plain `java-library` rather than the Java conventions, so it published neither a sources nor a javadoc jar; Maven Central requires both, and the staging repository would have failed to close. Producing the two jars moves from `mongo-hibernate-java` to `mongo-hibernate-publish`, since the requirement follows from publishing a module rather than from how the module is compiled.