### PR TITLE
HIBERNATE-83 Support HQL CASE expression

### DIFF
--- a/src/integrationTest/java/com/mongodb/hibernate/query/mutation/UpdatingIntegrationTests.java
+++ b/src/integrationTest/java/com/mongodb/hibernate/query/mutation/UpdatingIntegrationTests.java
@@ -159,6 +159,57 @@ class UpdatingIntegrationTests extends AbstractQueryIntegrationTests {
                 Set.of(Book.COLLECTION_NAME));
     }
 
+    // A CASE assignment is a computed value, so the update is emitted as a $set pipeline stage whose value
+    // is the $switch translation of the CASE.
+    @Test
+    void testCaseExpressionAssignment() {
+        assertMutationQuery(
+                "update Book b set b.publishYear = case when b.id = 1 then 100 else 200 end where b.id = 1",
+                1,
+                """
+                {
+                  "update": "books",
+                  "updates": [
+                    {
+                      "q": {"_id": {"$eq": 1}},
+                      "u": [
+                        {
+                          "$set": {
+                            "publishYear": {
+                              "$switch": {
+                                "branches": [
+                                  {"case": {"$eq": ["$_id", 1]}, "then": 100}
+                                ],
+                                "default": 200
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      "multi": true
+                    }
+                  ]
+                }""",
+                booksCollection,
+                List.of(
+                        BsonDocument.parse(
+                                """
+                                {"_id": 1, "title": "War & Peace", "outOfStock": true, "publishYear": 100, "isbn13": null, "discount": null, "price": null}"""),
+                        BsonDocument.parse(
+                                """
+                                {"_id": 2, "title": "Crime and Punishment", "outOfStock": false, "publishYear": 1866, "isbn13": null, "discount": null, "price": null}"""),
+                        BsonDocument.parse(
+                                """
+                                {"_id": 3, "title": "Anna Karenina", "outOfStock": false, "publishYear": 1877, "isbn13": null, "discount": null, "price": null}"""),
+                        BsonDocument.parse(
+                                """
+                                {"_id": 4, "title": "The Brothers Karamazov", "outOfStock": false, "publishYear": 1880, "isbn13": null, "discount": null, "price": null}"""),
+                        BsonDocument.parse(
+                                """
+                                {"_id": 5, "title": "War & Peace", "outOfStock": false, "publishYear": 2025, "isbn13": null, "discount": null, "price": null}""")),
+                Set.of(Book.COLLECTION_NAME));
+    }
+
     @Test
     void testUpdateWithZeroMutationCount() {
         assertMutationQuery(
@@ -393,16 +444,6 @@ class UpdatingIntegrationTests extends AbstractQueryIntegrationTests {
                     query -> {},
                     FeatureNotSupportedException.class,
                     "TODO-HIBERNATE-196 https://jira.mongodb.org/browse/HIBERNATE-196");
-        }
-
-        @Test
-        void testCaseExpressionAssignment() {
-            var hql = "update Book b set b.publishYear = case when b.id = 1 then 100 else 200 end where b.id = 1";
-            assertMutationQueryFailure(
-                    hql,
-                    query -> {},
-                    FeatureNotSupportedException.class,
-                    "TODO-HIBERNATE-83 https://jira.mongodb.org/browse/HIBERNATE-83");
         }
 
         @Test

--- a/src/integrationTest/java/com/mongodb/hibernate/query/select/ExpressionIntegrationTests.java
+++ b/src/integrationTest/java/com/mongodb/hibernate/query/select/ExpressionIntegrationTests.java
@@ -27,6 +27,7 @@ import com.mongodb.hibernate.query.AbstractQueryIntegrationTests;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 import org.bson.BsonDocument;
@@ -693,6 +694,219 @@ class ExpressionIntegrationTests extends AbstractQueryIntegrationTests {
                     List.of(false, false, false),
                     Set.of(Item.COLLECTION_NAME));
         }
+
+        // Searched CASE with a single WHEN and an ELSE: one $switch branch, the ELSE as the default.
+        @Test
+        void testSearchedCaseInSelect() {
+            assertSelectionQuery(
+                    "select case when x > 5 then 1 else 0 end from Item",
+                    Integer.class,
+                    """
+                    {
+                      "aggregate": "items",
+                      "pipeline": [
+                        {
+                          "$project": {
+                            "#c_1": {
+                              "$switch": {
+                                "branches": [
+                                  {"case": {"$gt": ["$x", {"$numberInt": "5"}]}, "then": {"$numberInt": "1"}}
+                                ],
+                                "default": {"$numberInt": "0"}
+                              }
+                            }
+                          }
+                        }
+                      ]
+                    }""",
+                    List.of(1, 0, 0),
+                    Set.of(Item.COLLECTION_NAME));
+        }
+
+        // Searched CASE with several WHENs: one $switch branch per WHEN, evaluated in order.
+        @Test
+        void testSearchedCaseMultipleBranchesInSelect() {
+            assertSelectionQuery(
+                    "select case when x > 5 then 1 when x > 4 then 2 else 0 end from Item",
+                    Integer.class,
+                    """
+                    {
+                      "aggregate": "items",
+                      "pipeline": [
+                        {
+                          "$project": {
+                            "#c_1": {
+                              "$switch": {
+                                "branches": [
+                                  {"case": {"$gt": ["$x", {"$numberInt": "5"}]}, "then": {"$numberInt": "1"}},
+                                  {"case": {"$gt": ["$x", {"$numberInt": "4"}]}, "then": {"$numberInt": "2"}}
+                                ],
+                                "default": {"$numberInt": "0"}
+                              }
+                            }
+                          }
+                        }
+                      ]
+                    }""",
+                    List.of(1, 0, 2),
+                    Set.of(Item.COLLECTION_NAME));
+        }
+
+        // A CASE with no ELSE returns SQL NULL, which maps to a null $switch default.
+        @Test
+        void testSearchedCaseWithoutElseInSelect() {
+            assertSelectionQuery(
+                    "select case when x > 5 then 1 end from Item",
+                    Integer.class,
+                    """
+                    {
+                      "aggregate": "items",
+                      "pipeline": [
+                        {
+                          "$project": {
+                            "#c_1": {
+                              "$switch": {
+                                "branches": [
+                                  {"case": {"$gt": ["$x", {"$numberInt": "5"}]}, "then": {"$numberInt": "1"}}
+                                ],
+                                "default": null
+                              }
+                            }
+                          }
+                        }
+                      ]
+                    }""",
+                    Arrays.asList(1, null, null),
+                    Set.of(Item.COLLECTION_NAME));
+        }
+
+        // A CASE branch's result may itself be a complex operator expression (here x * 1000), which is
+        // translated recursively into the $switch branch's `then`.
+        @Test
+        void testSearchedCaseWithComplexResultExpressionInSelect() {
+            assertSelectionQuery(
+                    "select case when y > 5 then x * 1000 else x end from Item",
+                    Integer.class,
+                    """
+                    {
+                      "aggregate": "items",
+                      "pipeline": [
+                        {
+                          "$project": {
+                            "#c_1": {
+                              "$switch": {
+                                "branches": [
+                                  {"case": {"$gt": ["$y", {"$numberInt": "5"}]}, "then": {"$multiply": ["$x", {"$numberInt": "1000"}]}}
+                                ],
+                                "default": "$x"
+                              }
+                            }
+                          }
+                        }
+                      ]
+                    }""",
+                    List.of(10, 4000, 5),
+                    Set.of(Item.COLLECTION_NAME));
+        }
+
+        // Simple CASE: the fixture ($x) is compared for equality against each WHEN value.
+        @Test
+        void testSimpleCaseInSelect() {
+            assertSelectionQuery(
+                    "select case x when 5 then 1 else 0 end from Item",
+                    Integer.class,
+                    """
+                    {
+                      "aggregate": "items",
+                      "pipeline": [
+                        {
+                          "$project": {
+                            "#c_1": {
+                              "$switch": {
+                                "branches": [
+                                  {"case": {"$eq": ["$x", {"$numberInt": "5"}]}, "then": {"$numberInt": "1"}}
+                                ],
+                                "default": {"$numberInt": "0"}
+                              }
+                            }
+                          }
+                        }
+                      ]
+                    }""",
+                    List.of(0, 0, 1),
+                    Set.of(Item.COLLECTION_NAME));
+        }
+
+        // Simple CASE whose fixture is a parameter, with several branches: the fixture renders once per
+        // branch, so it must bind one parameter per rendered marker (regression for misaligned binding).
+        @Test
+        void testSimpleCaseWithParameterFixtureAndMultipleBranches() {
+            assertSelectionQuery(
+                    "select case :p when 7 then 1 when 8 then 2 else 0 end from Item",
+                    Integer.class,
+                    q -> q.setParameter("p", 7),
+                    """
+                    {
+                      "aggregate": "items",
+                      "pipeline": [
+                        {
+                          "$project": {
+                            "#c_1": {
+                              "$switch": {
+                                "branches": [
+                                  {"case": {"$eq": [{"$numberInt": "7"}, {"$numberInt": "7"}]}, "then": {"$numberInt": "1"}},
+                                  {"case": {"$eq": [{"$numberInt": "7"}, {"$numberInt": "8"}]}, "then": {"$numberInt": "2"}}
+                                ],
+                                "default": {"$numberInt": "0"}
+                              }
+                            }
+                          }
+                        }
+                      ]
+                    }""",
+                    List.of(1, 1, 1),
+                    Set.of(Item.COLLECTION_NAME));
+        }
+
+        // A CASE in WHERE is an operand of a comparison, so the $switch is wrapped in $expr.
+        @Test
+        void testSearchedCaseInWhere() {
+            assertSelectionQuery(
+                    "from Item where (case when x > 5 then 1 else 0 end) = 1",
+                    Item.class,
+                    """
+                    {
+                      "aggregate": "items",
+                      "pipeline": [
+                        {
+                          "$match": {
+                            "$expr": {
+                              "$eq": [
+                                {
+                                  "$switch": {
+                                    "branches": [
+                                      {"case": {"$gt": ["$x", {"$numberInt": "5"}]}, "then": {"$numberInt": "1"}}
+                                    ],
+                                    "default": {"$numberInt": "0"}
+                                  }
+                                },
+                                {"$numberInt": "1"}
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "$project": {
+                            "_id": true,
+                            "x": true,
+                            "y": true
+                          }
+                        }
+                      ]
+                    }""",
+                    List.of(new Item(1, 10, 3)),
+                    Set.of(Item.COLLECTION_NAME));
+        }
     }
 
     // This case needs PORTABLE_INTEGER_DIVISION=true, which the shared registry does not set, so it
@@ -743,24 +957,6 @@ class ExpressionIntegrationTests extends AbstractQueryIntegrationTests {
     class Unsupported implements MongoServiceRegistryProducer {
 
         @Test
-        void testSearchedCaseExpressionInSelect() {
-            assertSelectQueryFailure(
-                    "select case when x > 5 then 1 else 0 end from Item",
-                    Integer.class,
-                    FeatureNotSupportedException.class,
-                    "TODO-HIBERNATE-83");
-        }
-
-        @Test
-        void testSimpleCaseExpressionInSelect() {
-            assertSelectQueryFailure(
-                    "select case x when 5 then 1 else 0 end from Item",
-                    Integer.class,
-                    FeatureNotSupportedException.class,
-                    "TODO-HIBERNATE-83");
-        }
-
-        @Test
         void testFunctionCallAsArithmeticOperandIsUnsupported() {
             assertSelectQueryFailure(
                     "select abs(x) + 1 from Item",
@@ -777,13 +973,62 @@ class ExpressionIntegrationTests extends AbstractQueryIntegrationTests {
                     "select x % 3 from Item", Integer.class, FeatureNotSupportedException.class, "TODO-HIBERNATE-196");
         }
 
+        // A CASE only yields an aggregation expression, so a position wanting a field path (the LIKE match
+        // expression in filter position) refuses it cleanly instead of tripping an internal assertion.
         @Test
-        void testCaseExpressionInWhereComparison() {
+        void testCaseAsLikeMatchExpression() {
             assertSelectQueryFailure(
-                    "from Item where case when x > 5 then 1 else 0 end > 3",
+                    "from Item where (case when y > 5 then 'a' else 'b' end) like '%a%'",
                     Item.class,
                     FeatureNotSupportedException.class,
-                    "TODO-HIBERNATE-83");
+                    "CASE expression is only supported in aggregation-expression position");
+        }
+
+        @Test
+        void testCaseInOrderByIsUnsupported() {
+            assertSelectQueryFailure(
+                    "from Item order by case when y > 5 then 1 else 0 end",
+                    Item.class,
+                    FeatureNotSupportedException.class,
+                    "TODO-HIBERNATE-79");
+        }
+
+        @Test
+        void testCaseInGroupByIsUnsupported() {
+            assertSelectQueryFailure(
+                    "select count(id) from Item group by case when y > 5 then 1 else 0 end",
+                    Long.class,
+                    FeatureNotSupportedException.class,
+                    "GroupBy is not supported");
+        }
+
+        @Test
+        void testCaseAsInListTestExpressionIsUnsupported() {
+            assertSelectQueryFailure(
+                    "from Item where (case when y > 5 then 1 else 0 end) in (1, 2)",
+                    Item.class,
+                    FeatureNotSupportedException.class,
+                    "Only the following list predicates are supported");
+        }
+
+        @Test
+        void testCaseAsNullnessTestExpressionIsUnsupported() {
+            assertSelectQueryFailure(
+                    "from Item where (case when y > 5 then 1 else 0 end) is null",
+                    Item.class,
+                    FeatureNotSupportedException.class,
+                    "Only the following nullness predicates are supported");
+        }
+
+        // A boolean-valued CASE used directly as a WHERE predicate is legal HQL that MQL could express via
+        // $expr, but the boolean-expression filter path only handles field paths today.
+        @Test
+        void testBooleanCaseAsPredicateIsUnsupported() {
+            assertSelectQueryFailure(
+                    "from Item where case when y > 5 then true else false end",
+                    Item.class,
+                    FeatureNotSupportedException.class,
+                    "Expression not of field path is not supported");
         }
     }
 

--- a/src/main/java/com/mongodb/hibernate/internal/translate/AbstractMqlTranslator.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/AbstractMqlTranslator.java
@@ -73,6 +73,8 @@ import com.mongodb.hibernate.internal.translate.mongoast.AstLogicalOperatorExpre
 import com.mongodb.hibernate.internal.translate.mongoast.AstNode;
 import com.mongodb.hibernate.internal.translate.mongoast.AstParameterMarker;
 import com.mongodb.hibernate.internal.translate.mongoast.AstRegexMatchExpression;
+import com.mongodb.hibernate.internal.translate.mongoast.AstSwitchCase;
+import com.mongodb.hibernate.internal.translate.mongoast.AstSwitchExpression;
 import com.mongodb.hibernate.internal.translate.mongoast.AstUnaryOperatorExpression;
 import com.mongodb.hibernate.internal.translate.mongoast.AstValue;
 import com.mongodb.hibernate.internal.translate.mongoast.AstValueExpression;
@@ -1299,12 +1301,58 @@ public abstract class AbstractMqlTranslator<T extends JdbcOperation> implements 
 
     @Override
     public void visitCaseSearchedExpression(CaseSearchedExpression caseSearchedExpression) {
-        throw new FeatureNotSupportedException("TODO-HIBERNATE-83 https://jira.mongodb.org/browse/HIBERNATE-83");
+        // A CASE only produces an aggregation expression ($switch); a position wanting a field path or a
+        // value (e.g. a LIKE match expression, or a sort key) cannot take it, so refuse cleanly rather
+        // than tripping the value holder's descriptor assertion.
+        assertCaseExpressionPosition();
+        // Searched CASE: each `when` predicate is a boolean aggregation expression (the branch's `case`),
+        // its result the branch's `then`.
+        var branches = new ArrayList<AstSwitchCase>(
+                caseSearchedExpression.getWhenFragments().size());
+        for (var whenFragment : caseSearchedExpression.getWhenFragments()) {
+            var caseExpression = acceptAndYield(whenFragment.getPredicate(), EXPRESSION);
+            var thenExpression = acceptAndYieldExpression(whenFragment.getResult());
+            branches.add(new AstSwitchCase(caseExpression, thenExpression));
+        }
+        astVisitorValueHolder.yield(
+                EXPRESSION,
+                new AstSwitchExpression(branches, resolveCaseDefault(caseSearchedExpression.getOtherwise())));
     }
 
     @Override
     public void visitCaseSimpleExpression(CaseSimpleExpression caseSimpleExpression) {
-        throw new FeatureNotSupportedException("TODO-HIBERNATE-83 https://jira.mongodb.org/browse/HIBERNATE-83");
+        assertCaseExpressionPosition();
+        // Simple CASE: the fixture is compared for equality against each `when` value, so each branch's
+        // `case` is a {$eq: [fixture, value]} expression. The fixture renders once per branch, so it must
+        // be visited once per branch too — visiting once and reusing the result would emit a single
+        // parameter binder for a fixture that renders N times, misaligning positional binding.
+        var branches = new ArrayList<AstSwitchCase>(
+                caseSimpleExpression.getWhenFragments().size());
+        for (var whenFragment : caseSimpleExpression.getWhenFragments()) {
+            var fixture = acceptAndYieldExpression(caseSimpleExpression.getFixture());
+            var checkValue = acceptAndYieldExpression(whenFragment.getCheckValue());
+            var caseExpression =
+                    new AstBinaryOperatorExpression(AstComparisonExpressionOperator.EQ, fixture, checkValue);
+            var thenExpression = acceptAndYieldExpression(whenFragment.getResult());
+            branches.add(new AstSwitchCase(caseExpression, thenExpression));
+        }
+        astVisitorValueHolder.yield(
+                EXPRESSION, new AstSwitchExpression(branches, resolveCaseDefault(caseSimpleExpression.getOtherwise())));
+    }
+
+    private void assertCaseExpressionPosition() {
+        if (!astVisitorValueHolder.expects(EXPRESSION)) {
+            throw new FeatureNotSupportedException(
+                    "CASE expression is only supported in aggregation-expression position");
+        }
+    }
+
+    // The CASE `default` (its ELSE). A missing ELSE returns SQL NULL, so it maps to a null literal — which
+    // also keeps $switch from erroring at runtime when no branch matches and no default is present.
+    private AstExpression resolveCaseDefault(@Nullable Expression otherwise) {
+        return otherwise == null
+                ? new AstValueExpression(new AstLiteral(BsonNull.VALUE))
+                : acceptAndYieldExpression(otherwise);
     }
 
     @Override

--- a/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/AstSwitchCase.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/AstSwitchCase.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2026-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.hibernate.internal.translate.mongoast;
+
+import org.bson.BsonWriter;
+
+/**
+ * One branch of a {@link AstSwitchExpression}, rendered as {@code {"case": <caseExpression>, "then":
+ * <thenExpression>}}. {@code caseExpression} is a boolean aggregation expression; {@code thenExpression} is the value
+ * produced when it is {@code true}.
+ *
+ * @see AstSwitchExpression
+ * @hidden
+ */
+@SuppressWarnings("MissingSummary")
+public record AstSwitchCase(AstExpression caseExpression, AstExpression thenExpression) implements AstNode {
+    @Override
+    public void render(BsonWriter writer) {
+        writer.writeStartDocument();
+        writer.writeName("case");
+        caseExpression.render(writer);
+        writer.writeName("then");
+        thenExpression.render(writer);
+        writer.writeEndDocument();
+    }
+}

--- a/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/AstSwitchExpression.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/AstSwitchExpression.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2026-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.hibernate.internal.translate.mongoast;
+
+import java.util.List;
+import org.bson.BsonWriter;
+
+/**
+ * The MongoDB {@code $switch} aggregation expression, evaluating each branch's {@code case} in order and yielding the
+ * matching branch's {@code then}, or {@code defaultExpression} when none match. Both HQL {@code CASE} flavours (simple
+ * and searched) translate to this; a missing {@code ELSE} maps to a {@code null} default, matching SQL semantics.
+ *
+ * @see AstSwitchCase
+ * @hidden
+ */
+@SuppressWarnings("MissingSummary")
+public record AstSwitchExpression(List<AstSwitchCase> branches, AstExpression defaultExpression)
+        implements AstExpression {
+    @Override
+    public void render(BsonWriter writer) {
+        writer.writeStartDocument();
+        writer.writeName("$switch");
+        writer.writeStartDocument();
+        writer.writeName("branches");
+        writer.writeStartArray();
+        branches.forEach(branch -> branch.render(writer));
+        writer.writeEndArray();
+        writer.writeName("default");
+        defaultExpression.render(writer);
+        writer.writeEndDocument();
+        writer.writeEndDocument();
+    }
+}

--- a/src/test/java/com/mongodb/hibernate/internal/translate/mongoast/AstSwitchExpressionTests.java
+++ b/src/test/java/com/mongodb/hibernate/internal/translate/mongoast/AstSwitchExpressionTests.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2026-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.hibernate.internal.translate.mongoast;
+
+import static com.mongodb.hibernate.internal.translate.mongoast.AstNodeAssertions.assertExpressionRendering;
+
+import java.util.List;
+import org.bson.BsonInt32;
+import org.bson.BsonNull;
+import org.junit.jupiter.api.Test;
+
+class AstSwitchExpressionTests {
+
+    @Test
+    void testRenderingSingleBranch() {
+        var expr = new AstSwitchExpression(
+                List.of(new AstSwitchCase(
+                        new AstBinaryOperatorExpression(
+                                AstComparisonExpressionOperator.GT,
+                                new AstFieldPathExpression("x"),
+                                new AstValueExpression(new AstLiteral(new BsonInt32(5)))),
+                        new AstValueExpression(new AstLiteral(new BsonInt32(1))))),
+                new AstValueExpression(new AstLiteral(new BsonInt32(0))));
+        assertExpressionRendering(
+                """
+                {"": {"$switch": {"branches": [{"case": {"$gt": ["$x", {"$numberInt": "5"}]}, "then": {"$numberInt": "1"}}], "default": {"$numberInt": "0"}}}}\
+                """,
+                expr);
+    }
+
+    @Test
+    void testRenderingMultipleBranchesWithNullDefault() {
+        var expr = new AstSwitchExpression(
+                List.of(
+                        new AstSwitchCase(
+                                new AstBinaryOperatorExpression(
+                                        AstComparisonExpressionOperator.EQ,
+                                        new AstFieldPathExpression("x"),
+                                        new AstValueExpression(new AstLiteral(new BsonInt32(1)))),
+                                new AstValueExpression(new AstLiteral(new BsonInt32(10)))),
+                        new AstSwitchCase(
+                                new AstBinaryOperatorExpression(
+                                        AstComparisonExpressionOperator.EQ,
+                                        new AstFieldPathExpression("x"),
+                                        new AstValueExpression(new AstLiteral(new BsonInt32(2)))),
+                                new AstValueExpression(new AstLiteral(new BsonInt32(20))))),
+                new AstValueExpression(new AstLiteral(BsonNull.VALUE)));
+        assertExpressionRendering(
+                """
+                {"": {"$switch": {"branches": [{"case": {"$eq": ["$x", {"$numberInt": "1"}]}, "then": {"$numberInt": "10"}}, {"case": {"$eq": ["$x", {"$numberInt": "2"}]}, "then": {"$numberInt": "20"}}], "default": null}}}\
+                """,
+                expr);
+    }
+}


### PR DESCRIPTION
Support HQL CASE expression
According to Hibernate user guide https://docs.hibernate.org/orm/8.0/userguide/html_single
there are two types of case statements
1. [Simple case expressions](https://docs.hibernate.org/orm/8.0/userguide/html_single/#hql-simple-case-expressions) 
2. [Search case expressions ](https://docs.hibernate.org/orm/8.0/userguide/html_single/#hql-searched-case-expressions)

A CASE only yields an aggregation expression, so positions that need a bare field path will throw unsupported exception (I haven't made a new ticket to support it )

For example this test [case ](https://github.com/mongodb/mongo-hibernate/pull/202/changes#diff-346ff10eafa7c3aa3de77e7b8a2ae02c6ecabf34ede4457b8d80780ef21f98d9R979)
```
        void testCaseAsLikeMatchExpression() {
            assertSelectQueryFailure(
                    "from Item where (case when y > 5 then 'a' else 'b' end) like '%a%'",
                    Item.class,
                    FeatureNotSupportedException.class,
                    "CASE expression is only supported in aggregation-expression position");
        }
```

