### PR TITLE
HIBERNATE-222: collect parameter binders while rendering the MQL AST

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -67,6 +67,24 @@ visitor as it evolves. It also bypasses `expects(...)`, and with it the filter-f
 `letVariableCounter`, `projectionKeyMap`, and `joinedTableQualifiers` all exist for exactly this. When
 a construct needs context that the visited node cannot carry, add a field and modify the visitor.
 
+## Parameter binders are collected while rendering
+
+A JDBC parameter carries no identity into the emitted command: it renders as BSON `undefined`, and
+`MongoPreparedStatement` recovers the parameter positions by walking the parsed command depth-first,
+in document-entry then array-index order. Hibernate then binds the i-th `JdbcParameterBinder` the
+translator produced into the i-th of those positions, so the two orders have to agree.
+
+They agree by construction. `visitParameter` yields an `AstParameterMarker` holding its own binder, and
+`AstNode.render` takes a `Consumer<JdbcParameterBinder>`: the marker appends its binder in the same
+statement that writes the `undefined`. Every binder in the list corresponds to a marker that was
+actually rendered, in the order it was rendered.
+
+The translator therefore imposes no ordering rule on the code that builds the AST. Reordering
+translated nodes is fine. Dropping one drops its binder with it. Reusing a single translated node in
+two positions renders two markers and collects its binder twice, which binds the same value at both
+positions, so a construct whose operand appears more than once may translate it once and share it
+rather than visiting it per occurrence.
+
 ## Filter form: two languages in `$match`, one in `$project`
 
 Two MongoDB languages are in play, and only one of the two names below is MongoDB's own:

--- a/src/integrationTest/java/com/mongodb/hibernate/query/select/ExpressionIntegrationTests.java
+++ b/src/integrationTest/java/com/mongodb/hibernate/query/select/ExpressionIntegrationTests.java
@@ -837,8 +837,8 @@ class ExpressionIntegrationTests extends AbstractQueryIntegrationTests {
                     Set.of(Item.COLLECTION_NAME));
         }
 
-        // Simple CASE whose fixture is a parameter, with several branches: the fixture renders once per
-        // branch, so it must bind one parameter per rendered marker (regression for misaligned binding).
+        // Simple CASE whose fixture is a parameter: the fixture is translated once and rendered once per
+        // branch, so one binder is collected per branch and every branch sees the bound value.
         @Test
         void testSimpleCaseWithParameterFixtureAndMultipleBranches() {
             assertSelectionQuery(

--- a/src/integrationTest/java/com/mongodb/hibernate/query/select/JoinSelectQueryIntegrationTests.java
+++ b/src/integrationTest/java/com/mongodb/hibernate/query/select/JoinSelectQueryIntegrationTests.java
@@ -1580,8 +1580,9 @@ class JoinSelectQueryIntegrationTests extends AbstractQueryIntegrationTests {
 
         @Test
         void testBetweenConjunct() {
-            // Delegation reuses visitBetweenPredicate (a $gte/$lte pair); the BETWEEN operand c.region binds a let
-            // variable for each bound. c.region falls within [o.id, o.total] for every diagonal-joined row.
+            // Delegation reuses visitBetweenPredicate (a $gte/$lte pair); the BETWEEN operand c.region is
+            // translated once, so both bounds read the same let variable. c.region falls within
+            // [o.id, o.total] for every diagonal-joined row.
             assertSelectionQuery(
                     "SELECT c.id, o.total FROM Customer c JOIN Order o"
                             + " ON c.id = o.id AND c.region BETWEEN o.id AND o.total ORDER BY c.id, o.id",
@@ -1595,8 +1596,7 @@ class JoinSelectQueryIntegrationTests extends AbstractQueryIntegrationTests {
                             "from": "Order",
                             "let": {
                               "v0_c1_0__id": "$_id",
-                              "v1_c1_0_region": "$region",
-                              "v2_c1_0_region": "$region"
+                              "v1_c1_0_region": "$region"
                             },
                             "pipeline": [
                               {
@@ -1607,7 +1607,7 @@ class JoinSelectQueryIntegrationTests extends AbstractQueryIntegrationTests {
                                       {
                                         "$and": [
                                           { "$gte": [ "$$v1_c1_0_region", "$_id" ] },
-                                          { "$lte": [ "$$v2_c1_0_region", "$total" ] }
+                                          { "$lte": [ "$$v1_c1_0_region", "$total" ] }
                                         ]
                                       }
                                     ]

--- a/src/integrationTest/java/com/mongodb/hibernate/query/select/PredicateExpressionIntegrationTests.java
+++ b/src/integrationTest/java/com/mongodb/hibernate/query/select/PredicateExpressionIntegrationTests.java
@@ -320,8 +320,8 @@ class PredicateExpressionIntegrationTests extends AbstractQueryIntegrationTests 
                     Set.of(Widget.COLLECTION_NAME));
         }
 
-        // A parameter in the BETWEEN operand appears in both bound comparisons, so its value must be
-        // bound twice; visiting the operand once and reusing the node emits two markers but one binder.
+        // The operand is translated once and shared by both bound comparisons, so a parameter in it
+        // renders as two markers and its binder is collected twice, binding the value at both.
         @Test
         void testParameterOperandBetween() {
             assertSelectionQuery(

--- a/src/main/java/com/mongodb/hibernate/internal/translate/AbstractMqlTranslator.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/AbstractMqlTranslator.java
@@ -1315,14 +1315,10 @@ public abstract class AbstractMqlTranslator<T extends JdbcOperation> implements 
     @Override
     public void visitCaseSimpleExpression(CaseSimpleExpression caseSimpleExpression) {
         assertCaseExpressionPosition();
-        // Simple CASE: the fixture is compared for equality against each `when` value, so each branch's
-        // `case` is a {$eq: [fixture, value]} expression. The fixture renders once per branch, so it must
-        // be visited once per branch too — visiting once and reusing the result would emit a single
-        // parameter binder for a fixture that renders N times, misaligning positional binding.
+        var fixture = acceptAndYieldExpression(caseSimpleExpression.getFixture());
         var branches = new ArrayList<AstSwitchCase>(
                 caseSimpleExpression.getWhenFragments().size());
         for (var whenFragment : caseSimpleExpression.getWhenFragments()) {
-            var fixture = acceptAndYieldExpression(caseSimpleExpression.getFixture());
             var checkValue = acceptAndYieldExpression(whenFragment.getCheckValue());
             var caseExpression =
                     new AstBinaryOperatorExpression(AstComparisonExpressionOperator.EQ, fixture, checkValue);
@@ -1465,7 +1461,7 @@ public abstract class AbstractMqlTranslator<T extends JdbcOperation> implements 
     }
 
     private AstLogicalOperatorExpression toBetweenExpression(BetweenPredicate betweenPredicate) {
-        var operand = betweenPredicate.getExpression();
+        var operand = acceptAndYieldExpression(betweenPredicate.getExpression());
         return new AstLogicalOperatorExpression(
                 betweenPredicate.isNegated() ? AstLogicalOperator.OR : AstLogicalOperator.AND,
                 List.of(
@@ -1484,9 +1480,9 @@ public abstract class AbstractMqlTranslator<T extends JdbcOperation> implements 
     }
 
     private AstBinaryOperatorExpression toBoundExpression(
-            Expression operand, ComparisonOperator operator, Expression bound) {
+            AstExpression operand, ComparisonOperator operator, Expression bound) {
         return new AstBinaryOperatorExpression(
-                toExprComparisonOperator(operator), acceptAndYieldExpression(operand), acceptAndYieldExpression(bound));
+                toExprComparisonOperator(operator), operand, acceptAndYieldExpression(bound));
     }
 
     @Override

--- a/src/main/java/com/mongodb/hibernate/internal/translate/AbstractMqlTranslator.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/AbstractMqlTranslator.java
@@ -128,6 +128,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Consumer;
 import java.util.regex.Pattern;
 import org.bson.BsonInt32;
 import org.bson.BsonNull;
@@ -272,8 +273,6 @@ public abstract class AbstractMqlTranslator<T extends JdbcOperation> implements 
 
     private @Nullable JoinLookupContext joinLookupContext;
 
-    private final List<JdbcParameterBinder> parameterBinders = new ArrayList<>();
-
     private final Set<String> affectedTableNames = new HashSet<>();
 
     private final Set<String> joinedTableQualifiers = new HashSet<>();
@@ -391,10 +390,8 @@ public abstract class AbstractMqlTranslator<T extends JdbcOperation> implements 
         }
         astVisitorValueHolder.yield(
                 MODEL_MUTATION_RESULT,
-                ModelMutationMqlTranslator.Result.create(
-                        new AstInsertCommand(
-                                tableInsert.getMutatingTable().getTableName(), List.of(new AstDocument(astElements))),
-                        parameterBinders));
+                ModelMutationMqlTranslator.Result.create(new AstInsertCommand(
+                        tableInsert.getMutatingTable().getTableName(), List.of(new AstDocument(astElements)))));
     }
 
     @Override
@@ -438,8 +435,7 @@ public abstract class AbstractMqlTranslator<T extends JdbcOperation> implements 
         astVisitorValueHolder.yield(
                 MODEL_MUTATION_RESULT,
                 ModelMutationMqlTranslator.Result.create(
-                        new AstDeleteCommand(tableDelete.getMutatingTable().getTableName(), keyFilter),
-                        parameterBinders));
+                        new AstDeleteCommand(tableDelete.getMutatingTable().getTableName(), keyFilter)));
     }
 
     @Override
@@ -460,7 +456,7 @@ public abstract class AbstractMqlTranslator<T extends JdbcOperation> implements 
     private ModelMutationMqlTranslator.Result createMutationResult(
             List<ColumnValueBinding> valueBindings, String tableName, AstFilter keyFilter) {
         var astUpdateCommand = createAstUpdateCommand(valueBindings, tableName, keyFilter);
-        return ModelMutationMqlTranslator.Result.create(astUpdateCommand, parameterBinders);
+        return ModelMutationMqlTranslator.Result.create(astUpdateCommand);
     }
 
     private AstFilter createKeyFilter(AbstractRestrictedTableMutation<? extends MutationOperation> tableMutation) {
@@ -488,8 +484,9 @@ public abstract class AbstractMqlTranslator<T extends JdbcOperation> implements 
 
     @Override
     public void visitParameter(JdbcParameter jdbcParameter) {
-        parameterBinders.add(jdbcParameter.getParameterBinder());
-        yieldValueOrExpression(AstParameterMarker.INSTANCE, parameterNeedsLiteralWrapping(jdbcParameter));
+        yieldValueOrExpression(
+                new AstParameterMarker(jdbcParameter.getParameterBinder()),
+                parameterNeedsLiteralWrapping(jdbcParameter));
     }
 
     // A parameter's bound value is unknown at translation time, so a string-typed parameter (which could
@@ -539,7 +536,6 @@ public abstract class AbstractMqlTranslator<T extends JdbcOperation> implements 
                 SELECT_RESULT,
                 new SelectMqlTranslator.Result(
                         new AstAggregateCommand(collection, stages),
-                        parameterBinders,
                         affectedTableNames,
                         skipLimitStagesAndJdbcParams.offset(),
                         skipLimitStagesAndJdbcParams.limit()));
@@ -1052,8 +1048,7 @@ public abstract class AbstractMqlTranslator<T extends JdbcOperation> implements 
 
         astVisitorValueHolder.yield(
                 MUTATION_RESULT,
-                new MutationMqlTranslator.Result(
-                        new AstDeleteCommand(collection, filter), parameterBinders, affectedTableNames));
+                new MutationMqlTranslator.Result(new AstDeleteCommand(collection, filter), affectedTableNames));
     }
 
     @Override
@@ -1066,8 +1061,7 @@ public abstract class AbstractMqlTranslator<T extends JdbcOperation> implements 
         AstUpdate update = allValues ? buildDocumentUpdate(assignments) : buildPipelineUpdate(assignments);
         astVisitorValueHolder.yield(
                 MUTATION_RESULT,
-                new MutationMqlTranslator.Result(
-                        new AstUpdateCommand(collection, filter, update), parameterBinders, affectedTableNames));
+                new MutationMqlTranslator.Result(new AstUpdateCommand(collection, filter, update), affectedTableNames));
     }
 
     private AstDocumentUpdate buildDocumentUpdate(List<Assignment> assignments) {
@@ -1159,8 +1153,7 @@ public abstract class AbstractMqlTranslator<T extends JdbcOperation> implements 
 
         astVisitorValueHolder.yield(
                 MUTATION_RESULT,
-                new MutationMqlTranslator.Result(
-                        new AstInsertCommand(collection, documents), parameterBinders, affectedTableNames));
+                new MutationMqlTranslator.Result(new AstInsertCommand(collection, documents), affectedTableNames));
     }
 
     @Override
@@ -1490,8 +1483,6 @@ public abstract class AbstractMqlTranslator<T extends JdbcOperation> implements 
                                 betweenPredicate.getUpperBound())));
     }
 
-    // Each bound is visited on its own (never a reused node): the operand appears in both comparisons,
-    // so a parameter in it must register a binder per occurrence to stay aligned with the rendered markers.
     private AstBinaryOperatorExpression toBoundExpression(
             Expression operand, ComparisonOperator operator, Expression bound) {
         return new AstBinaryOperatorExpression(
@@ -1817,10 +1808,12 @@ public abstract class AbstractMqlTranslator<T extends JdbcOperation> implements 
         throw new FeatureNotSupportedException();
     }
 
-    static String renderMongoAstNode(AstNode rootAstNode) {
+    // The binders are collected by the rendering itself, so they come out in the order in which
+    // MongoPreparedStatement recovers the markers they were rendered as.
+    static String renderMongoAstNode(AstNode rootAstNode, Consumer<JdbcParameterBinder> parameterBinderConsumer) {
         try (var stringWriter = new StringWriter();
                 var jsonWriter = new JsonWriter(stringWriter, EXTENDED_JSON_WRITER_SETTINGS)) {
-            rootAstNode.render(jsonWriter);
+            rootAstNode.render(jsonWriter, parameterBinderConsumer);
             jsonWriter.flush();
             return stringWriter.toString();
         } catch (IOException e) {

--- a/src/main/java/com/mongodb/hibernate/internal/translate/ModelMutationMqlTranslator.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/ModelMutationMqlTranslator.java
@@ -22,7 +22,7 @@ import static com.mongodb.hibernate.internal.translate.AstVisitorValueDescriptor
 import static java.util.Collections.emptyList;
 
 import com.mongodb.hibernate.internal.translate.mongoast.command.AstCommand;
-import java.util.List;
+import java.util.ArrayList;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.query.spi.QueryOptions;
 import org.hibernate.sql.exec.spi.JdbcParameterBinder;
@@ -63,23 +63,24 @@ final class ModelMutationMqlTranslator<O extends JdbcMutationOperation> extends 
     static final class Result {
         private final @Nullable AstCommand command;
 
-        private final List<JdbcParameterBinder> parameterBinders;
-
-        private Result(@Nullable AstCommand command, List<JdbcParameterBinder> parameterBinders) {
+        private Result(@Nullable AstCommand command) {
             this.command = command;
-            this.parameterBinders = parameterBinders;
         }
 
-        static Result create(AstCommand command, List<JdbcParameterBinder> parameterBinders) {
-            return new Result(assertNotNull(command), parameterBinders);
+        static Result create(AstCommand command) {
+            return new Result(assertNotNull(command));
         }
 
         private static Result empty() {
-            return new Result(null, emptyList());
+            return new Result(null);
         }
 
         private <O extends JdbcMutationOperation> O createJdbcMutationOperation(TableMutation<O> tableMutation) {
-            var mql = command == null ? "" : renderMongoAstNode(command);
+            if (command == null) {
+                return tableMutation.createMutationOperation("", emptyList());
+            }
+            var parameterBinders = new ArrayList<JdbcParameterBinder>();
+            var mql = renderMongoAstNode(command, parameterBinders::add);
             return tableMutation.createMutationOperation(mql, parameterBinders);
         }
     }

--- a/src/main/java/com/mongodb/hibernate/internal/translate/MutationMqlTranslator.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/MutationMqlTranslator.java
@@ -26,7 +26,7 @@ import com.mongodb.hibernate.internal.translate.mongoast.command.AstCommand;
 import com.mongodb.hibernate.internal.translate.mongoast.command.AstDeleteCommand;
 import com.mongodb.hibernate.internal.translate.mongoast.command.AstInsertCommand;
 import com.mongodb.hibernate.internal.translate.mongoast.command.AstUpdateCommand;
-import java.util.List;
+import java.util.ArrayList;
 import java.util.Set;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.query.spi.QueryOptions;
@@ -67,17 +67,16 @@ final class MutationMqlTranslator extends AbstractMqlTranslator<JdbcOperationQue
 
     static final class Result {
         private final AstCommand command;
-        private final List<JdbcParameterBinder> parameterBinders;
         private final Set<String> affectedTableNames;
 
-        Result(AstCommand command, List<JdbcParameterBinder> parameterBinders, Set<String> affectedTableNames) {
+        Result(AstCommand command, Set<String> affectedTableNames) {
             this.command = command;
-            this.parameterBinders = parameterBinders;
             this.affectedTableNames = affectedTableNames;
         }
 
         private JdbcOperationQueryMutation createJdbcOperationQueryMutation() {
-            var mql = renderMongoAstNode(command);
+            var parameterBinders = new ArrayList<JdbcParameterBinder>();
+            var mql = renderMongoAstNode(command, parameterBinders::add);
             if (command instanceof AstInsertCommand) {
                 return new JdbcOperationQueryInsertImpl(mql, parameterBinders, affectedTableNames);
             } else if (command instanceof AstUpdateCommand) {

--- a/src/main/java/com/mongodb/hibernate/internal/translate/SelectMqlTranslator.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/SelectMqlTranslator.java
@@ -23,7 +23,7 @@ import static org.hibernate.sql.ast.SqlTreePrinter.logSqlAst;
 import static org.hibernate.sql.exec.spi.JdbcLockStrategy.NONE;
 
 import com.mongodb.hibernate.internal.translate.mongoast.command.AstCommand;
-import java.util.List;
+import java.util.ArrayList;
 import java.util.Set;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.query.spi.QueryOptions;
@@ -64,19 +64,16 @@ final class SelectMqlTranslator extends AbstractMqlTranslator<JdbcSelect> {
 
     static final class Result {
         private final AstCommand command;
-        private final List<JdbcParameterBinder> parameterBinders;
         private final Set<String> affectedTableNames;
         private final @Nullable JdbcParameter offsetParameter;
         private final @Nullable JdbcParameter limitParameter;
 
         Result(
                 AstCommand command,
-                List<JdbcParameterBinder> parameterBinders,
                 Set<String> affectedTableNames,
                 @Nullable JdbcParameter offsetParameter,
                 @Nullable JdbcParameter limitParameter) {
             this.command = command;
-            this.parameterBinders = parameterBinders;
             this.affectedTableNames = affectedTableNames;
             this.offsetParameter = offsetParameter;
             this.limitParameter = limitParameter;
@@ -88,8 +85,10 @@ final class SelectMqlTranslator extends AbstractMqlTranslator<JdbcSelect> {
                     sessionFactory.getServiceRegistry().requireService(JdbcValuesMappingProducerProvider.class);
             var jdbcValuesMappingProducer =
                     jdbcValuesMappingProducerProvider.buildMappingProducer(selectStatement, sessionFactory);
+            var parameterBinders = new ArrayList<JdbcParameterBinder>();
+            var mql = renderMongoAstNode(command, parameterBinders::add);
             return new JdbcOperationQuerySelect(
-                    renderMongoAstNode(command),
+                    mql,
                     parameterBinders,
                     jdbcValuesMappingProducer,
                     affectedTableNames,

--- a/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/AstArray.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/AstArray.java
@@ -17,16 +17,18 @@
 package com.mongodb.hibernate.internal.translate.mongoast;
 
 import java.util.Collection;
+import java.util.function.Consumer;
 import org.bson.BsonWriter;
+import org.hibernate.sql.exec.spi.JdbcParameterBinder;
 
 /** @hidden */
 @SuppressWarnings("MissingSummary")
 public record AstArray(Collection<AstValue> elements) implements AstValue {
     @Override
-    public void render(BsonWriter writer) {
+    public void render(BsonWriter writer, Consumer<JdbcParameterBinder> binderConsumer) {
         writer.writeStartArray();
         {
-            elements.forEach(element -> element.render(writer));
+            elements.forEach(element -> element.render(writer, binderConsumer));
         }
         writer.writeEndArray();
     }

--- a/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/AstBinaryOperatorExpression.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/AstBinaryOperatorExpression.java
@@ -16,7 +16,9 @@
 
 package com.mongodb.hibernate.internal.translate.mongoast;
 
+import java.util.function.Consumer;
 import org.bson.BsonWriter;
+import org.hibernate.sql.exec.spi.JdbcParameterBinder;
 
 /** @hidden */
 @SuppressWarnings("MissingSummary")
@@ -34,12 +36,12 @@ public record AstBinaryOperatorExpression(String operator, AstExpression left, A
     }
 
     @Override
-    public void render(BsonWriter writer) {
+    public void render(BsonWriter writer, Consumer<JdbcParameterBinder> binderConsumer) {
         writer.writeStartDocument();
         writer.writeName(operator);
         writer.writeStartArray();
-        left.render(writer);
-        right.render(writer);
+        left.render(writer, binderConsumer);
+        right.render(writer, binderConsumer);
         writer.writeEndArray();
         writer.writeEndDocument();
     }

--- a/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/AstComputedFieldUpdate.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/AstComputedFieldUpdate.java
@@ -16,7 +16,9 @@
 
 package com.mongodb.hibernate.internal.translate.mongoast;
 
+import java.util.function.Consumer;
 import org.bson.BsonWriter;
+import org.hibernate.sql.exec.spi.JdbcParameterBinder;
 
 /**
  * One field assignment inside a {@code $set} stage of a pipeline-form update, whose value is an aggregation expression.
@@ -27,8 +29,8 @@ import org.bson.BsonWriter;
 @SuppressWarnings("MissingSummary")
 public record AstComputedFieldUpdate(String name, AstExpression value) implements AstNode {
     @Override
-    public void render(BsonWriter writer) {
+    public void render(BsonWriter writer, Consumer<JdbcParameterBinder> binderConsumer) {
         writer.writeName(name);
-        value.render(writer);
+        value.render(writer, binderConsumer);
     }
 }

--- a/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/AstDocument.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/AstDocument.java
@@ -17,7 +17,9 @@
 package com.mongodb.hibernate.internal.translate.mongoast;
 
 import java.util.Collection;
+import java.util.function.Consumer;
 import org.bson.BsonWriter;
+import org.hibernate.sql.exec.spi.JdbcParameterBinder;
 
 /**
  * See <a href="https://www.mongodb.com/docs/manual/core/document/">Documents</a>.
@@ -26,10 +28,10 @@ import org.bson.BsonWriter;
  */
 public record AstDocument(Collection<? extends AstElement> elements) implements AstValue {
     @Override
-    public void render(BsonWriter writer) {
+    public void render(BsonWriter writer, Consumer<JdbcParameterBinder> binderConsumer) {
         writer.writeStartDocument();
         {
-            elements.forEach(element -> element.render(writer));
+            elements.forEach(element -> element.render(writer, binderConsumer));
         }
         writer.writeEndDocument();
     }

--- a/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/AstElement.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/AstElement.java
@@ -16,7 +16,9 @@
 
 package com.mongodb.hibernate.internal.translate.mongoast;
 
+import java.util.function.Consumer;
 import org.bson.BsonWriter;
+import org.hibernate.sql.exec.spi.JdbcParameterBinder;
 
 /**
  * @see AstDocument
@@ -25,8 +27,8 @@ import org.bson.BsonWriter;
 @SuppressWarnings("MissingSummary")
 public record AstElement(String name, AstValue value) implements AstNode {
     @Override
-    public void render(BsonWriter writer) {
+    public void render(BsonWriter writer, Consumer<JdbcParameterBinder> binderConsumer) {
         writer.writeName(name);
-        value.render(writer);
+        value.render(writer, binderConsumer);
     }
 }

--- a/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/AstFieldPathExpression.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/AstFieldPathExpression.java
@@ -16,13 +16,15 @@
 
 package com.mongodb.hibernate.internal.translate.mongoast;
 
+import java.util.function.Consumer;
 import org.bson.BsonWriter;
+import org.hibernate.sql.exec.spi.JdbcParameterBinder;
 
 /** @hidden */
 @SuppressWarnings("MissingSummary")
 public record AstFieldPathExpression(String fieldPath) implements AstExpression {
     @Override
-    public void render(BsonWriter writer) {
+    public void render(BsonWriter writer, Consumer<JdbcParameterBinder> binderConsumer) {
         writer.writeString("$" + fieldPath);
     }
 }

--- a/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/AstFieldUpdate.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/AstFieldUpdate.java
@@ -16,7 +16,9 @@
 
 package com.mongodb.hibernate.internal.translate.mongoast;
 
+import java.util.function.Consumer;
 import org.bson.BsonWriter;
+import org.hibernate.sql.exec.spi.JdbcParameterBinder;
 
 /**
  * @see com.mongodb.hibernate.internal.translate.mongoast.command.AstUpdateCommand
@@ -25,8 +27,8 @@ import org.bson.BsonWriter;
 @SuppressWarnings("MissingSummary")
 public record AstFieldUpdate(String name, AstValue value) implements AstNode {
     @Override
-    public void render(BsonWriter writer) {
+    public void render(BsonWriter writer, Consumer<JdbcParameterBinder> binderConsumer) {
         writer.writeName(name);
-        value.render(writer);
+        value.render(writer, binderConsumer);
     }
 }

--- a/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/AstInExpression.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/AstInExpression.java
@@ -17,19 +17,21 @@
 package com.mongodb.hibernate.internal.translate.mongoast;
 
 import java.util.List;
+import java.util.function.Consumer;
 import org.bson.BsonWriter;
+import org.hibernate.sql.exec.spi.JdbcParameterBinder;
 
 /** @hidden */
 @SuppressWarnings("MissingSummary")
 public record AstInExpression(AstExpression value, List<? extends AstExpression> options) implements AstExpression {
     @Override
-    public void render(BsonWriter writer) {
+    public void render(BsonWriter writer, Consumer<JdbcParameterBinder> binderConsumer) {
         writer.writeStartDocument();
         writer.writeName("$in");
         writer.writeStartArray();
-        value.render(writer);
+        value.render(writer, binderConsumer);
         writer.writeStartArray();
-        options.forEach(option -> option.render(writer));
+        options.forEach(option -> option.render(writer, binderConsumer));
         writer.writeEndArray();
         writer.writeEndArray();
         writer.writeEndDocument();

--- a/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/AstLiteral.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/AstLiteral.java
@@ -16,11 +16,13 @@
 
 package com.mongodb.hibernate.internal.translate.mongoast;
 
+import java.util.function.Consumer;
 import org.bson.BsonBoolean;
 import org.bson.BsonValue;
 import org.bson.BsonWriter;
 import org.bson.codecs.BsonValueCodec;
 import org.bson.codecs.EncoderContext;
+import org.hibernate.sql.exec.spi.JdbcParameterBinder;
 
 /** @hidden */
 @SuppressWarnings("MissingSummary")
@@ -34,7 +36,7 @@ public record AstLiteral(BsonValue literalValue) implements AstValue {
     public static final AstLiteral FALSE = new AstLiteral(BsonBoolean.FALSE);
 
     @Override
-    public void render(BsonWriter writer) {
+    public void render(BsonWriter writer, Consumer<JdbcParameterBinder> binderConsumer) {
         BSON_VALUE_CODEC.encode(writer, literalValue, DEFAULT_CONTEXT);
     }
 }

--- a/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/AstLiteralExpression.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/AstLiteralExpression.java
@@ -16,7 +16,9 @@
 
 package com.mongodb.hibernate.internal.translate.mongoast;
 
+import java.util.function.Consumer;
 import org.bson.BsonWriter;
+import org.hibernate.sql.exec.spi.JdbcParameterBinder;
 
 /**
  * An {@link AstValue} (a literal or parameter) wrapped in {@code $literal} for aggregation-expression position, so it
@@ -29,10 +31,10 @@ import org.bson.BsonWriter;
 @SuppressWarnings("MissingSummary")
 public record AstLiteralExpression(AstValue value) implements AstExpression {
     @Override
-    public void render(BsonWriter writer) {
+    public void render(BsonWriter writer, Consumer<JdbcParameterBinder> binderConsumer) {
         writer.writeStartDocument();
         writer.writeName("$literal");
-        value.render(writer);
+        value.render(writer, binderConsumer);
         writer.writeEndDocument();
     }
 }

--- a/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/AstLogicalOperatorExpression.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/AstLogicalOperatorExpression.java
@@ -17,18 +17,20 @@
 package com.mongodb.hibernate.internal.translate.mongoast;
 
 import java.util.List;
+import java.util.function.Consumer;
 import org.bson.BsonWriter;
+import org.hibernate.sql.exec.spi.JdbcParameterBinder;
 
 /** @hidden */
 @SuppressWarnings("MissingSummary")
 public record AstLogicalOperatorExpression(AstLogicalOperator operator, List<? extends AstExpression> operands)
         implements AstExpression {
     @Override
-    public void render(BsonWriter writer) {
+    public void render(BsonWriter writer, Consumer<JdbcParameterBinder> binderConsumer) {
         writer.writeStartDocument();
         writer.writeName(operator.getOperatorName());
         writer.writeStartArray();
-        operands.forEach(operand -> operand.render(writer));
+        operands.forEach(operand -> operand.render(writer, binderConsumer));
         writer.writeEndArray();
         writer.writeEndDocument();
     }

--- a/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/AstNode.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/AstNode.java
@@ -16,10 +16,12 @@
 
 package com.mongodb.hibernate.internal.translate.mongoast;
 
+import java.util.function.Consumer;
 import org.bson.BsonWriter;
+import org.hibernate.sql.exec.spi.JdbcParameterBinder;
 
 /** @hidden */
 @SuppressWarnings("MissingSummary")
 public interface AstNode {
-    void render(BsonWriter writer);
+    void render(BsonWriter writer, Consumer<JdbcParameterBinder> binderConsumer);
 }

--- a/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/AstParameterMarker.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/AstParameterMarker.java
@@ -16,21 +16,20 @@
 
 package com.mongodb.hibernate.internal.translate.mongoast;
 
+import java.util.function.Consumer;
 import org.bson.BsonWriter;
+import org.hibernate.sql.exec.spi.JdbcParameterBinder;
 
 /**
  * @see org.hibernate.cfg.AvailableSettings#DIALECT_NATIVE_PARAM_MARKERS
  * @hidden
  */
 @SuppressWarnings("MissingSummary")
-public final class AstParameterMarker implements AstValue {
-
-    public static final AstParameterMarker INSTANCE = new AstParameterMarker();
-
-    private AstParameterMarker() {}
+public record AstParameterMarker(JdbcParameterBinder binder) implements AstValue {
 
     @Override
-    public void render(BsonWriter writer) {
+    public void render(BsonWriter writer, Consumer<JdbcParameterBinder> binderConsumer) {
         writer.writeUndefined();
+        binderConsumer.accept(binder);
     }
 }

--- a/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/AstRegexMatchExpression.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/AstRegexMatchExpression.java
@@ -16,18 +16,20 @@
 
 package com.mongodb.hibernate.internal.translate.mongoast;
 
+import java.util.function.Consumer;
 import org.bson.BsonWriter;
+import org.hibernate.sql.exec.spi.JdbcParameterBinder;
 
 /** @hidden */
 @SuppressWarnings("MissingSummary")
 public record AstRegexMatchExpression(AstExpression input, String regex, String options) implements AstExpression {
     @Override
-    public void render(BsonWriter writer) {
+    public void render(BsonWriter writer, Consumer<JdbcParameterBinder> binderConsumer) {
         writer.writeStartDocument();
         writer.writeName("$regexMatch");
         writer.writeStartDocument();
         writer.writeName("input");
-        input.render(writer);
+        input.render(writer, binderConsumer);
         writer.writeString("regex", regex);
         writer.writeString("options", options);
         writer.writeEndDocument();

--- a/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/AstSwitchCase.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/AstSwitchCase.java
@@ -16,7 +16,9 @@
 
 package com.mongodb.hibernate.internal.translate.mongoast;
 
+import java.util.function.Consumer;
 import org.bson.BsonWriter;
+import org.hibernate.sql.exec.spi.JdbcParameterBinder;
 
 /**
  * One branch of a {@link AstSwitchExpression}, rendered as {@code {"case": <caseExpression>, "then":
@@ -29,12 +31,12 @@ import org.bson.BsonWriter;
 @SuppressWarnings("MissingSummary")
 public record AstSwitchCase(AstExpression caseExpression, AstExpression thenExpression) implements AstNode {
     @Override
-    public void render(BsonWriter writer) {
+    public void render(BsonWriter writer, Consumer<JdbcParameterBinder> binderConsumer) {
         writer.writeStartDocument();
         writer.writeName("case");
-        caseExpression.render(writer);
+        caseExpression.render(writer, binderConsumer);
         writer.writeName("then");
-        thenExpression.render(writer);
+        thenExpression.render(writer, binderConsumer);
         writer.writeEndDocument();
     }
 }

--- a/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/AstSwitchExpression.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/AstSwitchExpression.java
@@ -17,7 +17,9 @@
 package com.mongodb.hibernate.internal.translate.mongoast;
 
 import java.util.List;
+import java.util.function.Consumer;
 import org.bson.BsonWriter;
+import org.hibernate.sql.exec.spi.JdbcParameterBinder;
 
 /**
  * The MongoDB {@code $switch} aggregation expression, evaluating each branch's {@code case} in order and yielding the
@@ -31,16 +33,16 @@ import org.bson.BsonWriter;
 public record AstSwitchExpression(List<AstSwitchCase> branches, AstExpression defaultExpression)
         implements AstExpression {
     @Override
-    public void render(BsonWriter writer) {
+    public void render(BsonWriter writer, Consumer<JdbcParameterBinder> binderConsumer) {
         writer.writeStartDocument();
         writer.writeName("$switch");
         writer.writeStartDocument();
         writer.writeName("branches");
         writer.writeStartArray();
-        branches.forEach(branch -> branch.render(writer));
+        branches.forEach(branch -> branch.render(writer, binderConsumer));
         writer.writeEndArray();
         writer.writeName("default");
-        defaultExpression.render(writer);
+        defaultExpression.render(writer, binderConsumer);
         writer.writeEndDocument();
         writer.writeEndDocument();
     }

--- a/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/AstUnaryOperatorExpression.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/AstUnaryOperatorExpression.java
@@ -16,7 +16,9 @@
 
 package com.mongodb.hibernate.internal.translate.mongoast;
 
+import java.util.function.Consumer;
 import org.bson.BsonWriter;
+import org.hibernate.sql.exec.spi.JdbcParameterBinder;
 
 /** @hidden */
 @SuppressWarnings("MissingSummary")
@@ -27,10 +29,10 @@ public record AstUnaryOperatorExpression(String operator, AstExpression operand)
     }
 
     @Override
-    public void render(BsonWriter writer) {
+    public void render(BsonWriter writer, Consumer<JdbcParameterBinder> binderConsumer) {
         writer.writeStartDocument();
         writer.writeName(operator);
-        operand.render(writer);
+        operand.render(writer, binderConsumer);
         writer.writeEndDocument();
     }
 }

--- a/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/AstValueExpression.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/AstValueExpression.java
@@ -16,7 +16,9 @@
 
 package com.mongodb.hibernate.internal.translate.mongoast;
 
+import java.util.function.Consumer;
 import org.bson.BsonWriter;
+import org.hibernate.sql.exec.spi.JdbcParameterBinder;
 
 /**
  * An {@link AstValue} (a literal or parameter) used verbatim in aggregation-expression position. Use this only when the
@@ -29,7 +31,7 @@ import org.bson.BsonWriter;
 @SuppressWarnings("MissingSummary")
 public record AstValueExpression(AstValue value) implements AstExpression {
     @Override
-    public void render(BsonWriter writer) {
-        value.render(writer);
+    public void render(BsonWriter writer, Consumer<JdbcParameterBinder> binderConsumer) {
+        value.render(writer, binderConsumer);
     }
 }

--- a/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/AstVariableExpression.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/AstVariableExpression.java
@@ -16,7 +16,9 @@
 
 package com.mongodb.hibernate.internal.translate.mongoast;
 
+import java.util.function.Consumer;
 import org.bson.BsonWriter;
+import org.hibernate.sql.exec.spi.JdbcParameterBinder;
 
 /**
  * A reference to a {@code let}-bound variable in aggregation-expression position, rendered as {@code $$name} (e.g. the
@@ -27,7 +29,7 @@ import org.bson.BsonWriter;
 @SuppressWarnings("MissingSummary")
 public record AstVariableExpression(String name) implements AstExpression {
     @Override
-    public void render(BsonWriter writer) {
+    public void render(BsonWriter writer, Consumer<JdbcParameterBinder> binderConsumer) {
         writer.writeString("$$" + name);
     }
 }

--- a/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/command/AstDeleteCommand.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/command/AstDeleteCommand.java
@@ -17,7 +17,9 @@
 package com.mongodb.hibernate.internal.translate.mongoast.command;
 
 import com.mongodb.hibernate.internal.translate.mongoast.filter.AstFilter;
+import java.util.function.Consumer;
 import org.bson.BsonWriter;
+import org.hibernate.sql.exec.spi.JdbcParameterBinder;
 
 /**
  * See <a href="https://www.mongodb.com/docs/manual/reference/command/delete/">{@code delete}</a>.
@@ -26,7 +28,7 @@ import org.bson.BsonWriter;
  */
 public record AstDeleteCommand(String collection, AstFilter filter) implements AstCommand {
     @Override
-    public void render(BsonWriter writer) {
+    public void render(BsonWriter writer, Consumer<JdbcParameterBinder> binderConsumer) {
         writer.writeStartDocument();
         {
             writer.writeString("delete", collection);
@@ -36,7 +38,7 @@ public record AstDeleteCommand(String collection, AstFilter filter) implements A
                 writer.writeStartDocument();
                 {
                     writer.writeName("q");
-                    filter.render(writer);
+                    filter.render(writer, binderConsumer);
                     writer.writeInt32("limit", 0);
                 }
                 writer.writeEndDocument();

--- a/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/command/AstDocumentUpdate.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/command/AstDocumentUpdate.java
@@ -18,7 +18,9 @@ package com.mongodb.hibernate.internal.translate.mongoast.command;
 
 import com.mongodb.hibernate.internal.translate.mongoast.AstFieldUpdate;
 import java.util.List;
+import java.util.function.Consumer;
 import org.bson.BsonWriter;
+import org.hibernate.sql.exec.spi.JdbcParameterBinder;
 
 /**
  * A document-form update payload, rendered as {@code { "$set": { … } }}.
@@ -28,13 +30,13 @@ import org.bson.BsonWriter;
 @SuppressWarnings("MissingSummary")
 public record AstDocumentUpdate(List<AstFieldUpdate> updates) implements AstUpdate {
     @Override
-    public void render(BsonWriter writer) {
+    public void render(BsonWriter writer, Consumer<JdbcParameterBinder> binderConsumer) {
         writer.writeStartDocument();
         {
             writer.writeName("$set");
             writer.writeStartDocument();
             {
-                updates.forEach(update -> update.render(writer));
+                updates.forEach(update -> update.render(writer, binderConsumer));
             }
             writer.writeEndDocument();
         }

--- a/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/command/AstInsertCommand.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/command/AstInsertCommand.java
@@ -20,7 +20,9 @@ import static com.mongodb.hibernate.internal.MongoAssertions.assertFalse;
 
 import com.mongodb.hibernate.internal.translate.mongoast.AstDocument;
 import java.util.Collection;
+import java.util.function.Consumer;
 import org.bson.BsonWriter;
+import org.hibernate.sql.exec.spi.JdbcParameterBinder;
 
 /**
  * See <a href="https://www.mongodb.com/docs/manual/reference/command/insert/">{@code insert}</a>.
@@ -34,14 +36,14 @@ public record AstInsertCommand(String collection, Collection<? extends AstDocume
     }
 
     @Override
-    public void render(BsonWriter writer) {
+    public void render(BsonWriter writer, Consumer<JdbcParameterBinder> binderConsumer) {
         writer.writeStartDocument();
         {
             writer.writeString("insert", collection);
             writer.writeName("documents");
             writer.writeStartArray();
             {
-                documents.forEach(document -> document.render(writer));
+                documents.forEach(document -> document.render(writer, binderConsumer));
             }
             writer.writeEndArray();
         }

--- a/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/command/AstPipelineUpdate.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/command/AstPipelineUpdate.java
@@ -18,13 +18,15 @@ package com.mongodb.hibernate.internal.translate.mongoast.command;
 
 import com.mongodb.hibernate.internal.translate.mongoast.AstComputedFieldUpdate;
 import java.util.List;
+import java.util.function.Consumer;
 import org.bson.BsonWriter;
+import org.hibernate.sql.exec.spi.JdbcParameterBinder;
 
 /** @hidden */
 @SuppressWarnings("MissingSummary")
 public record AstPipelineUpdate(List<AstComputedFieldUpdate> updates) implements AstUpdate {
     @Override
-    public void render(BsonWriter writer) {
+    public void render(BsonWriter writer, Consumer<JdbcParameterBinder> binderConsumer) {
         writer.writeStartArray();
         {
             writer.writeStartDocument();
@@ -32,7 +34,7 @@ public record AstPipelineUpdate(List<AstComputedFieldUpdate> updates) implements
                 writer.writeName("$set");
                 writer.writeStartDocument();
                 {
-                    updates.forEach(update -> update.render(writer));
+                    updates.forEach(update -> update.render(writer, binderConsumer));
                 }
                 writer.writeEndDocument();
             }

--- a/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/command/AstUpdateCommand.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/command/AstUpdateCommand.java
@@ -17,7 +17,9 @@
 package com.mongodb.hibernate.internal.translate.mongoast.command;
 
 import com.mongodb.hibernate.internal.translate.mongoast.filter.AstFilter;
+import java.util.function.Consumer;
 import org.bson.BsonWriter;
+import org.hibernate.sql.exec.spi.JdbcParameterBinder;
 
 /**
  * See <a href="https://www.mongodb.com/docs/manual/reference/command/update/">{@code update}</a>.
@@ -26,7 +28,7 @@ import org.bson.BsonWriter;
  */
 public record AstUpdateCommand(String collection, AstFilter filter, AstUpdate update) implements AstCommand {
     @Override
-    public void render(BsonWriter writer) {
+    public void render(BsonWriter writer, Consumer<JdbcParameterBinder> binderConsumer) {
         writer.writeStartDocument();
         {
             writer.writeString("update", collection);
@@ -36,9 +38,9 @@ public record AstUpdateCommand(String collection, AstFilter filter, AstUpdate up
                 writer.writeStartDocument();
                 {
                     writer.writeName("q");
-                    filter.render(writer);
+                    filter.render(writer, binderConsumer);
                     writer.writeName("u");
-                    update.render(writer);
+                    update.render(writer, binderConsumer);
                     writer.writeBoolean("multi", true);
                 }
                 writer.writeEndDocument();

--- a/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/command/aggregate/AstAggregateCommand.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/command/aggregate/AstAggregateCommand.java
@@ -18,7 +18,9 @@ package com.mongodb.hibernate.internal.translate.mongoast.command.aggregate;
 
 import com.mongodb.hibernate.internal.translate.mongoast.command.AstCommand;
 import java.util.Collection;
+import java.util.function.Consumer;
 import org.bson.BsonWriter;
+import org.hibernate.sql.exec.spi.JdbcParameterBinder;
 
 /**
  * See <a href="https://www.mongodb.com/docs/manual/reference/command/aggregate/">{@code aggregate}</a>.
@@ -28,14 +30,14 @@ import org.bson.BsonWriter;
 public record AstAggregateCommand(String collection, Collection<? extends AstStage> stages) implements AstCommand {
 
     @Override
-    public void render(BsonWriter writer) {
+    public void render(BsonWriter writer, Consumer<JdbcParameterBinder> binderConsumer) {
         writer.writeStartDocument();
         {
             writer.writeString("aggregate", collection);
             writer.writeName("pipeline");
             writer.writeStartArray();
             {
-                stages.forEach(stage -> stage.render(writer));
+                stages.forEach(stage -> stage.render(writer, binderConsumer));
             }
             writer.writeEndArray();
         }

--- a/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/command/aggregate/AstLetVariable.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/command/aggregate/AstLetVariable.java
@@ -18,7 +18,9 @@ package com.mongodb.hibernate.internal.translate.mongoast.command.aggregate;
 
 import com.mongodb.hibernate.internal.translate.mongoast.AstExpression;
 import com.mongodb.hibernate.internal.translate.mongoast.AstNode;
+import java.util.function.Consumer;
 import org.bson.BsonWriter;
+import org.hibernate.sql.exec.spi.JdbcParameterBinder;
 
 /**
  * A single {@code name → expression} binding in the {@code let} of a {@code $lookup} pipeline stage. Unlike an
@@ -31,8 +33,8 @@ import org.bson.BsonWriter;
 @SuppressWarnings("MissingSummary")
 public record AstLetVariable(String name, AstExpression expression) implements AstNode {
     @Override
-    public void render(BsonWriter writer) {
+    public void render(BsonWriter writer, Consumer<JdbcParameterBinder> binderConsumer) {
         writer.writeName(name);
-        expression.render(writer);
+        expression.render(writer, binderConsumer);
     }
 }

--- a/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/command/aggregate/AstLimitStage.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/command/aggregate/AstLimitStage.java
@@ -17,7 +17,9 @@
 package com.mongodb.hibernate.internal.translate.mongoast.command.aggregate;
 
 import com.mongodb.hibernate.internal.translate.mongoast.AstValue;
+import java.util.function.Consumer;
 import org.bson.BsonWriter;
+import org.hibernate.sql.exec.spi.JdbcParameterBinder;
 
 /**
  * See <a href="https://www.mongodb.com/docs/manual/reference/operator/aggregation/limit/">{@code limit}</a>.
@@ -26,11 +28,11 @@ import org.bson.BsonWriter;
  */
 public record AstLimitStage(AstValue value) implements AstStage {
     @Override
-    public void render(BsonWriter writer) {
+    public void render(BsonWriter writer, Consumer<JdbcParameterBinder> binderConsumer) {
         writer.writeStartDocument();
         {
             writer.writeName("$limit");
-            value.render(writer);
+            value.render(writer, binderConsumer);
         }
         writer.writeEndDocument();
     }

--- a/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/command/aggregate/AstLookupStage.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/command/aggregate/AstLookupStage.java
@@ -16,7 +16,9 @@
 
 package com.mongodb.hibernate.internal.translate.mongoast.command.aggregate;
 
+import java.util.function.Consumer;
 import org.bson.BsonWriter;
+import org.hibernate.sql.exec.spi.JdbcParameterBinder;
 
 /**
  * See <a href="https://www.mongodb.com/docs/manual/reference/operator/aggregation/lookup/">{@code $lookup}</a>.
@@ -25,7 +27,7 @@ import org.bson.BsonWriter;
  */
 public record AstLookupStage(String from, String localField, String foreignField, String as) implements AstStage {
     @Override
-    public void render(BsonWriter writer) {
+    public void render(BsonWriter writer, Consumer<JdbcParameterBinder> binderConsumer) {
         writer.writeStartDocument();
         {
             writer.writeName("$lookup");

--- a/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/command/aggregate/AstLookupStageWithPipeline.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/command/aggregate/AstLookupStageWithPipeline.java
@@ -17,7 +17,9 @@
 package com.mongodb.hibernate.internal.translate.mongoast.command.aggregate;
 
 import java.util.List;
+import java.util.function.Consumer;
 import org.bson.BsonWriter;
+import org.hibernate.sql.exec.spi.JdbcParameterBinder;
 
 /**
  * The pipeline form of <a
@@ -31,7 +33,7 @@ import org.bson.BsonWriter;
 public record AstLookupStageWithPipeline(String from, List<AstLetVariable> let, List<AstStage> pipeline, String as)
         implements AstStage {
     @Override
-    public void render(BsonWriter writer) {
+    public void render(BsonWriter writer, Consumer<JdbcParameterBinder> binderConsumer) {
         writer.writeStartDocument();
         {
             writer.writeName("$lookup");
@@ -41,13 +43,13 @@ public record AstLookupStageWithPipeline(String from, List<AstLetVariable> let, 
                 writer.writeName("let");
                 writer.writeStartDocument();
                 {
-                    let.forEach(variable -> variable.render(writer));
+                    let.forEach(variable -> variable.render(writer, binderConsumer));
                 }
                 writer.writeEndDocument();
                 writer.writeName("pipeline");
                 writer.writeStartArray();
                 {
-                    pipeline.forEach(stage -> stage.render(writer));
+                    pipeline.forEach(stage -> stage.render(writer, binderConsumer));
                 }
                 writer.writeEndArray();
                 writer.writeString("as", as);

--- a/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/command/aggregate/AstMatchStage.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/command/aggregate/AstMatchStage.java
@@ -17,7 +17,9 @@
 package com.mongodb.hibernate.internal.translate.mongoast.command.aggregate;
 
 import com.mongodb.hibernate.internal.translate.mongoast.filter.AstFilter;
+import java.util.function.Consumer;
 import org.bson.BsonWriter;
+import org.hibernate.sql.exec.spi.JdbcParameterBinder;
 
 /**
  * See <a href="https://www.mongodb.com/docs/manual/reference/operator/aggregation/match/">{@code $match}</a>.
@@ -26,11 +28,11 @@ import org.bson.BsonWriter;
  */
 public record AstMatchStage(AstFilter filter) implements AstStage {
     @Override
-    public void render(BsonWriter writer) {
+    public void render(BsonWriter writer, Consumer<JdbcParameterBinder> binderConsumer) {
         writer.writeStartDocument();
         {
             writer.writeName("$match");
-            filter.render(writer);
+            filter.render(writer, binderConsumer);
         }
         writer.writeEndDocument();
     }

--- a/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/command/aggregate/AstProjectStage.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/command/aggregate/AstProjectStage.java
@@ -19,7 +19,9 @@ package com.mongodb.hibernate.internal.translate.mongoast.command.aggregate;
 import static com.mongodb.hibernate.internal.MongoAssertions.assertFalse;
 
 import java.util.Collection;
+import java.util.function.Consumer;
 import org.bson.BsonWriter;
+import org.hibernate.sql.exec.spi.JdbcParameterBinder;
 
 /**
  * See <a href="https://www.mongodb.com/docs/manual/reference/operator/aggregation/project/">{@code project}</a>.
@@ -33,13 +35,13 @@ public record AstProjectStage(Collection<? extends AstProjectStageSpecification>
     }
 
     @Override
-    public void render(BsonWriter writer) {
+    public void render(BsonWriter writer, Consumer<JdbcParameterBinder> binderConsumer) {
         writer.writeStartDocument();
         {
             writer.writeName("$project");
             writer.writeStartDocument();
             {
-                specifications.forEach(specification -> specification.render(writer));
+                specifications.forEach(specification -> specification.render(writer, binderConsumer));
             }
             writer.writeEndDocument();
         }

--- a/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/command/aggregate/AstProjectStageExpressionSpecification.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/command/aggregate/AstProjectStageExpressionSpecification.java
@@ -17,15 +17,17 @@
 package com.mongodb.hibernate.internal.translate.mongoast.command.aggregate;
 
 import com.mongodb.hibernate.internal.translate.mongoast.AstExpression;
+import java.util.function.Consumer;
 import org.bson.BsonWriter;
+import org.hibernate.sql.exec.spi.JdbcParameterBinder;
 
 /** @hidden */
 @SuppressWarnings("MissingSummary")
 public record AstProjectStageExpressionSpecification(String key, AstExpression expression)
         implements AstProjectStageSpecification {
     @Override
-    public void render(BsonWriter writer) {
+    public void render(BsonWriter writer, Consumer<JdbcParameterBinder> binderConsumer) {
         writer.writeName(key);
-        expression.render(writer);
+        expression.render(writer, binderConsumer);
     }
 }

--- a/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/command/aggregate/AstProjectStageFieldPathSpecification.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/command/aggregate/AstProjectStageFieldPathSpecification.java
@@ -16,7 +16,9 @@
 
 package com.mongodb.hibernate.internal.translate.mongoast.command.aggregate;
 
+import java.util.function.Consumer;
 import org.bson.BsonWriter;
+import org.hibernate.sql.exec.spi.JdbcParameterBinder;
 
 /**
  * @see AstProjectStage
@@ -26,7 +28,7 @@ import org.bson.BsonWriter;
 public record AstProjectStageFieldPathSpecification(String field, String fieldPath)
         implements AstProjectStageSpecification {
     @Override
-    public void render(BsonWriter writer) {
+    public void render(BsonWriter writer, Consumer<JdbcParameterBinder> binderConsumer) {
         writer.writeString(field, "$" + fieldPath);
     }
 }

--- a/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/command/aggregate/AstProjectStageIncludeSpecification.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/command/aggregate/AstProjectStageIncludeSpecification.java
@@ -16,13 +16,15 @@
 
 package com.mongodb.hibernate.internal.translate.mongoast.command.aggregate;
 
+import java.util.function.Consumer;
 import org.bson.BsonWriter;
+import org.hibernate.sql.exec.spi.JdbcParameterBinder;
 
 /** @hidden */
 @SuppressWarnings("MissingSummary")
 public record AstProjectStageIncludeSpecification(String field) implements AstProjectStageSpecification {
     @Override
-    public void render(BsonWriter writer) {
+    public void render(BsonWriter writer, Consumer<JdbcParameterBinder> binderConsumer) {
         writer.writeBoolean(field, true);
     }
 }

--- a/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/command/aggregate/AstSkipStage.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/command/aggregate/AstSkipStage.java
@@ -17,7 +17,9 @@
 package com.mongodb.hibernate.internal.translate.mongoast.command.aggregate;
 
 import com.mongodb.hibernate.internal.translate.mongoast.AstValue;
+import java.util.function.Consumer;
 import org.bson.BsonWriter;
+import org.hibernate.sql.exec.spi.JdbcParameterBinder;
 
 /**
  * See <a href="https://www.mongodb.com/docs/manual/reference/operator/aggregation/skip/">{@code $skip}</a>.
@@ -26,11 +28,11 @@ import org.bson.BsonWriter;
  */
 public record AstSkipStage(AstValue value) implements AstStage {
     @Override
-    public void render(BsonWriter writer) {
+    public void render(BsonWriter writer, Consumer<JdbcParameterBinder> binderConsumer) {
         writer.writeStartDocument();
         {
             writer.writeName("$skip");
-            value.render(writer);
+            value.render(writer, binderConsumer);
         }
         writer.writeEndDocument();
     }

--- a/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/command/aggregate/AstSortField.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/command/aggregate/AstSortField.java
@@ -17,7 +17,9 @@
 package com.mongodb.hibernate.internal.translate.mongoast.command.aggregate;
 
 import com.mongodb.hibernate.internal.translate.mongoast.AstNode;
+import java.util.function.Consumer;
 import org.bson.BsonWriter;
+import org.hibernate.sql.exec.spi.JdbcParameterBinder;
 
 /**
  * @see AstSortStage
@@ -26,8 +28,8 @@ import org.bson.BsonWriter;
 @SuppressWarnings("MissingSummary")
 public record AstSortField(String path, AstSortOrder order) implements AstNode {
     @Override
-    public void render(BsonWriter writer) {
+    public void render(BsonWriter writer, Consumer<JdbcParameterBinder> binderConsumer) {
         writer.writeName(path);
-        order.render(writer);
+        order.render(writer, binderConsumer);
     }
 }

--- a/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/command/aggregate/AstSortOrder.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/command/aggregate/AstSortOrder.java
@@ -17,7 +17,9 @@
 package com.mongodb.hibernate.internal.translate.mongoast.command.aggregate;
 
 import com.mongodb.hibernate.internal.translate.mongoast.AstNode;
+import java.util.function.Consumer;
 import org.bson.BsonWriter;
+import org.hibernate.sql.exec.spi.JdbcParameterBinder;
 
 /**
  * @see AstSortField
@@ -35,7 +37,7 @@ public enum AstSortOrder implements AstNode {
     }
 
     @Override
-    public void render(BsonWriter writer) {
+    public void render(BsonWriter writer, Consumer<JdbcParameterBinder> binderConsumer) {
         writer.writeInt32(renderedValue);
     }
 }

--- a/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/command/aggregate/AstSortStage.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/command/aggregate/AstSortStage.java
@@ -19,7 +19,9 @@ package com.mongodb.hibernate.internal.translate.mongoast.command.aggregate;
 import static com.mongodb.hibernate.internal.MongoAssertions.assertFalse;
 
 import java.util.Collection;
+import java.util.function.Consumer;
 import org.bson.BsonWriter;
+import org.hibernate.sql.exec.spi.JdbcParameterBinder;
 
 /**
  * See <a href="https://www.mongodb.com/docs/manual/reference/operator/aggregation/sort/">{@code $sort}</a>.
@@ -33,13 +35,13 @@ public record AstSortStage(Collection<? extends AstSortField> sortFields) implem
     }
 
     @Override
-    public void render(BsonWriter writer) {
+    public void render(BsonWriter writer, Consumer<JdbcParameterBinder> binderConsumer) {
         writer.writeStartDocument();
         {
             writer.writeName("$sort");
             writer.writeStartDocument();
             {
-                sortFields.forEach(sortField -> sortField.render(writer));
+                sortFields.forEach(sortField -> sortField.render(writer, binderConsumer));
             }
             writer.writeEndDocument();
         }

--- a/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/command/aggregate/AstUnwindStage.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/command/aggregate/AstUnwindStage.java
@@ -16,7 +16,9 @@
 
 package com.mongodb.hibernate.internal.translate.mongoast.command.aggregate;
 
+import java.util.function.Consumer;
 import org.bson.BsonWriter;
+import org.hibernate.sql.exec.spi.JdbcParameterBinder;
 
 /**
  * See <a href="https://www.mongodb.com/docs/manual/reference/operator/aggregation/unwind/">{@code $unwind}</a>.
@@ -25,7 +27,7 @@ import org.bson.BsonWriter;
  */
 public record AstUnwindStage(String path, boolean preserveNullAndEmptyArrays) implements AstStage {
     @Override
-    public void render(BsonWriter writer) {
+    public void render(BsonWriter writer, Consumer<JdbcParameterBinder> binderConsumer) {
         writer.writeStartDocument();
         writer.writeName("$unwind");
         if (preserveNullAndEmptyArrays) {

--- a/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/filter/AstAllFilterOperation.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/filter/AstAllFilterOperation.java
@@ -21,7 +21,9 @@ import static com.mongodb.hibernate.internal.MongoAssertions.assertTrue;
 import com.mongodb.hibernate.internal.translate.mongoast.AstArray;
 import com.mongodb.hibernate.internal.translate.mongoast.AstParameterMarker;
 import com.mongodb.hibernate.internal.translate.mongoast.AstValue;
+import java.util.function.Consumer;
 import org.bson.BsonWriter;
+import org.hibernate.sql.exec.spi.JdbcParameterBinder;
 
 /**
  * See <a href="https://www.mongodb.com/docs/manual/reference/operator/query/all/">{@code $all}</a>.
@@ -35,11 +37,11 @@ public record AstAllFilterOperation(AstValue parameterMarkerOrArrayValue) implem
     }
 
     @Override
-    public void render(BsonWriter writer) {
+    public void render(BsonWriter writer, Consumer<JdbcParameterBinder> binderConsumer) {
         writer.writeStartDocument();
         {
             writer.writeName("$all");
-            parameterMarkerOrArrayValue.render(writer);
+            parameterMarkerOrArrayValue.render(writer, binderConsumer);
         }
         writer.writeEndDocument();
     }

--- a/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/filter/AstComparisonFilterOperation.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/filter/AstComparisonFilterOperation.java
@@ -17,7 +17,9 @@
 package com.mongodb.hibernate.internal.translate.mongoast.filter;
 
 import com.mongodb.hibernate.internal.translate.mongoast.AstValue;
+import java.util.function.Consumer;
 import org.bson.BsonWriter;
+import org.hibernate.sql.exec.spi.JdbcParameterBinder;
 
 /**
  * See <a href="https://www.mongodb.com/docs/manual/reference/operator/query/#comparison">Query and Projection
@@ -28,11 +30,11 @@ import org.bson.BsonWriter;
 public record AstComparisonFilterOperation(AstComparisonFilterOperator operator, AstValue value)
         implements AstFilterOperation {
     @Override
-    public void render(BsonWriter writer) {
+    public void render(BsonWriter writer, Consumer<JdbcParameterBinder> binderConsumer) {
         writer.writeStartDocument();
         {
             writer.writeName(operator.getOperatorName());
-            value.render(writer);
+            value.render(writer, binderConsumer);
         }
         writer.writeEndDocument();
     }

--- a/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/filter/AstElemMatchFilterOperation.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/filter/AstElemMatchFilterOperation.java
@@ -16,7 +16,9 @@
 
 package com.mongodb.hibernate.internal.translate.mongoast.filter;
 
+import java.util.function.Consumer;
 import org.bson.BsonWriter;
+import org.hibernate.sql.exec.spi.JdbcParameterBinder;
 
 /**
  * See <a href="https://www.mongodb.com/docs/manual/reference/operator/query/elemMatch/">$elemMatch</a>.
@@ -25,11 +27,11 @@ import org.bson.BsonWriter;
  */
 public record AstElemMatchFilterOperation(AstFilter body) implements AstFilterOperation {
     @Override
-    public void render(BsonWriter writer) {
+    public void render(BsonWriter writer, Consumer<JdbcParameterBinder> binderConsumer) {
         writer.writeStartDocument();
         {
             writer.writeName("$elemMatch");
-            body.render(writer);
+            body.render(writer, binderConsumer);
         }
         writer.writeEndDocument();
     }

--- a/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/filter/AstEmptyFilter.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/filter/AstEmptyFilter.java
@@ -16,7 +16,9 @@
 
 package com.mongodb.hibernate.internal.translate.mongoast.filter;
 
+import java.util.function.Consumer;
 import org.bson.BsonWriter;
+import org.hibernate.sql.exec.spi.JdbcParameterBinder;
 
 /**
  * Matches all documents.
@@ -31,7 +33,7 @@ public final class AstEmptyFilter implements AstFilter {
     private AstEmptyFilter() {}
 
     @Override
-    public void render(BsonWriter writer) {
+    public void render(BsonWriter writer, Consumer<JdbcParameterBinder> binderConsumer) {
         writer.writeStartDocument();
         writer.writeEndDocument();
     }

--- a/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/filter/AstExprFilter.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/filter/AstExprFilter.java
@@ -17,7 +17,9 @@
 package com.mongodb.hibernate.internal.translate.mongoast.filter;
 
 import com.mongodb.hibernate.internal.translate.mongoast.AstExpression;
+import java.util.function.Consumer;
 import org.bson.BsonWriter;
+import org.hibernate.sql.exec.spi.JdbcParameterBinder;
 
 /**
  * Renders {@code { $expr: expression }} as a MongoDB aggregation expression predicate in a {@code $match} stage. Used
@@ -29,10 +31,10 @@ import org.bson.BsonWriter;
 @SuppressWarnings("MissingSummary")
 public record AstExprFilter(AstExpression expression) implements AstFilter {
     @Override
-    public void render(BsonWriter writer) {
+    public void render(BsonWriter writer, Consumer<JdbcParameterBinder> binderConsumer) {
         writer.writeStartDocument();
         writer.writeName("$expr");
-        expression.render(writer);
+        expression.render(writer, binderConsumer);
         writer.writeEndDocument();
     }
 }

--- a/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/filter/AstFieldOperationFilter.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/filter/AstFieldOperationFilter.java
@@ -16,7 +16,9 @@
 
 package com.mongodb.hibernate.internal.translate.mongoast.filter;
 
+import java.util.function.Consumer;
 import org.bson.BsonWriter;
+import org.hibernate.sql.exec.spi.JdbcParameterBinder;
 
 /**
  * See <a href="https://www.mongodb.com/docs/manual/reference/glossary/#std-term-query-predicate">query predicate</a>,
@@ -27,11 +29,11 @@ import org.bson.BsonWriter;
  */
 public record AstFieldOperationFilter(String fieldPath, AstFilterOperation filterOperation) implements AstFilter {
     @Override
-    public void render(BsonWriter writer) {
+    public void render(BsonWriter writer, Consumer<JdbcParameterBinder> binderConsumer) {
         writer.writeStartDocument();
         {
             writer.writeName(fieldPath);
-            filterOperation.render(writer);
+            filterOperation.render(writer, binderConsumer);
         }
         writer.writeEndDocument();
     }

--- a/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/filter/AstListComparisonFilterOperation.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/filter/AstListComparisonFilterOperation.java
@@ -18,7 +18,9 @@ package com.mongodb.hibernate.internal.translate.mongoast.filter;
 
 import com.mongodb.hibernate.internal.translate.mongoast.AstValue;
 import java.util.List;
+import java.util.function.Consumer;
 import org.bson.BsonWriter;
+import org.hibernate.sql.exec.spi.JdbcParameterBinder;
 
 /**
  * See <a href="https://www.mongodb.com/docs/manual/reference/operator/query/in/">Query and Projection Operators. Query
@@ -29,13 +31,13 @@ import org.bson.BsonWriter;
 public record AstListComparisonFilterOperation(AstListComparisonFilterOperator operator, List<AstValue> values)
         implements AstFilterOperation {
     @Override
-    public void render(BsonWriter writer) {
+    public void render(BsonWriter writer, Consumer<JdbcParameterBinder> binderConsumer) {
         writer.writeStartDocument();
         {
             writer.writeName(operator.getOperatorName());
             writer.writeStartArray();
             for (final var value : values) {
-                value.render(writer);
+                value.render(writer, binderConsumer);
             }
             writer.writeEndArray();
         }

--- a/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/filter/AstLogicalFilter.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/filter/AstLogicalFilter.java
@@ -19,7 +19,9 @@ package com.mongodb.hibernate.internal.translate.mongoast.filter;
 import static com.mongodb.hibernate.internal.MongoAssertions.assertFalse;
 
 import java.util.Collection;
+import java.util.function.Consumer;
 import org.bson.BsonWriter;
+import org.hibernate.sql.exec.spi.JdbcParameterBinder;
 
 /**
  * See <a href="https://www.mongodb.com/docs/manual/reference/operator/query/#logical">Query and Projection Operators.
@@ -35,13 +37,13 @@ public record AstLogicalFilter(AstLogicalFilterOperator operator, Collection<? e
     }
 
     @Override
-    public void render(BsonWriter writer) {
+    public void render(BsonWriter writer, Consumer<JdbcParameterBinder> binderConsumer) {
         writer.writeStartDocument();
         {
             writer.writeName(operator.getOperatorName());
             writer.writeStartArray();
             {
-                filters.forEach(filter -> filter.render(writer));
+                filters.forEach(filter -> filter.render(writer, binderConsumer));
             }
             writer.writeEndArray();
         }

--- a/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/filter/AstRegularExpressionFilterOperation.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/filter/AstRegularExpressionFilterOperation.java
@@ -16,8 +16,10 @@
 
 package com.mongodb.hibernate.internal.translate.mongoast.filter;
 
+import java.util.function.Consumer;
 import org.bson.BsonRegularExpression;
 import org.bson.BsonWriter;
+import org.hibernate.sql.exec.spi.JdbcParameterBinder;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -78,7 +80,7 @@ public record AstRegularExpressionFilterOperation(String pattern, String options
     }
 
     @Override
-    public void render(BsonWriter writer) {
+    public void render(BsonWriter writer, Consumer<JdbcParameterBinder> binderConsumer) {
         writer.writeStartDocument();
         {
             writer.writeName("$regex");

--- a/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/filter/AstTypeFilterOperation.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/filter/AstTypeFilterOperation.java
@@ -19,8 +19,10 @@ package com.mongodb.hibernate.internal.translate.mongoast.filter;
 import static com.mongodb.hibernate.internal.MongoAssertions.assertFalse;
 
 import java.util.Collection;
+import java.util.function.Consumer;
 import org.bson.BsonType;
 import org.bson.BsonWriter;
+import org.hibernate.sql.exec.spi.JdbcParameterBinder;
 
 /**
  * See <a href="https://www.mongodb.com/docs/manual/reference/operator/query/type/">{@code $type}</a>.
@@ -33,7 +35,7 @@ public record AstTypeFilterOperation(Collection<BsonType> types) implements AstF
     }
 
     @Override
-    public void render(BsonWriter writer) {
+    public void render(BsonWriter writer, Consumer<JdbcParameterBinder> binderConsumer) {
         writer.writeStartDocument();
         {
             writer.writeName("$type");

--- a/src/test/java/com/mongodb/hibernate/internal/translate/AstVisitorValueHolderTests.java
+++ b/src/test/java/com/mongodb/hibernate/internal/translate/AstVisitorValueHolderTests.java
@@ -18,7 +18,6 @@ package com.mongodb.hibernate.internal.translate;
 
 import static com.mongodb.hibernate.internal.translate.AstVisitorValueDescriptor.MODEL_MUTATION_RESULT;
 import static com.mongodb.hibernate.internal.translate.AstVisitorValueDescriptor.VALUE;
-import static java.util.Collections.emptyList;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -29,6 +28,7 @@ import com.mongodb.hibernate.internal.translate.mongoast.AstParameterMarker;
 import com.mongodb.hibernate.internal.translate.mongoast.command.AstInsertCommand;
 import java.util.List;
 import org.bson.BsonString;
+import org.hibernate.sql.exec.spi.JdbcParameterBinder;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -58,14 +58,14 @@ class AstVisitorValueHolderTests {
 
         Runnable tableInserter = () -> {
             Runnable fieldValueYielder = () -> {
-                astVisitorValueHolder.yield(VALUE, AstParameterMarker.INSTANCE);
+                astVisitorValueHolder.yield(VALUE, new AstParameterMarker(JdbcParameterBinder.NOOP));
             };
             var fieldValue = astVisitorValueHolder.execute(VALUE, fieldValueYielder);
             AstElement astElement = new AstElement("province", fieldValue);
             astVisitorValueHolder.yield(
                     MODEL_MUTATION_RESULT,
                     ModelMutationMqlTranslator.Result.create(
-                            new AstInsertCommand("city", List.of(new AstDocument(List.of(astElement)))), emptyList()));
+                            new AstInsertCommand("city", List.of(new AstDocument(List.of(astElement))))));
         };
 
         astVisitorValueHolder.execute(MODEL_MUTATION_RESULT, tableInserter);

--- a/src/test/java/com/mongodb/hibernate/internal/translate/ParameterBinderCollectionTests.java
+++ b/src/test/java/com/mongodb/hibernate/internal/translate/ParameterBinderCollectionTests.java
@@ -16,13 +16,11 @@
 
 package com.mongodb.hibernate.internal.translate;
 
-import static com.mongodb.hibernate.internal.translate.AbstractMqlTranslator.renderMongoAstNode;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static com.mongodb.hibernate.internal.translate.mongoast.AstNodeAssertions.assertValueRendering;
 
 import com.mongodb.hibernate.internal.translate.mongoast.AstDocument;
 import com.mongodb.hibernate.internal.translate.mongoast.AstElement;
 import com.mongodb.hibernate.internal.translate.mongoast.AstParameterMarker;
-import java.util.ArrayList;
 import java.util.List;
 import org.hibernate.sql.exec.spi.JdbcParameterBinder;
 import org.junit.jupiter.api.Test;
@@ -33,12 +31,6 @@ class ParameterBinderCollectionTests {
         return (statement, startPosition, jdbcParameterBindings, executionContext) -> {};
     }
 
-    private static List<JdbcParameterBinder> render(AstDocument document) {
-        var parameterBinders = new ArrayList<JdbcParameterBinder>();
-        renderMongoAstNode(document, parameterBinders::add);
-        return parameterBinders;
-    }
-
     @Test
     void testBindersFollowRenderingOrderRatherThanConstructionOrder() {
         var first = binder();
@@ -47,8 +39,8 @@ class ParameterBinderCollectionTests {
         var document = new AstDocument(List.of(
                 new AstElement("a", new AstParameterMarker(second)),
                 new AstElement("b", new AstParameterMarker(first))));
-
-        assertEquals(List.of(second, first), render(document));
+        assertValueRendering("""
+                {"": {"a": ?, "b": ?}}""", List.of(second, first), document);
     }
 
     @Test
@@ -57,7 +49,7 @@ class ParameterBinderCollectionTests {
         var marker = new AstParameterMarker(shared);
 
         var document = new AstDocument(List.of(new AstElement("a", marker), new AstElement("b", marker)));
-
-        assertEquals(List.of(shared, shared), render(document));
+        assertValueRendering("""
+                {"": {"a": ?, "b": ?}}""", List.of(shared, shared), document);
     }
 }

--- a/src/test/java/com/mongodb/hibernate/internal/translate/ParameterBinderCollectionTests.java
+++ b/src/test/java/com/mongodb/hibernate/internal/translate/ParameterBinderCollectionTests.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2026-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.hibernate.internal.translate;
+
+import static com.mongodb.hibernate.internal.translate.AbstractMqlTranslator.renderMongoAstNode;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.mongodb.hibernate.internal.translate.mongoast.AstDocument;
+import com.mongodb.hibernate.internal.translate.mongoast.AstElement;
+import com.mongodb.hibernate.internal.translate.mongoast.AstParameterMarker;
+import java.util.ArrayList;
+import java.util.List;
+import org.hibernate.sql.exec.spi.JdbcParameterBinder;
+import org.junit.jupiter.api.Test;
+
+class ParameterBinderCollectionTests {
+
+    private static JdbcParameterBinder binder() {
+        return (statement, startPosition, jdbcParameterBindings, executionContext) -> {};
+    }
+
+    private static List<JdbcParameterBinder> render(AstDocument document) {
+        var parameterBinders = new ArrayList<JdbcParameterBinder>();
+        renderMongoAstNode(document, parameterBinders::add);
+        return parameterBinders;
+    }
+
+    @Test
+    void testBindersFollowRenderingOrderRatherThanConstructionOrder() {
+        var first = binder();
+        var second = binder();
+
+        var document = new AstDocument(List.of(
+                new AstElement("a", new AstParameterMarker(second)),
+                new AstElement("b", new AstParameterMarker(first))));
+
+        assertEquals(List.of(second, first), render(document));
+    }
+
+    @Test
+    void testMarkerRenderedTwiceContributesTwoBinders() {
+        var shared = binder();
+        var marker = new AstParameterMarker(shared);
+
+        var document = new AstDocument(List.of(new AstElement("a", marker), new AstElement("b", marker)));
+
+        assertEquals(List.of(shared, shared), render(document));
+    }
+}

--- a/src/test/java/com/mongodb/hibernate/internal/translate/mongoast/AstNodeAssertions.java
+++ b/src/test/java/com/mongodb/hibernate/internal/translate/mongoast/AstNodeAssertions.java
@@ -21,30 +21,43 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.List;
 import org.bson.json.JsonWriter;
+import org.hibernate.sql.exec.spi.JdbcParameterBinder;
+import org.junit.jupiter.params.shadow.de.siegmar.fastcsv.util.Nullable;
 
 public final class AstNodeAssertions {
 
     private AstNodeAssertions() {}
 
     public static void assertRendering(String expectedCanonicalExtendedJson, AstNode node) {
-        doAssertRendering(expectedCanonicalExtendedJson, node, AstNodeKind.DOCUMENT);
+        doAssertRendering(expectedCanonicalExtendedJson, null, node, AstNodeKind.DOCUMENT);
     }
 
     public static void assertElementRendering(String expectedCanonicalExtendedJson, AstNode node) {
-        doAssertRendering(expectedCanonicalExtendedJson, node, AstNodeKind.ELEMENT);
+        doAssertRendering(expectedCanonicalExtendedJson, null, node, AstNodeKind.ELEMENT);
     }
 
     public static void assertValueRendering(String expectedCanonicalExtendedJson, AstValue node) {
-        doAssertRendering(expectedCanonicalExtendedJson, node, AstNodeKind.VALUE);
+        doAssertRendering(expectedCanonicalExtendedJson, null, node, AstNodeKind.VALUE);
+    }
+
+    public static void assertValueRendering(
+            String expectedCanonicalExtendedJson, List<JdbcParameterBinder> expectedParameterBinders, AstValue node) {
+        doAssertRendering(expectedCanonicalExtendedJson, expectedParameterBinders, node, AstNodeKind.VALUE);
     }
 
     public static void assertExpressionRendering(String expectedCanonicalExtendedJson, AstExpression node) {
         // An expression renders in value position, so it uses the same rendering path as a value.
-        doAssertRendering(expectedCanonicalExtendedJson, node, AstNodeKind.VALUE);
+        doAssertRendering(expectedCanonicalExtendedJson, null, node, AstNodeKind.VALUE);
     }
 
-    private static void doAssertRendering(String expectedJson, AstNode node, AstNodeKind nodeKind) {
+    private static void doAssertRendering(
+            String expectedJson,
+            @Nullable List<JdbcParameterBinder> expectedParameterBinders,
+            AstNode node,
+            AstNodeKind nodeKind) {
         try (var stringWriter = new StringWriter();
                 var jsonWriter = new JsonWriter(stringWriter, EXTENDED_JSON_WRITER_SETTINGS)) {
             if (nodeKind != AstNodeKind.DOCUMENT) {
@@ -54,13 +67,17 @@ public final class AstNodeAssertions {
             if (nodeKind == AstNodeKind.VALUE) {
                 jsonWriter.writeName(ancillaryFieldName);
             }
-            node.render(jsonWriter, parameterBinder -> {});
+            var consumedBinders = new ArrayList<JdbcParameterBinder>();
+            node.render(jsonWriter, consumedBinders::add);
             if (nodeKind != AstNodeKind.DOCUMENT) {
                 jsonWriter.writeEndDocument();
             }
             jsonWriter.flush();
             var actualJson = stringWriter.toString();
             assertEquals(expectedJson, actualJson);
+            if (expectedParameterBinders != null) {
+                assertEquals(expectedParameterBinders, consumedBinders);
+            }
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/src/test/java/com/mongodb/hibernate/internal/translate/mongoast/AstNodeAssertions.java
+++ b/src/test/java/com/mongodb/hibernate/internal/translate/mongoast/AstNodeAssertions.java
@@ -54,7 +54,7 @@ public final class AstNodeAssertions {
             if (nodeKind == AstNodeKind.VALUE) {
                 jsonWriter.writeName(ancillaryFieldName);
             }
-            node.render(jsonWriter);
+            node.render(jsonWriter, parameterBinder -> {});
             if (nodeKind != AstNodeKind.DOCUMENT) {
                 jsonWriter.writeEndDocument();
             }

--- a/src/test/java/com/mongodb/hibernate/internal/translate/mongoast/AstParameterMarkerTests.java
+++ b/src/test/java/com/mongodb/hibernate/internal/translate/mongoast/AstParameterMarkerTests.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2026-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.hibernate.internal.translate.mongoast;
+
+import static com.mongodb.hibernate.internal.translate.mongoast.AstNodeAssertions.assertValueRendering;
+
+import java.util.List;
+import org.hibernate.sql.exec.spi.JdbcParameterBinder;
+import org.junit.jupiter.api.Test;
+
+public class AstParameterMarkerTests {
+    private static JdbcParameterBinder binder() {
+        return (statement, startPosition, jdbcParameterBindings, executionContext) -> {};
+    }
+
+    @Test
+    void testRender() {
+        var binder = binder();
+        var expr = new AstParameterMarker(binder);
+        assertValueRendering("""
+                             {"": ?}""", List.of(binder), expr);
+    }
+}

--- a/src/test/java/com/mongodb/hibernate/internal/translate/mongoast/command/AstInsertCommandTests.java
+++ b/src/test/java/com/mongodb/hibernate/internal/translate/mongoast/command/AstInsertCommandTests.java
@@ -25,6 +25,7 @@ import com.mongodb.hibernate.internal.translate.mongoast.AstParameterMarker;
 import java.util.List;
 import org.bson.BsonInt32;
 import org.bson.BsonString;
+import org.hibernate.sql.exec.spi.JdbcParameterBinder;
 import org.junit.jupiter.api.Test;
 
 class AstInsertCommandTests {
@@ -37,13 +38,13 @@ class AstInsertCommandTests {
         var elements1 = List.of(
                 new AstElement("title", new AstLiteral(new BsonString("War and Peace"))),
                 new AstElement("year", new AstLiteral(new BsonInt32(1867))),
-                new AstElement("_id", AstParameterMarker.INSTANCE));
+                new AstElement("_id", new AstParameterMarker(JdbcParameterBinder.NOOP)));
         var document1 = new AstDocument(elements1);
 
         var elements2 = List.of(
                 new AstElement("title", new AstLiteral(new BsonString("Crime and Punishment"))),
                 new AstElement("year", new AstLiteral(new BsonInt32(1868))),
-                new AstElement("_id", AstParameterMarker.INSTANCE));
+                new AstElement("_id", new AstParameterMarker(JdbcParameterBinder.NOOP)));
         var document2 = new AstDocument(elements2);
 
         var insertCommand = new AstInsertCommand(collection, List.of(document1, document2));

--- a/src/test/java/com/mongodb/hibernate/internal/translate/mongoast/filter/AstAllFilterOperationTests.java
+++ b/src/test/java/com/mongodb/hibernate/internal/translate/mongoast/filter/AstAllFilterOperationTests.java
@@ -24,6 +24,7 @@ import com.mongodb.hibernate.internal.translate.mongoast.AstLiteral;
 import com.mongodb.hibernate.internal.translate.mongoast.AstParameterMarker;
 import java.util.List;
 import org.bson.BsonNull;
+import org.hibernate.sql.exec.spi.JdbcParameterBinder;
 import org.junit.jupiter.api.Test;
 
 class AstAllFilterOperationTests {
@@ -33,7 +34,7 @@ class AstAllFilterOperationTests {
                 () -> assertRendering(
                         """
                         {"$all": ?}""",
-                        new AstAllFilterOperation(AstParameterMarker.INSTANCE)),
+                        new AstAllFilterOperation(new AstParameterMarker(JdbcParameterBinder.NOOP))),
                 () -> assertRendering(
                         """
                         {"$all": [null]}""",


### PR DESCRIPTION
A JDBC parameter renders as BSON undefined and carries no identity into the emitted command. MongoPreparedStatement recovers the parameter positions by walking the parsed command depth-first, and Hibernate binds the i-th JdbcParameterBinder into the i-th of those positions. The binder list was built separately, in the order visitParameter ran, so the two orders were equal only by convention and nothing compared them. Permuting translated expressions, using one translated node in two positions, or collecting named arguments into a sorted map each broke the pairing, two of the three silently.

AstParameterMarker now carries its own binder and AstNode.render takes a Consumer<JdbcParameterBinder>, so the marker appends its binder in the same statement that writes the undefined. The binder list is produced by the rendering itself and the translator no longer accumulates one. Reordering, dropping and duplicating translated nodes are all correct as a result.