### PR TITLE
HIBERNATE-217: support StatelessSession.upsert on unversioned entities

### DIFF
--- a/src/integrationTest/java/com/mongodb/hibernate/UpsertIntegrationTests.java
+++ b/src/integrationTest/java/com/mongodb/hibernate/UpsertIntegrationTests.java
@@ -16,57 +16,274 @@
 
 package com.mongodb.hibernate;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.mongodb.client.MongoCollection;
 import com.mongodb.hibernate.internal.FeatureNotSupportedException;
-import com.mongodb.hibernate.junit.MongoExtension;
+import com.mongodb.hibernate.junit.InjectMongoCollection;
 import com.mongodb.hibernate.junit.MongoServiceRegistryProducer;
+import com.mongodb.hibernate.query.AbstractQueryIntegrationTests;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import jakarta.persistence.Version;
+import java.util.List;
+import org.bson.BsonDocument;
 import org.hibernate.testing.orm.junit.DomainModel;
-import org.hibernate.testing.orm.junit.SessionFactory;
-import org.hibernate.testing.orm.junit.SessionFactoryScope;
-import org.hibernate.testing.orm.junit.SessionFactoryScopeAware;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
-@SessionFactory(exportSchema = false)
-@DomainModel(annotatedClasses = {UpsertIntegrationTests.Item.class})
-@ExtendWith(MongoExtension.class)
-class UpsertIntegrationTests implements SessionFactoryScopeAware, MongoServiceRegistryProducer {
-    private SessionFactoryScope sessionFactoryScope;
+@DomainModel(
+        annotatedClasses = {
+            UpsertIntegrationTests.Item.class,
+            UpsertIntegrationTests.AuditedItem.class,
+            UpsertIntegrationTests.TalliedItem.class,
+            UpsertIntegrationTests.VersionedItem.class,
+            UpsertIntegrationTests.StampedItem.class,
+            UpsertIntegrationTests.BareItem.class
+        })
+class UpsertIntegrationTests extends AbstractQueryIntegrationTests {
 
-    @Override
-    public void injectSessionFactoryScope(SessionFactoryScope sessionFactoryScope) {
-        this.sessionFactoryScope = sessionFactoryScope;
+    @InjectMongoCollection("items")
+    private MongoCollection<BsonDocument> itemCollection;
+
+    @InjectMongoCollection("auditedItems")
+    private MongoCollection<BsonDocument> auditedItemCollection;
+
+    @InjectMongoCollection("stampedItems")
+    private MongoCollection<BsonDocument> stampedItemCollection;
+
+    @Test
+    void upsertInsertsWhenNoDocumentMatches() {
+        getSessionFactoryScope().inStatelessTransaction(session -> {
+            session.upsert(new Item(1, 10, "a"));
+            assertActualCommandsInOrder(
+                    BsonDocument.parse(
+                            """
+                            {"update": "items", "updates": [{"q": {"_id": {"$eq": 1}}, "u": {"$set": {"label": "a", "v": 10}}, "upsert": true}]}
+                            """));
+        });
+        assertThat(itemCollection.find())
+                .containsExactly(BsonDocument.parse("""
+                        {"_id": 1, "label": "a", "v": 10}"""));
     }
 
     @Test
-    void unsupported() {
-        var item = new Item(1, 1);
-        sessionFactoryScope.inStatelessTransaction(session ->
-                assertThatThrownBy(() -> session.upsert(item)).isInstanceOf(FeatureNotSupportedException.class));
+    void upsertUpdatesWhenDocumentMatches() {
+        getSessionFactoryScope().inStatelessTransaction(session -> session.upsert(new Item(1, 10, "a")));
+        getSessionFactoryScope().inStatelessTransaction(session -> {
+            // discard the seeding upsert's command; the extension only clears before the test body
+            commandHistory.clear();
+            session.upsert(new Item(1, 20, "b"));
+            assertActualCommandsInOrder(
+                    BsonDocument.parse(
+                            """
+                            {"update": "items", "updates": [{"q": {"_id": {"$eq": 1}}, "u": {"$set": {"label": "b", "v": 20}}, "upsert": true}]}
+                            """));
+        });
+        assertThat(itemCollection.find())
+                .containsExactly(BsonDocument.parse("""
+                        {"_id": 1, "label": "b", "v": 20}"""));
     }
 
-    @Entity
-    @Table(name = Item.COLLECTION_NAME)
-    static class Item {
-        static final String COLLECTION_NAME = "items";
+    @Test
+    void upsertMultipleBatchesIntoOneCommand() {
+        getSessionFactoryScope().inStatelessTransaction(session -> {
+            session.upsertMultiple(List.of(new Item(1, 10, "a"), new Item(2, 20, "b")));
+            assertActualCommandsInOrder(
+                    BsonDocument.parse(
+                            """
+                            {"update": "items", "updates": [
+                              {"q": {"_id": {"$eq": 1}}, "u": {"$set": {"label": "a", "v": 10}}, "upsert": true},
+                              {"q": {"_id": {"$eq": 2}}, "u": {"$set": {"label": "b", "v": 20}}, "upsert": true}]}
+                            """));
+        });
+        assertThat(itemCollection.find())
+                .containsExactly(
+                        BsonDocument.parse("""
+                                {"_id": 1, "label": "a", "v": 10}"""),
+                        BsonDocument.parse("""
+                                {"_id": 2, "label": "b", "v": 20}"""));
+    }
 
+    @Test
+    void nonUpdatableAttributeGoesToSetOnInsert() {
+        getSessionFactoryScope().inStatelessTransaction(session -> {
+            session.upsert(new AuditedItem(1, "first", "jeff"));
+            assertActualCommandsInOrder(
+                    BsonDocument.parse(
+                            """
+                            {"update": "auditedItems", "updates": [{"q": {"_id": {"$eq": 1}}, "u": {"$set": {"label": "first"}, "$setOnInsert": {"createdBy": "jeff"}}, "upsert": true}]}
+                            """));
+        });
+        assertThat(auditedItemCollection.find())
+                .containsExactly(BsonDocument.parse(
+                        """
+                        {"_id": 1, "createdBy": "jeff", "label": "first"}"""));
+
+        getSessionFactoryScope()
+                .inStatelessTransaction(session -> session.upsert(new AuditedItem(1, "second", "intruder")));
+        assertThat(auditedItemCollection.find())
+                .containsExactly(BsonDocument.parse(
+                        """
+                        {"_id": 1, "createdBy": "jeff", "label": "second"}"""));
+    }
+
+    @Test
+    void upsertIsIdempotent() {
+        getSessionFactoryScope().inStatelessTransaction(session -> session.upsert(new Item(1, 10, "a")));
+        getSessionFactoryScope().inStatelessTransaction(session -> session.upsert(new Item(1, 10, "a")));
+        assertThat(itemCollection.find())
+                .containsExactly(BsonDocument.parse("""
+                        {"_id": 1, "label": "a", "v": 10}"""));
+    }
+
+    @Test
+    void upsertMatchingWithoutModifyingSucceeds() {
+        getSessionFactoryScope().inStatelessTransaction(session -> session.upsert(new StampedItem(1, "jeff")));
+        getSessionFactoryScope().inStatelessTransaction(session -> session.upsert(new StampedItem(1, "intruder")));
+        assertThat(stampedItemCollection.find())
+                .containsExactly(BsonDocument.parse("""
+                        {"_id": 1, "createdBy": "jeff"}"""));
+    }
+
+    @Nested
+    class Unsupported implements MongoServiceRegistryProducer {
+
+        @Test
+        void upsertOnVersionedEntityIsNotSupported() {
+            getSessionFactoryScope().inStatelessTransaction(session -> assertThatThrownBy(
+                            () -> session.upsert(new VersionedItem(1, "a")))
+                    .isInstanceOf(FeatureNotSupportedException.class)
+                    .hasMessage("TODO-HIBERNATE-216 https://jira.mongodb.org/browse/HIBERNATE-216"));
+        }
+
+        @Test
+        void upsertOnNonInsertableAttributeIsNotSupported() {
+            getSessionFactoryScope().inStatelessTransaction(session -> assertThatThrownBy(
+                            () -> session.upsert(new TalliedItem(1, "a", 5)))
+                    .isInstanceOf(FeatureNotSupportedException.class)
+                    .hasMessage("MongoDB does not support upserting a column that is updatable but not insertable:"
+                            + " [tally]"));
+        }
+
+        @Test
+        void upsertOnIdOnlyEntityIsNotSupported() {
+            getSessionFactoryScope()
+                    .inStatelessTransaction(
+                            session -> assertThatThrownBy(() -> session.upsert(new BareItem(1)))
+                                    .isInstanceOf(FeatureNotSupportedException.class)
+                                    .hasMessage(
+                                            "MongoDB does not support upserting an entity whose only persistent attribute is its identifier"));
+        }
+    }
+
+    @Entity(name = "Item")
+    @Table(name = "items")
+    static class Item {
         @Id
         int id;
-        /**
-         * {@link org.hibernate.StatelessSession#upsert(Object)} results in no commands issued to the DBMS if {@link Id}
-         * is the only persistent attribute, which must be a bug.
-         */
+
         int v;
+        String label;
 
         Item() {}
 
-        Item(int id, int v) {
+        Item(int id, int v, String label) {
             this.id = id;
-            v = 1;
+            this.v = v;
+            this.label = label;
+        }
+    }
+
+    @Entity(name = "AuditedItem")
+    @Table(name = "auditedItems")
+    static class AuditedItem {
+        @Id
+        int id;
+
+        String label;
+
+        @Column(updatable = false)
+        String createdBy;
+
+        AuditedItem() {}
+
+        AuditedItem(int id, String label, String createdBy) {
+            this.id = id;
+            this.label = label;
+            this.createdBy = createdBy;
+        }
+    }
+
+    @Entity(name = "TalliedItem")
+    @Table(name = "talliedItems")
+    static class TalliedItem {
+        @Id
+        int id;
+
+        String label;
+
+        @Column(insertable = false)
+        Integer tally;
+
+        TalliedItem() {}
+
+        TalliedItem(int id, String label, Integer tally) {
+            this.id = id;
+            this.label = label;
+            this.tally = tally;
+        }
+    }
+
+    @Entity(name = "VersionedItem")
+    @Table(name = "versionedItems")
+    static class VersionedItem {
+        @Id
+        int id;
+
+        String label;
+
+        @Version
+        int version;
+
+        VersionedItem() {}
+
+        VersionedItem(int id, String label) {
+            this.id = id;
+            this.label = label;
+        }
+    }
+
+    @Entity(name = "StampedItem")
+    @Table(name = "stampedItems")
+    static class StampedItem {
+        @Id
+        int id;
+
+        @Column(updatable = false)
+        String createdBy;
+
+        StampedItem() {}
+
+        StampedItem(int id, String createdBy) {
+            this.id = id;
+            this.createdBy = createdBy;
+        }
+    }
+
+    @Entity(name = "BareItem")
+    @Table(name = "bareItems")
+    static class BareItem {
+        @Id
+        int id;
+
+        BareItem() {}
+
+        BareItem(int id) {
+            this.id = id;
         }
     }
 }

--- a/src/integrationTest/java/com/mongodb/hibernate/UpsertIntegrationTests.java
+++ b/src/integrationTest/java/com/mongodb/hibernate/UpsertIntegrationTests.java
@@ -24,13 +24,17 @@ import com.mongodb.hibernate.internal.FeatureNotSupportedException;
 import com.mongodb.hibernate.junit.InjectMongoCollection;
 import com.mongodb.hibernate.junit.MongoServiceRegistryProducer;
 import com.mongodb.hibernate.query.AbstractQueryIntegrationTests;
+import jakarta.persistence.AccessType;
 import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.persistence.Version;
 import java.util.List;
 import org.bson.BsonDocument;
+import org.hibernate.annotations.Parent;
+import org.hibernate.annotations.Struct;
 import org.hibernate.testing.orm.junit.DomainModel;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -42,7 +46,16 @@ import org.junit.jupiter.api.Test;
             UpsertIntegrationTests.TalliedItem.class,
             UpsertIntegrationTests.VersionedItem.class,
             UpsertIntegrationTests.StampedItem.class,
-            UpsertIntegrationTests.BareItem.class
+            UpsertIntegrationTests.BareItem.class,
+            UpsertIntegrationTests.AddressedItem.class,
+            UpsertIntegrationTests.NestedlyAddressedItem.class,
+            UpsertIntegrationTests.AuditedAddressedItem.class,
+            UpsertIntegrationTests.TaggedItem.class,
+            UpsertIntegrationTests.DualAddressedItem.class,
+            UpsertIntegrationTests.CatalogedItem.class,
+            UpsertIntegrationTests.ParentedItem.class,
+            UpsertIntegrationTests.RenamedAddressItem.class,
+            UpsertIntegrationTests.AddressLabeledItem.class
         })
 class UpsertIntegrationTests extends AbstractQueryIntegrationTests {
 
@@ -54,6 +67,33 @@ class UpsertIntegrationTests extends AbstractQueryIntegrationTests {
 
     @InjectMongoCollection("stampedItems")
     private MongoCollection<BsonDocument> stampedItemCollection;
+
+    @InjectMongoCollection("addressedItems")
+    private MongoCollection<BsonDocument> addressedItemCollection;
+
+    @InjectMongoCollection("nestedlyAddressedItems")
+    private MongoCollection<BsonDocument> nestedlyAddressedItemCollection;
+
+    @InjectMongoCollection("auditedAddressedItems")
+    private MongoCollection<BsonDocument> auditedAddressedItemCollection;
+
+    @InjectMongoCollection("taggedItems")
+    private MongoCollection<BsonDocument> taggedItemCollection;
+
+    @InjectMongoCollection("dualAddressedItems")
+    private MongoCollection<BsonDocument> dualAddressedItemCollection;
+
+    @InjectMongoCollection("catalogedItems")
+    private MongoCollection<BsonDocument> catalogedItemCollection;
+
+    @InjectMongoCollection("parentedItems")
+    private MongoCollection<BsonDocument> parentedItemCollection;
+
+    @InjectMongoCollection("renamedAddressItems")
+    private MongoCollection<BsonDocument> renamedAddressItemCollection;
+
+    @InjectMongoCollection("addressLabeledItems")
+    private MongoCollection<BsonDocument> addressLabeledItemCollection;
 
     @Test
     void upsertInsertsWhenNoDocumentMatches() {
@@ -147,6 +187,267 @@ class UpsertIntegrationTests extends AbstractQueryIntegrationTests {
         assertThat(stampedItemCollection.find())
                 .containsExactly(BsonDocument.parse("""
                         {"_id": 1, "createdBy": "jeff"}"""));
+    }
+
+    @Test
+    void upsertInsertsStructAggregateEmbeddable() {
+        getSessionFactoryScope().inStatelessTransaction(session -> {
+            session.upsert(new AddressedItem(1, "a", new Address("NYC", 10001)));
+            assertActualCommandsInOrder(
+                    BsonDocument.parse(
+                            """
+                            {"update": "addressedItems", "updates": [{"q": {"_id": {"$eq": 1}}, "u": {"$set": {"address": {"city": "NYC", "zipCode": 10001}, "label": "a"}}, "upsert": true}]}
+                            """));
+        });
+        assertThat(addressedItemCollection.find())
+                .containsExactly(
+                        BsonDocument.parse(
+                                """
+                                {"_id": 1, "address": {"city": "NYC", "zipCode": 10001}, "label": "a"}"""));
+    }
+
+    @Test
+    void upsertReplacesWholeStructAggregateEmbeddable() {
+        getSessionFactoryScope()
+                .inStatelessTransaction(
+                        session -> session.upsert(new AddressedItem(1, "a", new Address("NYC", 10001))));
+        getSessionFactoryScope().inStatelessTransaction(session -> {
+            // discard the seeding upsert's command; the extension only clears before the test body
+            commandHistory.clear();
+            session.upsert(new AddressedItem(1, "b", new Address(null, 20002)));
+            assertActualCommandsInOrder(
+                    BsonDocument.parse(
+                            """
+                            {"update": "addressedItems", "updates": [{"q": {"_id": {"$eq": 1}}, "u": {"$set": {"address": {"city": null, "zipCode": 20002}, "label": "b"}}, "upsert": true}]}
+                            """));
+        });
+        assertThat(addressedItemCollection.find())
+                .containsExactly(
+                        BsonDocument.parse(
+                                """
+                                {"_id": 1, "address": {"city": null, "zipCode": 20002}, "label": "b"}"""));
+    }
+
+    @Test
+    void upsertMultipleBatchesStructAggregateEmbeddablesIntoOneCommand() {
+        getSessionFactoryScope().inStatelessTransaction(session -> {
+            session.upsertMultiple(List.of(
+                    new AddressedItem(1, "a", new Address("NYC", 10001)),
+                    new AddressedItem(2, "b", new Address("LA", 90001))));
+            assertActualCommandsInOrder(
+                    BsonDocument.parse(
+                            """
+                            {"update": "addressedItems", "updates": [
+                              {"q": {"_id": {"$eq": 1}}, "u": {"$set": {"address": {"city": "NYC", "zipCode": 10001}, "label": "a"}}, "upsert": true},
+                              {"q": {"_id": {"$eq": 2}}, "u": {"$set": {"address": {"city": "LA", "zipCode": 90001}, "label": "b"}}, "upsert": true}]}
+                            """));
+        });
+        assertThat(addressedItemCollection.find())
+                .containsExactly(
+                        BsonDocument.parse(
+                                """
+                                {"_id": 1, "address": {"city": "NYC", "zipCode": 10001}, "label": "a"}"""),
+                        BsonDocument.parse(
+                                """
+                                {"_id": 2, "address": {"city": "LA", "zipCode": 90001}, "label": "b"}"""));
+    }
+
+    @Test
+    void upsertInsertsNestedStructAggregateEmbeddable() {
+        getSessionFactoryScope().inStatelessTransaction(session -> {
+            session.upsert(new NestedlyAddressedItem(1, new NestedAddress("NYC", new Zone(7))));
+            assertActualCommandsInOrder(
+                    BsonDocument.parse(
+                            """
+                            {"update": "nestedlyAddressedItems", "updates": [{"q": {"_id": {"$eq": 1}}, "u": {"$set": {"address": {"city": "NYC", "zone": {"code": 7}}}}, "upsert": true}]}
+                            """));
+        });
+        assertThat(nestedlyAddressedItemCollection.find())
+                .containsExactly(BsonDocument.parse(
+                        """
+                        {"_id": 1, "address": {"city": "NYC", "zone": {"code": 7}}}"""));
+    }
+
+    @Test
+    void upsertSplitsStructAggregateEmbeddableAndNonUpdatableColumnAcrossOperators() {
+        getSessionFactoryScope().inStatelessTransaction(session -> {
+            session.upsert(new AuditedAddressedItem(1, "a", new Address("NYC", 10001), "jeff"));
+            assertActualCommandsInOrder(
+                    BsonDocument.parse(
+                            """
+                            {"update": "auditedAddressedItems", "updates": [{"q": {"_id": {"$eq": 1}}, "u": {"$set": {"address": {"city": "NYC", "zipCode": 10001}, "label": "a"}, "$setOnInsert": {"createdBy": "jeff"}}, "upsert": true}]}
+                            """));
+        });
+        assertThat(auditedAddressedItemCollection.find())
+                .containsExactly(
+                        BsonDocument.parse(
+                                """
+                                {"_id": 1, "address": {"city": "NYC", "zipCode": 10001}, "createdBy": "jeff", "label": "a"}"""));
+    }
+
+    @Test
+    void upsertWritesArraysAndPlainEmbeddables() {
+        getSessionFactoryScope().inStatelessTransaction(session -> {
+            session.upsert(new TaggedItem(1, new int[] {2, 3}, new Coordinates(4, 5)));
+            assertActualCommandsInOrder(
+                    BsonDocument.parse(
+                            """
+                            {"update": "taggedItems", "updates": [{"q": {"_id": {"$eq": 1}}, "u": {"$set": {"x": 4, "y": 5, "tags": [2, 3]}}, "upsert": true}]}
+                            """));
+        });
+        assertThat(taggedItemCollection.find())
+                .containsExactly(BsonDocument.parse(
+                        """
+                                           {"_id": 1, "x": 4, "y": 5, "tags": [2, 3]}"""));
+    }
+
+    @Test
+    void upsertInsertsTwoStructAggregateEmbeddables() {
+        getSessionFactoryScope().inStatelessTransaction(session -> {
+            session.upsert(new DualAddressedItem(1, new Address("NYC", 10001), new Address("Boston", 20002)));
+            assertActualCommandsInOrder(
+                    BsonDocument.parse(
+                            """
+                            {"update": "dualAddressedItems", "updates": [{"q": {"_id": {"$eq": 1}}, "u": {"$set": {"homeAddress": {"city": "NYC", "zipCode": 10001}, "workAddress": {"city": "Boston", "zipCode": 20002}}}, "upsert": true}]}
+                            """));
+        });
+        assertThat(dualAddressedItemCollection.find())
+                .containsExactly(
+                        BsonDocument.parse(
+                                """
+                                {"_id": 1, "homeAddress": {"city": "NYC", "zipCode": 10001}, "workAddress": {"city": "Boston", "zipCode": 20002}}"""));
+    }
+
+    @Test
+    void upsertUpdatesTwoStructAggregateEmbeddables() {
+        getSessionFactoryScope()
+                .inStatelessTransaction(session -> session.upsert(
+                        new DualAddressedItem(1, new Address("NYC", 10001), new Address("Boston", 20002))));
+        getSessionFactoryScope().inStatelessTransaction(session -> {
+            // discard the seeding upsert's command; the extension only clears before the test body
+            commandHistory.clear();
+            session.upsert(new DualAddressedItem(1, new Address("LA", 90001), new Address("Miami", 33101)));
+            assertActualCommandsInOrder(
+                    BsonDocument.parse(
+                            """
+                            {"update": "dualAddressedItems", "updates": [{"q": {"_id": {"$eq": 1}}, "u": {"$set": {"homeAddress": {"city": "LA", "zipCode": 90001}, "workAddress": {"city": "Miami", "zipCode": 33101}}}, "upsert": true}]}
+                            """));
+        });
+        assertThat(dualAddressedItemCollection.find())
+                .containsExactly(
+                        BsonDocument.parse(
+                                """
+                                {"_id": 1, "homeAddress": {"city": "LA", "zipCode": 90001}, "workAddress": {"city": "Miami", "zipCode": 33101}}"""));
+    }
+
+    @Test
+    void upsertMultipleBatchesTwoStructAggregateEmbeddablesIntoOneCommand() {
+        getSessionFactoryScope().inStatelessTransaction(session -> {
+            session.upsertMultiple(List.of(
+                    new DualAddressedItem(1, new Address("NYC", 10001), new Address("Boston", 20002)),
+                    new DualAddressedItem(2, new Address("LA", 90001), new Address("Miami", 33101))));
+            assertActualCommandsInOrder(
+                    BsonDocument.parse(
+                            """
+                            {"update": "dualAddressedItems", "updates": [
+                              {"q": {"_id": {"$eq": 1}}, "u": {"$set": {"homeAddress": {"city": "NYC", "zipCode": 10001}, "workAddress": {"city": "Boston", "zipCode": 20002}}}, "upsert": true},
+                              {"q": {"_id": {"$eq": 2}}, "u": {"$set": {"homeAddress": {"city": "LA", "zipCode": 90001}, "workAddress": {"city": "Miami", "zipCode": 33101}}}, "upsert": true}]}
+                            """));
+        });
+        assertThat(dualAddressedItemCollection.find())
+                .containsExactly(
+                        BsonDocument.parse(
+                                """
+                                {"_id": 1, "homeAddress": {"city": "NYC", "zipCode": 10001}, "workAddress": {"city": "Boston", "zipCode": 20002}}"""),
+                        BsonDocument.parse(
+                                """
+                                {"_id": 2, "homeAddress": {"city": "LA", "zipCode": 90001}, "workAddress": {"city": "Miami", "zipCode": 33101}}"""));
+    }
+
+    @Test
+    void upsertInsertsStructAggregateEmbeddableContainingAnArray() {
+        getSessionFactoryScope().inStatelessTransaction(session -> {
+            session.upsert(new CatalogedItem(1, new Catalog("c", new int[] {2, 3})));
+            assertActualCommandsInOrder(
+                    BsonDocument.parse(
+                            """
+                            {"update": "catalogedItems", "updates": [{"q": {"_id": {"$eq": 1}}, "u": {"$set": {"catalog": {"name": "c", "codes": [2, 3]}}}, "upsert": true}]}
+                            """));
+        });
+        assertThat(catalogedItemCollection.find())
+                .containsExactly(BsonDocument.parse(
+                        """
+                        {"_id": 1, "catalog": {"name": "c", "codes": [2, 3]}}"""));
+    }
+
+    @Test
+    void upsertInsertsStructAggregateEmbeddableWithParentBackReference() {
+        getSessionFactoryScope().inStatelessTransaction(session -> {
+            session.upsert(new ParentedItem(1, new AddressWithParent("NYC")));
+            assertActualCommandsInOrder(
+                    BsonDocument.parse(
+                            """
+                            {"update": "parentedItems", "updates": [{"q": {"_id": {"$eq": 1}}, "u": {"$set": {"address": {"city": "NYC"}}}, "upsert": true}]}
+                            """));
+        });
+        assertThat(parentedItemCollection.find())
+                .containsExactly(BsonDocument.parse(
+                        """
+                                           {"_id": 1, "address": {"city": "NYC"}}"""));
+    }
+
+    @Test
+    void upsertInsertsNullStructAggregateEmbeddable() {
+        getSessionFactoryScope().inStatelessTransaction(session -> {
+            session.upsert(new AddressedItem(1, "a", null));
+            assertActualCommandsInOrder(
+                    BsonDocument.parse(
+                            """
+                            {"update": "addressedItems", "updates": [{"q": {"_id": {"$eq": 1}}, "u": {"$set": {"address": null, "label": "a"}}, "upsert": true}]}
+                            """));
+        });
+        assertThat(addressedItemCollection.find())
+                .containsExactly(BsonDocument.parse(
+                        """
+                                           {"_id": 1, "address": null, "label": "a"}"""));
+    }
+
+    @Test
+    void upsertInsertsStructAggregateEmbeddableMappedToRenamedColumn() {
+        getSessionFactoryScope().inStatelessTransaction(session -> {
+            session.upsert(new RenamedAddressItem(1, new Address("NYC", 10001)));
+            assertActualCommandsInOrder(
+                    BsonDocument.parse(
+                            """
+                            {"update": "renamedAddressItems", "updates": [{"q": {"_id": {"$eq": 1}}, "u": {"$set": {"addr": {"city": "NYC", "zipCode": 10001}}}, "upsert": true}]}
+                            """));
+        });
+        assertThat(renamedAddressItemCollection.find())
+                .containsExactly(BsonDocument.parse(
+                        """
+                        {"_id": 1, "addr": {"city": "NYC", "zipCode": 10001}}"""));
+    }
+
+    /**
+     * {@code addressLabel} shares a prefix with the aggregate column {@code address} but is a distinct scalar column;
+     * {@code findAggregate}'s dot boundary must keep the two apart, since a bare prefix match would swallow
+     * {@code addressLabel}'s own binding into the aggregate and leave its parameter unmatched.
+     */
+    @Test
+    void upsertKeepsAggregateAndPrefixedScalarColumnDistinct() {
+        getSessionFactoryScope().inStatelessTransaction(session -> {
+            session.upsert(new AddressLabeledItem(1, new Address("NYC", 10001), "home"));
+            assertActualCommandsInOrder(
+                    BsonDocument.parse(
+                            """
+                            {"update": "addressLabeledItems", "updates": [{"q": {"_id": {"$eq": 1}}, "u": {"$set": {"address": {"city": "NYC", "zipCode": 10001}, "addressLabel": "home"}}, "upsert": true}]}
+                            """));
+        });
+        assertThat(addressLabeledItemCollection.find())
+                .containsExactly(
+                        BsonDocument.parse(
+                                """
+                                {"_id": 1, "address": {"city": "NYC", "zipCode": 10001}, "addressLabel": "home"}"""));
     }
 
     @Nested
@@ -284,6 +585,214 @@ class UpsertIntegrationTests extends AbstractQueryIntegrationTests {
 
         BareItem(int id) {
             this.id = id;
+        }
+    }
+
+    @Entity(name = "AddressedItem")
+    @Table(name = "addressedItems")
+    static class AddressedItem {
+        @Id
+        int id;
+
+        String label;
+        Address address;
+
+        AddressedItem() {}
+
+        AddressedItem(int id, String label, Address address) {
+            this.id = id;
+            this.label = label;
+            this.address = address;
+        }
+    }
+
+    @Embeddable
+    @Struct(name = "Address")
+    record Address(String city, int zipCode) {}
+
+    @Entity(name = "NestedlyAddressedItem")
+    @Table(name = "nestedlyAddressedItems")
+    static class NestedlyAddressedItem {
+        @Id
+        int id;
+
+        NestedAddress address;
+
+        NestedlyAddressedItem() {}
+
+        NestedlyAddressedItem(int id, NestedAddress address) {
+            this.id = id;
+            this.address = address;
+        }
+    }
+
+    @Embeddable
+    @Struct(name = "NestedAddress")
+    record NestedAddress(String city, Zone zone) {}
+
+    @Embeddable
+    @Struct(name = "Zone")
+    record Zone(int code) {}
+
+    @Entity(name = "AuditedAddressedItem")
+    @Table(name = "auditedAddressedItems")
+    static class AuditedAddressedItem {
+        @Id
+        int id;
+
+        String label;
+        Address address;
+
+        @Column(updatable = false)
+        String createdBy;
+
+        AuditedAddressedItem() {}
+
+        AuditedAddressedItem(int id, String label, Address address, String createdBy) {
+            this.id = id;
+            this.label = label;
+            this.address = address;
+            this.createdBy = createdBy;
+        }
+    }
+
+    @Entity(name = "TaggedItem")
+    @Table(name = "taggedItems")
+    static class TaggedItem {
+        @Id
+        int id;
+
+        int[] tags;
+        Coordinates coordinates;
+
+        TaggedItem() {}
+
+        TaggedItem(int id, int[] tags, Coordinates coordinates) {
+            this.id = id;
+            this.tags = tags;
+            this.coordinates = coordinates;
+        }
+    }
+
+    @Embeddable
+    record Coordinates(int x, int y) {}
+
+    @Entity(name = "DualAddressedItem")
+    @Table(name = "dualAddressedItems")
+    static class DualAddressedItem {
+        @Id
+        int id;
+
+        Address homeAddress;
+        Address workAddress;
+
+        DualAddressedItem() {}
+
+        DualAddressedItem(int id, Address homeAddress, Address workAddress) {
+            this.id = id;
+            this.homeAddress = homeAddress;
+            this.workAddress = workAddress;
+        }
+    }
+
+    @Entity(name = "CatalogedItem")
+    @Table(name = "catalogedItems")
+    static class CatalogedItem {
+        @Id
+        int id;
+
+        Catalog catalog;
+
+        CatalogedItem() {}
+
+        CatalogedItem(int id, Catalog catalog) {
+            this.id = id;
+            this.catalog = catalog;
+        }
+    }
+
+    @Embeddable
+    @Struct(name = "Catalog")
+    record Catalog(String name, int[] codes) {}
+
+    @Entity(name = "ParentedItem")
+    @Table(name = "parentedItems")
+    static class ParentedItem {
+        @Id
+        int id;
+
+        AddressWithParent address;
+
+        ParentedItem() {}
+
+        ParentedItem(int id, AddressWithParent address) {
+            this.id = id;
+            this.address = address;
+        }
+    }
+
+    @Embeddable
+    @Struct(name = "AddressWithParent")
+    static class AddressWithParent {
+        String city;
+
+        @Parent ParentedItem parent;
+
+        AddressWithParent() {}
+
+        AddressWithParent(String city) {
+            this.city = city;
+        }
+
+        /**
+         * Hibernate ORM requires a setter for a {@link Parent} field, despite us using {@linkplain AccessType#FIELD
+         * field-based access}.
+         */
+        void setParent(ParentedItem parent) {
+            this.parent = parent;
+        }
+
+        /**
+         * Hibernate ORM requires a getter for a {@link Parent} field, despite us using {@linkplain AccessType#FIELD
+         * field-based access}.
+         */
+        ParentedItem getParent() {
+            return parent;
+        }
+    }
+
+    @Entity(name = "RenamedAddressItem")
+    @Table(name = "renamedAddressItems")
+    static class RenamedAddressItem {
+        @Id
+        int id;
+
+        @Column(name = "addr")
+        Address address;
+
+        RenamedAddressItem() {}
+
+        RenamedAddressItem(int id, Address address) {
+            this.id = id;
+            this.address = address;
+        }
+    }
+
+    @Entity(name = "AddressLabeledItem")
+    @Table(name = "addressLabeledItems")
+    static class AddressLabeledItem {
+        @Id
+        int id;
+
+        Address address;
+        String addressLabel;
+
+        AddressLabeledItem() {}
+
+        AddressLabeledItem(int id, Address address, String addressLabel) {
+            this.id = id;
+            this.address = address;
+            this.addressLabel = addressLabel;
         }
     }
 }

--- a/src/main/java/com/mongodb/hibernate/internal/dialect/MongoDialect.java
+++ b/src/main/java/com/mongodb/hibernate/internal/dialect/MongoDialect.java
@@ -45,6 +45,7 @@ import org.hibernate.dialect.aggregate.AggregateSupport;
 import org.hibernate.engine.jdbc.dialect.spi.DialectResolutionInfo;
 import org.hibernate.engine.jdbc.env.spi.NameQualifierSupport;
 import org.hibernate.engine.jdbc.mutation.JdbcValueBindings;
+import org.hibernate.engine.jdbc.mutation.internal.MutationQueryOptions;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.exception.spi.SQLExceptionConversionDelegate;
@@ -282,20 +283,73 @@ public sealed class MongoDialect extends Dialect permits TestMongoDialect {
         functionRegistry.register("unnest", new MongoUnnestFunction());
     }
 
-    /** @mongoCme The {@link MutationOperation} returned from this method does not have to be thread-safe. */
+    /**
+     * @mongoCme The {@link MutationOperation} returned from this method is created once per entity at SessionFactory
+     *     build time and shared across sessions, so it must be thread-safe.
+     */
     @Override
     public MutationOperation createOptionalTableUpdateOperation(
             EntityMutationTarget mutationTarget,
             OptionalTableUpdate optionalTableUpdate,
             SessionFactoryImplementor factory) {
+        // This runs at SessionFactory build time for every entity, so nothing here may throw:
+        // rejections are deferred to performMutation, which runs only when upsert is called.
+        // In particular, an optional (e.g. @SecondaryTable) mutating table would otherwise make
+        // visitOptionalTableUpdate throw eagerly during this same boot-time call.
+        if (optionalTableUpdate.getMutatingTable().getTableMapping().isOptional()) {
+            return rejectingUpsertOperation(
+                    mutationTarget,
+                    optionalTableUpdate,
+                    factory,
+                    "TODO-HIBERNATE-69 https://jira.mongodb.org/browse/HIBERNATE-69");
+        }
+        if (optionalTableUpdate.getValueBindings().isEmpty()) {
+            // TableMergeBuilder always builds an OptionalTableUpdate, so an entity whose only persistent
+            // attribute is its identifier reaches this boot-time translation with nothing to write.
+            return rejectingUpsertOperation(
+                    mutationTarget,
+                    optionalTableUpdate,
+                    factory,
+                    format(
+                            "%s does not support upserting an entity whose only persistent attribute is its identifier",
+                            MONGO_DBMS_NAME));
+        }
+        if (optionalTableUpdate.getNumberOfOptimisticLockBindings() > 0) {
+            return rejectingUpsertOperation(
+                    mutationTarget,
+                    optionalTableUpdate,
+                    factory,
+                    "TODO-HIBERNATE-216 https://jira.mongodb.org/browse/HIBERNATE-216");
+        }
+        for (var valueBinding : optionalTableUpdate.getValueBindings()) {
+            if (!valueBinding.isAttributeInsertable()) {
+                return rejectingUpsertOperation(
+                        mutationTarget,
+                        optionalTableUpdate,
+                        factory,
+                        format(
+                                "%s does not support upserting a column that is updatable but not insertable: [%s]",
+                                MONGO_DBMS_NAME,
+                                valueBinding.getColumnReference().getColumnExpression()));
+            }
+        }
+        return MongoTranslatorFactory.INSTANCE
+                .buildUpsertModelMutationTranslator(optionalTableUpdate, factory)
+                .translate(null, MutationQueryOptions.INSTANCE);
+    }
+
+    private static OptionalTableUpdateOperation rejectingUpsertOperation(
+            EntityMutationTarget mutationTarget,
+            OptionalTableUpdate optionalTableUpdate,
+            SessionFactoryImplementor factory,
+            String message) {
         return new OptionalTableUpdateOperation(mutationTarget, optionalTableUpdate, factory) {
             @Override
             public void performMutation(
                     JdbcValueBindings jdbcValueBindings,
                     ValuesAnalysis valuesAnalysis,
                     SharedSessionContractImplementor session) {
-                throw new FeatureNotSupportedException(
-                        "TODO-HIBERNATE-94 https://jira.mongodb.org/browse/HIBERNATE-94");
+                throw new FeatureNotSupportedException(message);
             }
         };
     }

--- a/src/main/java/com/mongodb/hibernate/internal/jdbc/MongoStatement.java
+++ b/src/main/java/com/mongodb/hibernate/internal/jdbc/MongoStatement.java
@@ -357,8 +357,9 @@ class MongoStatement implements StatementAdapter {
             // The Postgres driver (and others) returns matched count for updates (rather than modified count).
             // Hibernate relies on this behavior for StatelessSession#upsert, which expects executeUpdate to
             // return 1 even if the row was matched but not modified and throws a StaleStateException otherwise.
-            //  An upsert counts as a match as well.
-            case UPDATE -> bulkWriteResult.getMatchedCount() + bulkWriteResult.getUpserts().size();
+            // An upsert counts as a match as well.
+            case UPDATE ->
+                bulkWriteResult.getMatchedCount() + bulkWriteResult.getUpserts().size();
             case DELETE -> bulkWriteResult.getDeletedCount();
             default -> throw fail();
         };

--- a/src/main/java/com/mongodb/hibernate/internal/jdbc/MongoStatement.java
+++ b/src/main/java/com/mongodb/hibernate/internal/jdbc/MongoStatement.java
@@ -42,6 +42,7 @@ import com.mongodb.client.model.DeleteOneModel;
 import com.mongodb.client.model.InsertOneModel;
 import com.mongodb.client.model.UpdateManyModel;
 import com.mongodb.client.model.UpdateOneModel;
+import com.mongodb.client.model.UpdateOptions;
 import com.mongodb.client.model.WriteModel;
 import com.mongodb.hibernate.internal.FeatureNotSupportedException;
 import com.mongodb.hibernate.internal.VisibleForTesting;
@@ -356,7 +357,8 @@ class MongoStatement implements StatementAdapter {
             // The Postgres driver (and others) returns matched count for updates (rather than modified count).
             // Hibernate relies on this behavior for StatelessSession#upsert, which expects executeUpdate to
             // return 1 even if the row was matched but not modified and throws a StaleStateException otherwise.
-            case UPDATE -> bulkWriteResult.getMatchedCount();
+            //  An upsert counts as a match as well.
+            case UPDATE -> bulkWriteResult.getMatchedCount() + bulkWriteResult.getUpserts().size();
             case DELETE -> bulkWriteResult.getDeletedCount();
             default -> throw fail();
         };
@@ -520,7 +522,7 @@ class MongoStatement implements StatementAdapter {
         private static final Set<String> SUPPORTED_INSERT_COMMAND_FIELDS = Set.of("documents");
 
         private static final Set<String> SUPPORTED_UPDATE_COMMAND_FIELDS = Set.of("updates");
-        private static final Set<String> SUPPORTED_UPDATE_STATEMENT_FIELDS = Set.of("q", "u", "multi");
+        private static final Set<String> SUPPORTED_UPDATE_STATEMENT_FIELDS = Set.of("q", "u", "multi", "upsert");
 
         private static final Set<String> SUPPORTED_DELETE_COMMAND_FIELDS = Set.of("deletes");
         private static final Set<String> SUPPORTED_DELETE_STATEMENT_FIELDS = Set.of("q", "limit");
@@ -571,6 +573,8 @@ class MongoStatement implements StatementAdapter {
                 throws SQLFeatureNotSupportedException {
             checkStatementFields(updateStatement, commandDescription, SUPPORTED_UPDATE_STATEMENT_FIELDS);
             var isMulti = updateStatement.getBoolean("multi", FALSE).getValue();
+            var options = new UpdateOptions()
+                    .upsert(updateStatement.getBoolean("upsert", FALSE).getValue());
             var filter = updateStatement.getDocument("q");
             var updateModification = updateStatement.get("u");
             if (updateModification == null) {
@@ -579,14 +583,14 @@ class MongoStatement implements StatementAdapter {
             }
             if (updateModification instanceof BsonDocument updateDocument) {
                 return isMulti
-                        ? new UpdateManyModel<>(filter, updateDocument)
-                        : new UpdateOneModel<>(filter, updateDocument);
+                        ? new UpdateManyModel<>(filter, updateDocument, options)
+                        : new UpdateOneModel<>(filter, updateDocument, options);
             } else if (updateModification instanceof BsonArray updatePipelineArray) {
                 var updatePipeline =
                         updatePipelineArray.stream().map(BsonValue::asDocument).toList();
                 return isMulti
-                        ? new UpdateManyModel<>(filter, updatePipeline)
-                        : new UpdateOneModel<>(filter, updatePipeline);
+                        ? new UpdateManyModel<>(filter, updatePipeline, options)
+                        : new UpdateOneModel<>(filter, updatePipeline, options);
             } else {
                 throw new SQLFeatureNotSupportedException(
                         "Only document or pipeline type is supported as value for field: [u]");

--- a/src/main/java/com/mongodb/hibernate/internal/translate/AbstractMqlTranslator.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/AbstractMqlTranslator.java
@@ -34,6 +34,7 @@ import static com.mongodb.hibernate.internal.translate.AstVisitorValueDescriptor
 import static com.mongodb.hibernate.internal.translate.AstVisitorValueDescriptor.SELECT_RESULT;
 import static com.mongodb.hibernate.internal.translate.AstVisitorValueDescriptor.SORT_FIELDS;
 import static com.mongodb.hibernate.internal.translate.AstVisitorValueDescriptor.TUPLE;
+import static com.mongodb.hibernate.internal.translate.AstVisitorValueDescriptor.UPSERT_MODEL_MUTATION_RESULT;
 import static com.mongodb.hibernate.internal.translate.AstVisitorValueDescriptor.VALUE;
 import static com.mongodb.hibernate.internal.translate.mongoast.AstLiteral.FALSE;
 import static com.mongodb.hibernate.internal.translate.mongoast.AstLiteral.TRUE;
@@ -83,6 +84,7 @@ import com.mongodb.hibernate.internal.translate.mongoast.command.AstInsertComman
 import com.mongodb.hibernate.internal.translate.mongoast.command.AstPipelineUpdate;
 import com.mongodb.hibernate.internal.translate.mongoast.command.AstUpdate;
 import com.mongodb.hibernate.internal.translate.mongoast.command.AstUpdateCommand;
+import com.mongodb.hibernate.internal.translate.mongoast.command.AstUpdateStatement;
 import com.mongodb.hibernate.internal.translate.mongoast.command.aggregate.AstAggregateCommand;
 import com.mongodb.hibernate.internal.translate.mongoast.command.aggregate.AstLetVariable;
 import com.mongodb.hibernate.internal.translate.mongoast.command.aggregate.AstLimitStage;
@@ -1065,7 +1067,9 @@ public abstract class AbstractMqlTranslator<T extends JdbcOperation> implements 
         astVisitorValueHolder.yield(
                 MUTATION_RESULT,
                 new MutationMqlTranslator.Result(
-                        new AstUpdateCommand(collection, filter, update), parameterBinders, affectedTableNames));
+                        new AstUpdateCommand(collection, List.of(new AstUpdateStatement(filter, update, false, true))),
+                        parameterBinders,
+                        affectedTableNames));
     }
 
     private AstDocumentUpdate buildDocumentUpdate(List<Assignment> assignments) {
@@ -1104,15 +1108,22 @@ public abstract class AbstractMqlTranslator<T extends JdbcOperation> implements 
         return restriction == null ? AstEmptyFilter.INSTANCE : acceptAndYield(restriction, FILTER);
     }
 
-    private AstUpdateCommand createAstUpdateCommand(
-            final List<ColumnValueBinding> valueBindings, final String tableName, final AstFilter keyFilter) {
+    private List<AstFieldUpdate> createFieldUpdates(List<ColumnValueBinding> valueBindings) {
         var updates = new ArrayList<AstFieldUpdate>(valueBindings.size());
         for (var valueBinding : valueBindings) {
             var fieldName = acceptAndYield(valueBinding.getColumnReference(), FIELD_PATH);
             var fieldValue = acceptAndYield(valueBinding.getValueExpression(), VALUE);
             updates.add(new AstFieldUpdate(fieldName, fieldValue));
         }
-        return new AstUpdateCommand(tableName, keyFilter, new AstDocumentUpdate(updates));
+        return updates;
+    }
+
+    private AstUpdateCommand createAstUpdateCommand(
+            final List<ColumnValueBinding> valueBindings, final String tableName, final AstFilter keyFilter) {
+        return new AstUpdateCommand(
+                tableName,
+                List.of(new AstUpdateStatement(
+                        keyFilter, new AstDocumentUpdate(createFieldUpdates(valueBindings)), false, true)));
     }
 
     @Override
@@ -1757,11 +1768,34 @@ public abstract class AbstractMqlTranslator<T extends JdbcOperation> implements 
         if (optionalTableUpdate.getMutatingTable().getTableMapping().isOptional()) {
             throw new FeatureNotSupportedException("TODO-HIBERNATE-69 https://jira.mongodb.org/browse/HIBERNATE-69");
         }
-        var mutationResult = createMutationResult(
-                optionalTableUpdate.getValueBindings(),
-                optionalTableUpdate.getMutatingTable().getTableName(),
-                createKeyFilter(optionalTableUpdate));
-        astVisitorValueHolder.yield(MODEL_MUTATION_RESULT, mutationResult);
+        if (astVisitorValueHolder.expects(UPSERT_MODEL_MUTATION_RESULT)) {
+            var setBindings = new ArrayList<ColumnValueBinding>();
+            var setOnInsertBindings = new ArrayList<ColumnValueBinding>();
+            for (var valueBinding : optionalTableUpdate.getValueBindings()) {
+                // MongoDialect returns a rejecting operation for non-insertable bindings and the
+                // merge coordinator filters out bindings with neither flag, so insertable holds here.
+                assertTrue(valueBinding.isAttributeInsertable());
+                if (valueBinding.isAttributeUpdatable()) {
+                    setBindings.add(valueBinding);
+                } else {
+                    setOnInsertBindings.add(valueBinding);
+                }
+            }
+            var keyFilter = createKeyFilter(optionalTableUpdate);
+            var update =
+                    new AstDocumentUpdate(createFieldUpdates(setBindings), createFieldUpdates(setOnInsertBindings));
+            var command = new AstUpdateCommand(
+                    optionalTableUpdate.getMutatingTable().getTableName(),
+                    List.of(new AstUpdateStatement(keyFilter, update, true, false)));
+            astVisitorValueHolder.yield(
+                    UPSERT_MODEL_MUTATION_RESULT, ModelMutationMqlTranslator.Result.create(command, parameterBinders));
+        } else {
+            var mutationResult = createMutationResult(
+                    optionalTableUpdate.getValueBindings(),
+                    optionalTableUpdate.getMutatingTable().getTableName(),
+                    createKeyFilter(optionalTableUpdate));
+            astVisitorValueHolder.yield(MODEL_MUTATION_RESULT, mutationResult);
+        }
     }
 
     @Override

--- a/src/main/java/com/mongodb/hibernate/internal/translate/AbstractMqlTranslator.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/AbstractMqlTranslator.java
@@ -134,9 +134,12 @@ import org.bson.BsonNull;
 import org.bson.BsonString;
 import org.bson.BsonValue;
 import org.bson.json.JsonWriter;
+import org.hibernate.engine.jdbc.mutation.ParameterUsage;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.internal.util.collections.Stack;
 import org.hibernate.metamodel.mapping.EmbeddableValuedModelPart;
+import org.hibernate.metamodel.mapping.SelectableMapping;
+import org.hibernate.metamodel.mapping.internal.EmbeddedAttributeMapping;
 import org.hibernate.persister.entity.EntityPersister;
 import org.hibernate.persister.entity.JoinedSubclassEntityPersister;
 import org.hibernate.persister.entity.SingleTableEntityPersister;
@@ -237,7 +240,9 @@ import org.hibernate.sql.exec.spi.JdbcParameterBindings;
 import org.hibernate.sql.model.MutationOperation;
 import org.hibernate.sql.model.ast.AbstractRestrictedTableMutation;
 import org.hibernate.sql.model.ast.ColumnValueBinding;
+import org.hibernate.sql.model.ast.ColumnValueParameter;
 import org.hibernate.sql.model.ast.ColumnWriteFragment;
+import org.hibernate.sql.model.ast.MutatingTableReference;
 import org.hibernate.sql.model.internal.OptionalTableUpdate;
 import org.hibernate.sql.model.internal.TableDeleteCustomSql;
 import org.hibernate.sql.model.internal.TableDeleteStandard;
@@ -1111,11 +1116,75 @@ public abstract class AbstractMqlTranslator<T extends JdbcOperation> implements 
     private List<AstFieldUpdate> createFieldUpdates(List<ColumnValueBinding> valueBindings) {
         var updates = new ArrayList<AstFieldUpdate>(valueBindings.size());
         for (var valueBinding : valueBindings) {
-            var fieldName = acceptAndYield(valueBinding.getColumnReference(), FIELD_PATH);
-            var fieldValue = acceptAndYield(valueBinding.getValueExpression(), VALUE);
-            updates.add(new AstFieldUpdate(fieldName, fieldValue));
+            updates.add(createFieldUpdate(valueBinding));
         }
         return updates;
+    }
+
+    private AstFieldUpdate createFieldUpdate(ColumnValueBinding valueBinding) {
+        var fieldName = acceptAndYield(valueBinding.getColumnReference(), FIELD_PATH);
+        var fieldValue = acceptAndYield(valueBinding.getValueExpression(), VALUE);
+        return new AstFieldUpdate(fieldName, fieldValue);
+    }
+
+    /**
+     * The merge coordinator decomposes a {@code @Struct} embeddable into one binding per leaf field, but
+     * {@code UpdateCoordinatorStandard} binds a single value for the aggregate as a whole. Emitting the leaves would
+     * therefore leave the aggregate's bound value without a matching parameter, so each aggregate's leaves collapse
+     * into one field update, named after the aggregate column and backed by a parameter carrying the aggregate's own
+     * mapping. The leaves' value expressions must not be visited: every visit appends a parameter binder and emits a
+     * placeholder, and the JDBC layer pairs the two by position.
+     *
+     * <p>This exists only to work around <a href="https://hibernate.atlassian.net/browse/HHH-20754">HHH-20754</a>.
+     * {@code MergeCoordinatorStandard} overrides {@code forEachUpdatable} to call {@code forEachSelectable}, which
+     * descends into the leaves, while {@code EmbeddableMappingTypeImpl.forEachUpdatable} short-circuits on
+     * {@code shouldMutateAggregateMapping()} and emits the aggregate. That is why the standard update path needs none
+     * of this. Once the merge path emits the aggregate, {@link #findAggregate} stops matching and this collapsing
+     * becomes dead rather than wrong, so it can be deleted along with {@link #aggregateMappings} and
+     * {@link #findAggregate}, restoring plain per-binding rendering.
+     */
+    private List<AstFieldUpdate> createUpsertFieldUpdates(
+            List<ColumnValueBinding> valueBindings,
+            List<SelectableMapping> aggregates,
+            MutatingTableReference mutatingTable) {
+        var updates = new ArrayList<AstFieldUpdate>(valueBindings.size());
+        var collapsedAggregates = new HashSet<String>();
+        for (var valueBinding : valueBindings) {
+            var aggregate = findAggregate(aggregates, valueBinding);
+            if (aggregate == null) {
+                updates.add(createFieldUpdate(valueBinding));
+            } else if (collapsedAggregates.add(aggregate.getSelectionExpression())) {
+                parameterBinders.add(
+                        new ColumnValueParameter(new ColumnReference(mutatingTable, aggregate), ParameterUsage.SET));
+                updates.add(new AstFieldUpdate(aggregate.getSelectionExpression(), AstParameterMarker.INSTANCE));
+            }
+        }
+        return updates;
+    }
+
+    private static List<SelectableMapping> aggregateMappings(OptionalTableUpdate optionalTableUpdate) {
+        var aggregates = new ArrayList<SelectableMapping>();
+        optionalTableUpdate.getMutationTarget().getTargetPart().forEachAttributeMapping(attributeMapping -> {
+            if (attributeMapping instanceof EmbeddedAttributeMapping embeddedAttributeMapping) {
+                var aggregate =
+                        embeddedAttributeMapping.getEmbeddableTypeDescriptor().getAggregateMapping();
+                if (aggregate != null) {
+                    aggregates.add(aggregate);
+                }
+            }
+        });
+        return aggregates;
+    }
+
+    private static @Nullable SelectableMapping findAggregate(
+            List<SelectableMapping> aggregates, ColumnValueBinding valueBinding) {
+        var columnExpression = valueBinding.getColumnReference().getColumnExpression();
+        for (var aggregate : aggregates) {
+            if (columnExpression.startsWith(aggregate.getSelectionExpression() + ".")) {
+                return aggregate;
+            }
+        }
+        return null;
     }
 
     private AstUpdateCommand createAstUpdateCommand(
@@ -1769,21 +1838,28 @@ public abstract class AbstractMqlTranslator<T extends JdbcOperation> implements 
             throw new FeatureNotSupportedException("TODO-HIBERNATE-69 https://jira.mongodb.org/browse/HIBERNATE-69");
         }
         if (astVisitorValueHolder.expects(UPSERT_MODEL_MUTATION_RESULT)) {
+            var aggregates = aggregateMappings(optionalTableUpdate);
             var setBindings = new ArrayList<ColumnValueBinding>();
             var setOnInsertBindings = new ArrayList<ColumnValueBinding>();
             for (var valueBinding : optionalTableUpdate.getValueBindings()) {
                 // MongoDialect returns a rejecting operation for non-insertable bindings and the
                 // merge coordinator filters out bindings with neither flag, so insertable holds here.
                 assertTrue(valueBinding.isAttributeInsertable());
-                if (valueBinding.isAttributeUpdatable()) {
+                var aggregate = findAggregate(aggregates, valueBinding);
+                // An aggregate's leaves may individually claim to be non-updatable, but the coordinator binds
+                // the aggregate as a whole, so the aggregate column's own flag is what governs.
+                var updatable = aggregate != null ? aggregate.isUpdateable() : valueBinding.isAttributeUpdatable();
+                if (updatable) {
                     setBindings.add(valueBinding);
                 } else {
                     setOnInsertBindings.add(valueBinding);
                 }
             }
             var keyFilter = createKeyFilter(optionalTableUpdate);
-            var update =
-                    new AstDocumentUpdate(createFieldUpdates(setBindings), createFieldUpdates(setOnInsertBindings));
+            var mutatingTable = optionalTableUpdate.getMutatingTable();
+            var update = new AstDocumentUpdate(
+                    createUpsertFieldUpdates(setBindings, aggregates, mutatingTable),
+                    createUpsertFieldUpdates(setOnInsertBindings, aggregates, mutatingTable));
             var command = new AstUpdateCommand(
                     optionalTableUpdate.getMutatingTable().getTableName(),
                     List.of(new AstUpdateStatement(keyFilter, update, true, false)));

--- a/src/main/java/com/mongodb/hibernate/internal/translate/AbstractMqlTranslator.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/AbstractMqlTranslator.java
@@ -38,6 +38,8 @@ import static com.mongodb.hibernate.internal.translate.AstVisitorValueDescriptor
 import static com.mongodb.hibernate.internal.translate.AstVisitorValueDescriptor.VALUE;
 import static com.mongodb.hibernate.internal.translate.mongoast.AstLiteral.FALSE;
 import static com.mongodb.hibernate.internal.translate.mongoast.AstLiteral.TRUE;
+import static com.mongodb.hibernate.internal.translate.mongoast.command.AstUpdateStatement.createMultiUpdateStatement;
+import static com.mongodb.hibernate.internal.translate.mongoast.command.AstUpdateStatement.createUpsertStatement;
 import static com.mongodb.hibernate.internal.translate.mongoast.command.aggregate.AstSortOrder.ASC;
 import static com.mongodb.hibernate.internal.translate.mongoast.command.aggregate.AstSortOrder.DESC;
 import static com.mongodb.hibernate.internal.translate.mongoast.filter.AstComparisonFilterOperator.EQ;
@@ -84,7 +86,6 @@ import com.mongodb.hibernate.internal.translate.mongoast.command.AstInsertComman
 import com.mongodb.hibernate.internal.translate.mongoast.command.AstPipelineUpdate;
 import com.mongodb.hibernate.internal.translate.mongoast.command.AstUpdate;
 import com.mongodb.hibernate.internal.translate.mongoast.command.AstUpdateCommand;
-import com.mongodb.hibernate.internal.translate.mongoast.command.AstUpdateStatement;
 import com.mongodb.hibernate.internal.translate.mongoast.command.aggregate.AstAggregateCommand;
 import com.mongodb.hibernate.internal.translate.mongoast.command.aggregate.AstLetVariable;
 import com.mongodb.hibernate.internal.translate.mongoast.command.aggregate.AstLimitStage;
@@ -1072,7 +1073,7 @@ public abstract class AbstractMqlTranslator<T extends JdbcOperation> implements 
         astVisitorValueHolder.yield(
                 MUTATION_RESULT,
                 new MutationMqlTranslator.Result(
-                        new AstUpdateCommand(collection, List.of(new AstUpdateStatement(filter, update, false, true))),
+                        new AstUpdateCommand(collection, List.of(createMultiUpdateStatement(filter, update))),
                         parameterBinders,
                         affectedTableNames));
     }
@@ -1191,8 +1192,8 @@ public abstract class AbstractMqlTranslator<T extends JdbcOperation> implements 
             final List<ColumnValueBinding> valueBindings, final String tableName, final AstFilter keyFilter) {
         return new AstUpdateCommand(
                 tableName,
-                List.of(new AstUpdateStatement(
-                        keyFilter, new AstDocumentUpdate(createFieldUpdates(valueBindings)), false, true)));
+                List.of(createMultiUpdateStatement(
+                        keyFilter, new AstDocumentUpdate(createFieldUpdates(valueBindings)))));
     }
 
     @Override
@@ -1862,7 +1863,7 @@ public abstract class AbstractMqlTranslator<T extends JdbcOperation> implements 
                     createUpsertFieldUpdates(setOnInsertBindings, aggregates, mutatingTable));
             var command = new AstUpdateCommand(
                     optionalTableUpdate.getMutatingTable().getTableName(),
-                    List.of(new AstUpdateStatement(keyFilter, update, true, false)));
+                    List.of(createUpsertStatement(keyFilter, update)));
             astVisitorValueHolder.yield(
                     UPSERT_MODEL_MUTATION_RESULT, ModelMutationMqlTranslator.Result.create(command, parameterBinders));
         } else {

--- a/src/main/java/com/mongodb/hibernate/internal/translate/AstVisitorValueDescriptor.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/AstVisitorValueDescriptor.java
@@ -37,6 +37,8 @@ public final class AstVisitorValueDescriptor<T> {
 
     static final AstVisitorValueDescriptor<ModelMutationMqlTranslator.Result> MODEL_MUTATION_RESULT =
             new AstVisitorValueDescriptor<>();
+    static final AstVisitorValueDescriptor<ModelMutationMqlTranslator.Result> UPSERT_MODEL_MUTATION_RESULT =
+            new AstVisitorValueDescriptor<>();
     static final AstVisitorValueDescriptor<SelectMqlTranslator.Result> SELECT_RESULT =
             new AstVisitorValueDescriptor<>();
     static final AstVisitorValueDescriptor<MutationMqlTranslator.Result> MUTATION_RESULT =

--- a/src/main/java/com/mongodb/hibernate/internal/translate/ModelMutationMqlTranslator.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/ModelMutationMqlTranslator.java
@@ -35,15 +35,24 @@ import org.jspecify.annotations.Nullable;
 /**
  * @mongoCme Does not have to be thread-safe because it is
  *     {@linkplain MongoTranslatorFactory#buildModelMutationTranslator(TableMutation, SessionFactoryImplementor)
- *     single-use}.
+ *     single-use}, as is {@link MongoTranslatorFactory#buildUpsertModelMutationTranslator}.
  */
 final class ModelMutationMqlTranslator<O extends JdbcMutationOperation> extends AbstractMqlTranslator<O> {
 
     private final TableMutation<O> tableMutation;
+    private final AstVisitorValueDescriptor<Result> resultDescriptor;
 
     ModelMutationMqlTranslator(TableMutation<O> tableMutation, SessionFactoryImplementor sessionFactory) {
+        this(tableMutation, sessionFactory, MODEL_MUTATION_RESULT);
+    }
+
+    ModelMutationMqlTranslator(
+            TableMutation<O> tableMutation,
+            SessionFactoryImplementor sessionFactory,
+            AstVisitorValueDescriptor<Result> resultDescriptor) {
         super(sessionFactory);
         this.tableMutation = tableMutation;
+        this.resultDescriptor = resultDescriptor;
     }
 
     @Override
@@ -55,7 +64,7 @@ final class ModelMutationMqlTranslator<O extends JdbcMutationOperation> extends 
         if ((TableMutation<?>) tableMutation instanceof TableUpdateNoSet) {
             result = Result.empty();
         } else {
-            result = acceptAndYield(tableMutation, MODEL_MUTATION_RESULT);
+            result = acceptAndYield(tableMutation, resultDescriptor);
         }
         return result.createJdbcMutationOperation(tableMutation);
     }

--- a/src/main/java/com/mongodb/hibernate/internal/translate/MongoTranslatorFactory.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/MongoTranslatorFactory.java
@@ -24,6 +24,7 @@ import org.hibernate.sql.ast.tree.select.SelectStatement;
 import org.hibernate.sql.exec.spi.JdbcOperationQueryMutation;
 import org.hibernate.sql.exec.spi.JdbcSelect;
 import org.hibernate.sql.model.ast.TableMutation;
+import org.hibernate.sql.model.internal.OptionalTableUpdate;
 import org.hibernate.sql.model.jdbc.JdbcMutationOperation;
 
 /**
@@ -52,5 +53,21 @@ public final class MongoTranslatorFactory implements SqlAstTranslatorFactory {
     public <O extends JdbcMutationOperation> SqlAstTranslator<O> buildModelMutationTranslator(
             TableMutation<O> tableMutation, SessionFactoryImplementor sessionFactoryImplementor) {
         return new ModelMutationMqlTranslator<>(tableMutation, sessionFactoryImplementor);
+    }
+
+    /**
+     * For {@code StatelessSession.upsert}: translates the same {@link OptionalTableUpdate} node that
+     * {@link #buildModelMutationTranslator} translates as a plain update, requesting the upsert form via the value
+     * descriptor instead.
+     */
+    public SqlAstTranslator<JdbcMutationOperation> buildUpsertModelMutationTranslator(
+            OptionalTableUpdate optionalTableUpdate, SessionFactoryImplementor sessionFactoryImplementor) {
+        // OptionalTableUpdate is a TableMutation<MutationOperation>; the operation this translator
+        // makes it create is a JdbcUpdateMutation, so the narrowing is safe at runtime. Hibernate
+        // itself routes this node through the same <O extends JdbcMutationOperation> bound.
+        @SuppressWarnings("unchecked")
+        var tableMutation = (TableMutation<JdbcMutationOperation>) (TableMutation<?>) optionalTableUpdate;
+        return new ModelMutationMqlTranslator<>(
+                tableMutation, sessionFactoryImplementor, AstVisitorValueDescriptor.UPSERT_MODEL_MUTATION_RESULT);
     }
 }

--- a/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/command/AstDocumentUpdate.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/command/AstDocumentUpdate.java
@@ -16,27 +16,46 @@
 
 package com.mongodb.hibernate.internal.translate.mongoast.command;
 
+import static com.mongodb.hibernate.internal.MongoAssertions.assertFalse;
+
 import com.mongodb.hibernate.internal.translate.mongoast.AstFieldUpdate;
 import java.util.List;
 import org.bson.BsonWriter;
 
 /**
- * A document-form update payload, rendered as {@code { "$set": { … } }}.
+ * A document-form update payload, carrying {@code $set} and/or {@code $setOnInsert}, each rendered only when non-empty.
  *
  * @hidden
  */
 @SuppressWarnings("MissingSummary")
-public record AstDocumentUpdate(List<AstFieldUpdate> updates) implements AstUpdate {
+public record AstDocumentUpdate(List<AstFieldUpdate> set, List<AstFieldUpdate> setOnInsert) implements AstUpdate {
+
+    public AstDocumentUpdate {
+        assertFalse(set.isEmpty() && setOnInsert.isEmpty());
+    }
+
+    public AstDocumentUpdate(List<AstFieldUpdate> set) {
+        this(set, List.of());
+    }
+
     @Override
     public void render(BsonWriter writer) {
         writer.writeStartDocument();
         {
-            writer.writeName("$set");
-            writer.writeStartDocument();
-            {
-                updates.forEach(update -> update.render(writer));
-            }
-            writer.writeEndDocument();
+            renderOperator(writer, "$set", set);
+            renderOperator(writer, "$setOnInsert", setOnInsert);
+        }
+        writer.writeEndDocument();
+    }
+
+    private static void renderOperator(BsonWriter writer, String operator, List<AstFieldUpdate> updates) {
+        if (updates.isEmpty()) {
+            return;
+        }
+        writer.writeName(operator);
+        writer.writeStartDocument();
+        {
+            updates.forEach(update -> update.render(writer));
         }
         writer.writeEndDocument();
     }

--- a/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/command/AstUpdateStatement.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/command/AstUpdateStatement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-present MongoDB, Inc.
+ * Copyright 2026-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,34 +16,29 @@
 
 package com.mongodb.hibernate.internal.translate.mongoast.command;
 
-import static com.mongodb.hibernate.internal.MongoAssertions.assertFalse;
-
-import java.util.List;
+import com.mongodb.hibernate.internal.translate.mongoast.AstNode;
+import com.mongodb.hibernate.internal.translate.mongoast.filter.AstFilter;
 import org.bson.BsonWriter;
 
 /**
- * See <a href="https://www.mongodb.com/docs/manual/reference/command/update/">{@code update}</a>.
+ * See the <a href="https://www.mongodb.com/docs/manual/reference/command/update/#update-statements">update
+ * statements</a> of the {@code update} command.
  *
  * @hidden
  */
-@SuppressWarnings("InvalidParam")
-public record AstUpdateCommand(String collection, List<AstUpdateStatement> updates) implements AstCommand {
-
-    public AstUpdateCommand {
-        assertFalse(updates.isEmpty());
-    }
-
+public record AstUpdateStatement(AstFilter filter, AstUpdate update, boolean upsert, boolean multi) implements AstNode {
     @Override
     public void render(BsonWriter writer) {
         writer.writeStartDocument();
         {
-            writer.writeString("update", collection);
-            writer.writeName("updates");
-            writer.writeStartArray();
-            {
-                updates.forEach(statement -> statement.render(writer));
+            writer.writeName("q");
+            filter.render(writer);
+            writer.writeName("u");
+            update.render(writer);
+            if (upsert) {
+                writer.writeBoolean("upsert", true);
             }
-            writer.writeEndArray();
+            writer.writeBoolean("multi", multi);
         }
         writer.writeEndDocument();
     }

--- a/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/command/AstUpdateStatement.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/command/AstUpdateStatement.java
@@ -26,7 +26,28 @@ import org.bson.BsonWriter;
  *
  * @hidden
  */
-public record AstUpdateStatement(AstFilter filter, AstUpdate update, boolean upsert, boolean multi) implements AstNode {
+public class AstUpdateStatement implements AstNode {
+    private final AstFilter filter;
+    private final AstUpdate update;
+    private final boolean upsert;
+    private final boolean multi;
+
+    public static AstUpdateStatement createUpsertStatement(AstFilter filter, AstUpdate update) {
+        return new AstUpdateStatement(filter, update, true, false);
+    }
+
+    public static AstUpdateStatement createMultiUpdateStatement(AstFilter filter, AstUpdate update) {
+        return new AstUpdateStatement(filter, update, false, true);
+    }
+
+    private AstUpdateStatement(
+            final AstFilter filter, final AstUpdate update, final boolean upsert, final boolean multi) {
+        this.filter = filter;
+        this.update = update;
+        this.upsert = upsert;
+        this.multi = multi;
+    }
+
     @Override
     public void render(BsonWriter writer) {
         writer.writeStartDocument();

--- a/src/test/java/com/mongodb/hibernate/internal/jdbc/MongoPreparedStatementTests.java
+++ b/src/test/java/com/mongodb/hibernate/internal/jdbc/MongoPreparedStatementTests.java
@@ -422,7 +422,6 @@ class MongoPreparedStatementTests {
                     of("collation: {}", "Unsupported field in [update] statement: [collation]"),
                     of("arrayFilters: []", "Unsupported field in [update] statement: [arrayFilters]"),
                     of("sort: {}", "Unsupported field in [update] statement: [sort]"),
-                    of("upsert: true", "Unsupported field in [update] statement: [upsert]"),
                     of("u: 1", "Only document or pipeline type is supported as value for field: [u]"),
                     of("c: {}", "Unsupported field in [update] statement: [c]"));
         }

--- a/src/test/java/com/mongodb/hibernate/internal/jdbc/MongoStatementTests.java
+++ b/src/test/java/com/mongodb/hibernate/internal/jdbc/MongoStatementTests.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyList;
@@ -30,13 +31,17 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
 
 import com.mongodb.bulk.BulkWriteResult;
+import com.mongodb.bulk.BulkWriteUpsert;
 import com.mongodb.client.AggregateIterable;
 import com.mongodb.client.ClientSession;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoCursor;
 import com.mongodb.client.MongoDatabase;
+import com.mongodb.client.model.UpdateOneModel;
+import com.mongodb.client.model.WriteModel;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
@@ -44,11 +49,13 @@ import java.sql.SQLSyntaxErrorException;
 import java.util.List;
 import java.util.function.BiConsumer;
 import org.bson.BsonDocument;
+import org.bson.BsonInt32;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.function.Executable;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -242,6 +249,84 @@ class MongoStatementTests {
 
             var sqlException = assertThrows(SQLException.class, () -> mongoStatement.executeUpdate(mql));
             assertEquals(dbAccessException, sqlException.getCause());
+        }
+    }
+
+    @Nested
+    class ExecuteUpdateWithUpsertTests {
+
+        private static final String UPSERT_MQL =
+                """
+                {
+                  update: "items",
+                  updates: [
+                    {
+                      q: { _id: { $eq: 1 } },
+                      u: { $set: { v: 10 } },
+                      upsert: true,
+                      multi: false
+                    }
+                  ]
+                }""";
+
+        @BeforeEach
+        void beforeEach() {
+            doReturn(mongoCollection).when(mongoDatabase).getCollection(anyString(), eq(BsonDocument.class));
+        }
+
+        @Test
+        void testUpsertOptionIsPassedToTheWriteModel() throws SQLException {
+            doReturn(BulkWriteResult.acknowledged(0, 1, 0, 0, emptyList(), emptyList()))
+                    .when(mongoCollection)
+                    .bulkWrite(eq(clientSession), anyList());
+
+            mongoStatement.executeUpdate(UPSERT_MQL);
+
+            @SuppressWarnings("unchecked")
+            ArgumentCaptor<List<WriteModel<BsonDocument>>> modelsCaptor = ArgumentCaptor.forClass(List.class);
+            verify(mongoCollection).bulkWrite(eq(clientSession), modelsCaptor.capture());
+            var model = (UpdateOneModel<BsonDocument>) modelsCaptor.getValue().get(0);
+            assertTrue(model.getOptions().isUpsert());
+        }
+
+        @Test
+        void testUpdateCountIsMatchedPlusUpserted() throws SQLException {
+            doReturn(BulkWriteResult.acknowledged(
+                            0, 2, 0, 0, List.of(new BulkWriteUpsert(0, new BsonInt32(1))), emptyList()))
+                    .when(mongoCollection)
+                    .bulkWrite(eq(clientSession), anyList());
+
+            assertEquals(3, mongoStatement.executeUpdate(UPSERT_MQL));
+        }
+
+        @Test
+        void testPipelineUpdateUpsertsAsWriteModel() throws SQLException {
+            doReturn(BulkWriteResult.acknowledged(0, 1, 0, 0, emptyList(), emptyList()))
+                    .when(mongoCollection)
+                    .bulkWrite(eq(clientSession), anyList());
+
+            var pipelineUpsertMql =
+                    """
+                    {
+                      update: "items",
+                      updates: [
+                        {
+                          q: { _id: { $eq: 1 } },
+                          u: [ { $set: { v: 10 } } ],
+                          upsert: true,
+                          multi: false
+                        }
+                      ]
+                    }""";
+
+            mongoStatement.executeUpdate(pipelineUpsertMql);
+
+            @SuppressWarnings("unchecked")
+            ArgumentCaptor<List<WriteModel<BsonDocument>>> modelsCaptor = ArgumentCaptor.forClass(List.class);
+            verify(mongoCollection).bulkWrite(eq(clientSession), modelsCaptor.capture());
+            var model = (UpdateOneModel<BsonDocument>) modelsCaptor.getValue().get(0);
+            assertTrue(model.getOptions().isUpsert());
+            assertNotNull(model.getUpdatePipeline());
         }
     }
 

--- a/src/test/java/com/mongodb/hibernate/internal/translate/mongoast/command/AstUpdateCommandTests.java
+++ b/src/test/java/com/mongodb/hibernate/internal/translate/mongoast/command/AstUpdateCommandTests.java
@@ -17,6 +17,7 @@
 package com.mongodb.hibernate.internal.translate.mongoast.command;
 
 import static com.mongodb.hibernate.internal.translate.mongoast.AstNodeAssertions.assertRendering;
+import static com.mongodb.hibernate.internal.translate.mongoast.command.AstUpdateStatement.createUpsertStatement;
 
 import com.mongodb.hibernate.internal.translate.mongoast.AstArithmeticExpressionOperator;
 import com.mongodb.hibernate.internal.translate.mongoast.AstBinaryOperatorExpression;
@@ -50,8 +51,8 @@ class AstUpdateCommandTests {
 
         var updateCommand = new AstUpdateCommand(
                 collection,
-                List.of(new AstUpdateStatement(
-                        filter, new AstDocumentUpdate(List.of(astFieldUpdate1, astFieldUpdate2)), false, true)));
+                List.of(AstUpdateStatement.createMultiUpdateStatement(
+                        filter, new AstDocumentUpdate(List.of(astFieldUpdate1, astFieldUpdate2)))));
 
         var expectedJson =
                 """
@@ -73,7 +74,8 @@ class AstUpdateCommandTests {
                         new AstValueExpression(new AstLiteral(new BsonInt32(1)))));
         var updateCommand = new AstUpdateCommand(
                 "books",
-                List.of(new AstUpdateStatement(filter, new AstPipelineUpdate(List.of(computed)), false, true)));
+                List.of(AstUpdateStatement.createMultiUpdateStatement(
+                        filter, new AstPipelineUpdate(List.of(computed)))));
 
         var expectedJson =
                 """
@@ -88,7 +90,7 @@ class AstUpdateCommandTests {
                 "_id",
                 new AstComparisonFilterOperation(AstComparisonFilterOperator.EQ, new AstLiteral(new BsonInt32(1))));
         var update = new AstDocumentUpdate(List.of(new AstFieldUpdate("v", new AstLiteral(new BsonInt32(10)))));
-        var updateCommand = new AstUpdateCommand("items", List.of(new AstUpdateStatement(filter, update, true, false)));
+        var updateCommand = new AstUpdateCommand("items", List.of(createUpsertStatement(filter, update)));
 
         var expectedJson =
                 """
@@ -105,7 +107,7 @@ class AstUpdateCommandTests {
         var update = new AstDocumentUpdate(
                 List.of(new AstFieldUpdate("label", new AstLiteral(new BsonString("a")))),
                 List.of(new AstFieldUpdate("createdBy", new AstLiteral(new BsonString("jeff")))));
-        var updateCommand = new AstUpdateCommand("items", List.of(new AstUpdateStatement(filter, update, true, false)));
+        var updateCommand = new AstUpdateCommand("items", List.of(createUpsertStatement(filter, update)));
 
         var expectedJson =
                 """

--- a/src/test/java/com/mongodb/hibernate/internal/translate/mongoast/command/AstUpdateCommandTests.java
+++ b/src/test/java/com/mongodb/hibernate/internal/translate/mongoast/command/AstUpdateCommandTests.java
@@ -49,7 +49,9 @@ class AstUpdateCommandTests {
                         AstComparisonFilterOperator.EQ, new AstLiteral(new BsonInt64(12345L))));
 
         var updateCommand = new AstUpdateCommand(
-                collection, filter, new AstDocumentUpdate(List.of(astFieldUpdate1, astFieldUpdate2)));
+                collection,
+                List.of(new AstUpdateStatement(
+                        filter, new AstDocumentUpdate(List.of(astFieldUpdate1, astFieldUpdate2)), false, true)));
 
         var expectedJson =
                 """
@@ -69,11 +71,45 @@ class AstUpdateCommandTests {
                         AstArithmeticExpressionOperator.ADD,
                         new AstFieldPathExpression("publishYear"),
                         new AstValueExpression(new AstLiteral(new BsonInt32(1)))));
-        var updateCommand = new AstUpdateCommand("books", filter, new AstPipelineUpdate(List.of(computed)));
+        var updateCommand = new AstUpdateCommand(
+                "books",
+                List.of(new AstUpdateStatement(filter, new AstPipelineUpdate(List.of(computed)), false, true)));
 
         var expectedJson =
                 """
                 {"update": "books", "updates": [{"q": {"_id": {"$eq": {"$numberInt": "1"}}}, "u": [{"$set": {"publishYear": {"$add": ["$publishYear", {"$numberInt": "1"}]}}}], "multi": true}]}\
+                """;
+        assertRendering(expectedJson, updateCommand);
+    }
+
+    @Test
+    void testRenderingUpsert() {
+        var filter = new AstFieldOperationFilter(
+                "_id",
+                new AstComparisonFilterOperation(AstComparisonFilterOperator.EQ, new AstLiteral(new BsonInt32(1))));
+        var update = new AstDocumentUpdate(List.of(new AstFieldUpdate("v", new AstLiteral(new BsonInt32(10)))));
+        var updateCommand = new AstUpdateCommand("items", List.of(new AstUpdateStatement(filter, update, true, false)));
+
+        var expectedJson =
+                """
+                {"update": "items", "updates": [{"q": {"_id": {"$eq": {"$numberInt": "1"}}}, "u": {"$set": {"v": {"$numberInt": "10"}}}, "upsert": true, "multi": false}]}\
+                """;
+        assertRendering(expectedJson, updateCommand);
+    }
+
+    @Test
+    void testRenderingSetOnInsert() {
+        var filter = new AstFieldOperationFilter(
+                "_id",
+                new AstComparisonFilterOperation(AstComparisonFilterOperator.EQ, new AstLiteral(new BsonInt32(1))));
+        var update = new AstDocumentUpdate(
+                List.of(new AstFieldUpdate("label", new AstLiteral(new BsonString("a")))),
+                List.of(new AstFieldUpdate("createdBy", new AstLiteral(new BsonString("jeff")))));
+        var updateCommand = new AstUpdateCommand("items", List.of(new AstUpdateStatement(filter, update, true, false)));
+
+        var expectedJson =
+                """
+                {"update": "items", "updates": [{"q": {"_id": {"$eq": {"$numberInt": "1"}}}, "u": {"$set": {"label": "a"}, "$setOnInsert": {"createdBy": "jeff"}}, "upsert": true, "multi": false}]}\
                 """;
         assertRendering(expectedJson, updateCommand);
     }


### PR DESCRIPTION
Translate the OptionalTableUpdate built for StatelessSession.upsert and upsertMultiple into a single update statement: filter from the key bindings, $set over value bindings that are both insertable and updatable, $setOnInsert for insertable-only ones, upsert: true, multi: false.

visitOptionalTableUpdate serves two callers that hand it the same node: the boot-time forced version increment wants a plain update, the dialect wants an upsert. The caller's intent travels as the requested value descriptor, tested with expects(...).

The dialect translates eagerly at SessionFactory build time and defers every rejection to performMutation, since an eager throw would fail boot for entities that work today for everything except upsert: @Version entities throw TODO-HIBERNATE-216, attributes that are updatable but not insertable and entities whose only persistent attribute is the identifier throw bare messages (MQL has no matched-path-only write), and optional tables keep the TODO-HIBERNATE-69 rejection.

AstUpdateCommand now holds a list of {q, u, upsert?, multi} statements and renders byte-identically for every existing caller; AstDocumentUpdate gains $setOnInsert, rendering each operator only when non-empty and asserting the update is never empty; MongoStatement accepts upsert in update statements and extends the JDBC row count to matched plus upserted.