### PR TITLE
HIBERNATE-220: executeUpdate returns the JDBC row count for updates

### DIFF
--- a/src/integrationTest/java/com/mongodb/hibernate/query/mutation/UpdatingIntegrationTests.java
+++ b/src/integrationTest/java/com/mongodb/hibernate/query/mutation/UpdatingIntegrationTests.java
@@ -337,6 +337,52 @@ class UpdatingIntegrationTests extends AbstractQueryIntegrationTests {
                 Set.of(Book.COLLECTION_NAME));
     }
 
+    @Test
+    void testUpdateMutationCountIsMatchedCount() {
+        assertMutationQuery(
+                "update Book set outOfStock = false where id = 1 or id = 2",
+                2,
+                """
+                {
+                   "update": "books",
+                   "updates": [
+                     {
+                       "multi": true,
+                       "q": {
+                         "$or": [
+                           {"_id": {"$eq": 1}},
+                           {"_id": {"$eq": 2}}
+                         ]
+                       },
+                       "u": {
+                         "$set": {
+                           "outOfStock": false
+                         }
+                       }
+                     }
+                   ]
+                }
+                """,
+                booksCollection,
+                List.of(
+                        BsonDocument.parse(
+                                """
+                                {"_id": 1, "title": "War & Peace", "outOfStock": false, "publishYear": 1869, "isbn13": null, "discount": null, "price": null}"""),
+                        BsonDocument.parse(
+                                """
+                                {"_id": 2, "title": "Crime and Punishment", "outOfStock": false, "publishYear": 1866, "isbn13": null, "discount": null, "price": null}"""),
+                        BsonDocument.parse(
+                                """
+                                {"_id": 3, "title": "Anna Karenina", "outOfStock": false, "publishYear": 1877, "isbn13": null, "discount": null, "price": null}"""),
+                        BsonDocument.parse(
+                                """
+                                {"_id": 4, "title": "The Brothers Karamazov", "outOfStock": false, "publishYear": 1880, "isbn13": null, "discount": null, "price": null}"""),
+                        BsonDocument.parse(
+                                """
+                                {"_id": 5, "title": "War & Peace", "outOfStock": false, "publishYear": 2025, "isbn13": null, "discount": null, "price": null}""")),
+                Set.of(Book.COLLECTION_NAME));
+    }
+
     @Nested
     class Unsupported implements MongoServiceRegistryProducer {
         @Test

--- a/src/main/java/com/mongodb/hibernate/internal/jdbc/MongoStatement.java
+++ b/src/main/java/com/mongodb/hibernate/internal/jdbc/MongoStatement.java
@@ -353,7 +353,7 @@ class MongoStatement implements StatementAdapter {
     private static int getUpdateCount(CommandDescription commandDescription, BulkWriteResult bulkWriteResult) {
         return switch (commandDescription) {
             case INSERT -> bulkWriteResult.getInsertedCount();
-            case UPDATE -> bulkWriteResult.getModifiedCount();
+            case UPDATE -> bulkWriteResult.getMatchedCount();
             case DELETE -> bulkWriteResult.getDeletedCount();
             default -> throw fail();
         };

--- a/src/test/java/com/mongodb/hibernate/internal/jdbc/MongoStatementTests.java
+++ b/src/test/java/com/mongodb/hibernate/internal/jdbc/MongoStatementTests.java
@@ -168,6 +168,15 @@ class MongoStatementTests {
         }
 
         @Test
+        void testExecuteUpdateReturnsMatchedCount() throws SQLException {
+            doReturn(BulkWriteResult.acknowledged(0, 2, 0, 1, emptyList(), emptyList()))
+                    .when(mongoCollection)
+                    .bulkWrite(eq(clientSession), anyList());
+
+            assertEquals(2, mongoStatement.executeUpdate(EXAMPLE_UPDATE_MQL));
+        }
+
+        @Test
         void testExecute() throws SQLException {
             assertThrows(SQLFeatureNotSupportedException.class, () -> mongoStatement.execute(EXAMPLE_UPDATE_MQL));
             assertTrue(lastOpenResultSet.isClosed());


### PR DESCRIPTION
JDBC's Statement#executeUpdate contract is the count of rows matched by the DML statement, not the count of rows whose values actually changed. The UPDATE arm of MongoStatement.getUpdateCount used getModifiedCount(), which under-reports when a bulk HQL UPDATE matches a document that already holds the target value. Switch to getMatchedCount().

Discovered while implementing upsert support in scope of HIBERNATE-217, which exposed this bug.