### PR TITLE
docs: document positional parameter binding

### DIFF
--- a/.claude/skills/add-hql-to-mql-translation/SKILL.md
+++ b/.claude/skills/add-hql-to-mql-translation/SKILL.md
@@ -47,6 +47,10 @@ Extract source from the Hibernate sources JAR at `~/.gradle/caches/.../hibernate
 
 **Known gotchas** — patterns that are easy to miss when translating Hibernate's SQL AST:
 
+- **Parameter markers are matched by position.** If the construct reorders, duplicates or drops
+  argument nodes, do it to the `SqlAstNode`s before translating them, never to the translated
+  `AstExpression`s, and never collect named arguments into a sorted map. See "Parameter binding is
+  positional" in `ARCHITECTURE.md`.
 - **`isVirtual()` table groups** — virtual table groups are embeddable wrappers that don't render to a JOIN themselves; the SQL translator descends into their sub-joins without emitting a JOIN clause. Do the same: skip emitting a stage but recurse into sub-joins.
 
 **For any new unsupported shape:** confirm it is reachable from HQL (not just handcrafted SQL AST) so negative tests can be written through HQL. Check `SemanticQueryBuilder` and the HQL grammar in `HqlParser.java` to verify the syntax.
@@ -94,6 +98,8 @@ The plan must follow this task order:
 - When the `$project` fields are unknown upfront (e.g. JOIN FETCH): use `assertActualCommandsInOrder` with `/* FILL IN after first test run */`; upgrade to full `assertSelectionQuery` once the actual MQL is known
 - Negative tests: `assertSelectQueryFailure(hql, resultType, FeatureNotSupportedException.class, "TODO-HIBERNATE-NNN ...")` — substitute the real ticket number, following the `TODO-HIBERNATE-NNN` codebase convention
 - Positive tests live in a descriptively named `@Nested` class with `@BeforeEach` seed data; negative tests live at the outer class level for one-off cases or in `@Nested class Unsupported` when there are several.
+- Any construct taking more than one argument needs a case binding two or more parameters, not just
+  literals. Argument-order defects are invisible to a test whose arguments are all literals or field paths
 - Every non-trivial code path (loop iterations, recursive calls, each instanceof branch) must be covered by a positive or negative test
 
 ---

--- a/.claude/skills/reviewing-pull-requests/SKILL.md
+++ b/.claude/skills/reviewing-pull-requests/SKILL.md
@@ -124,6 +124,7 @@ which `$match` form is correct for which operand shape. What a reviewer adds is 
 | Composition | `f(g(x))`, `f(x) = f(y)`, `f(x) = column` | recursion |
 | Absent / null values | nullable column, missing field | server-side rejection |
 | Literal vs parameter | `f(x, 2)` vs `f(x, :p)` | constant folding, `$literal` wrapping |
+| Two or more parameters | `f(:p, :q)`, not `f(:p, x)` | marker order matching binder order |
 
 ### Schema, DDL, and JDBC contexts
 
@@ -174,6 +175,11 @@ translation PR. These are the diff symptoms that indicate a violation:
   translator state and will diverge on the next change.
 - A new field on the translator, sitting alongside `elemMatchInnerAlias` and `letVariableCounter` ---
   that is the *sanctioned* pattern, so it is a point in the PR's favour, not a smell.
+- Anything that reorders, duplicates or drops translated nodes after they were visited: an explicit
+  permutation, a node reused in two positions, or a `TreeMap`/`SortedMap` of named arguments. Parameter
+  markers are paired with binders by position (`ARCHITECTURE.md`, "Parameter binding is positional"),
+  so each of these silently mis-binds. Probe it. A construct exercised only with literals looks
+  correct, and a single parameter is not enough either, since one marker cannot be out of order.
 
 ## Reading outcomes
 
@@ -221,6 +227,7 @@ review that arrives with a patch instead of a mechanism is harder to act on, not
 - About to write "this looks like it could break" without having tried to break it.
 - About to call something a regression without a parent-commit run.
 - Probe catches `Exception` instead of `Throwable` --- it will silently miss every `AssertionError`.
+- Every probe of a multi-argument construct passes literals, so no parameter marker was ever emitted.
 - Probe reports `(none of 0 captured)` --- the listener is not installed, so you are reading nothing
   and concluding something. Fix the harness before trusting a single result.
 - Signed off on a translation without seeing its `$match` output next to its `$project` output.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -67,6 +67,36 @@ visitor as it evolves. It also bypasses `expects(...)`, and with it the filter-f
 `letVariableCounter`, `projectionKeyMap`, and `joinedTableQualifiers` all exist for exactly this. When
 a construct needs context that the visited node cannot carry, add a field and modify the visitor.
 
+## Parameter binding is positional
+
+A JDBC parameter carries no identity into the emitted command. `visitParameter` does two things:
+appends the parameter's binder to the translator's `parameterBinders` list, and yields the singleton
+`AstParameterMarker.INSTANCE`, which renders as BSON `undefined`. At execution
+`MongoPreparedStatement` walks the parsed command depth-first, in document-entry then array-index
+order, collecting one setter per `undefined`, and the i-th binder is bound into the i-th setter.
+
+**The i-th `undefined` in a depth-first walk of the rendered command must be the i-th node visited.**
+Nothing checks this. Visit order is fixed while the AST is built; marker order is a property of the
+finished BSON. Any step in between that changes the order or the number of markers breaks the pairing,
+and the two orders are never compared.
+
+Three ways to break it:
+
+- **Reordering after visiting.** Translating arguments into a list and then permuting that list moves
+  the slots while the markers stay put, so values land in each other's places. Nothing fails; the
+  answer is just wrong. Permute the `SqlAstNode`s *before* translating them.
+- **Rendering a visited node twice.** Reusing one translated node in two positions emits two markers
+  against one binder, and execution fails with `Parameter with index [n] is not set`. Visit the node
+  once per occurrence so each marker gets its own binder. `toBoundExpression`, used by the `BETWEEN`
+  translation, does this deliberately and says so.
+- **Collecting into a container that imposes an order.** A `TreeMap` of named arguments renders
+  alphabetically while the binders were appended in declaration order. Same defect as the first, with
+  nothing in the code that looks like a reordering.
+
+A construct with fewer than two parameters cannot expose any of this, so tests built from literals and
+field paths will pass over all three. Any construct taking more than one argument needs a case that
+binds two or more parameters.
+
 ## Filter form: two languages in `$match`, one in `$project`
 
 Two MongoDB languages are in play, and only one of the two names below is MongoDB's own:


### PR DESCRIPTION
A parameter marker carries no identity: MongoPreparedStatement pairs the i-th BSON undefined in the rendered command with the i-th binder appended during traversal. Reordering, duplicating or sorting translated nodes after they are visited breaks that pairing, silently in two of the three cases, and a test whose arguments are all literals cannot detect any of them.

Record the contract in ARCHITECTURE.md and point the translation and review skills at it.