### PR TITLE
HIBERNATE-207: rename colliding join column in GROUP BY join test

### DIFF
--- a/src/integrationTest/java/com/mongodb/hibernate/query/select/GroupByQueryIntegrationTests.java
+++ b/src/integrationTest/java/com/mongodb/hibernate/query/select/GroupByQueryIntegrationTests.java
@@ -396,7 +396,7 @@ public class GroupByQueryIntegrationTests extends AbstractQueryIntegrationTests 
                         {
                           "$lookup": {
                             "from": "ItemB",
-                            "localField": "id",
+                            "localField": "itemBId",
                             "foreignField": "_id",
                             "as": "#ib1_0"
                           }
@@ -440,7 +440,7 @@ public class GroupByQueryIntegrationTests extends AbstractQueryIntegrationTests 
                         {
                           "$lookup": {
                             "from": "ItemB",
-                            "localField": "id",
+                            "localField": "itemBId",
                             "foreignField": "_id",
                             "as": "#ib1_0"
                           }
@@ -484,7 +484,7 @@ public class GroupByQueryIntegrationTests extends AbstractQueryIntegrationTests 
                         {
                           "$lookup": {
                             "from": "ItemB",
-                            "localField": "id",
+                            "localField": "itemBId",
                             "foreignField": "_id",
                             "as": "#ib1_0"
                           }
@@ -533,7 +533,7 @@ public class GroupByQueryIntegrationTests extends AbstractQueryIntegrationTests 
                         {
                           "$lookup": {
                             "from": "ItemB",
-                            "localField": "id",
+                            "localField": "itemBId",
                             "foreignField": "_id",
                             "as": "#ib1_0"
                           }
@@ -582,7 +582,7 @@ public class GroupByQueryIntegrationTests extends AbstractQueryIntegrationTests 
                         {
                           "$lookup": {
                             "from": "ItemB",
-                            "localField": "id",
+                            "localField": "itemBId",
                             "foreignField": "_id",
                             "as": "#ib1_0"
                           }
@@ -637,7 +637,7 @@ public class GroupByQueryIntegrationTests extends AbstractQueryIntegrationTests 
                         {
                           "$lookup": {
                             "from": "ItemB",
-                            "localField": "id",
+                            "localField": "itemBId",
                             "foreignField": "_id",
                             "as": "#ib1_0"
                           }
@@ -693,7 +693,7 @@ public class GroupByQueryIntegrationTests extends AbstractQueryIntegrationTests 
             int id;
 
             @ManyToOne(fetch = FetchType.LAZY)
-            @JoinColumn(name = "id")
+            @JoinColumn(name = "itemBId")
             ManyToOneJoin.ItemB itemB;
 
             ItemA() {}


### PR DESCRIPTION
The `forbidDerivedIdentity` guard added by HIBERNATE-207 rejects an entity whose `ToOne` column name overlaps an id column name. That made `GroupByQueryIntegrationTests.ManyToOneJoin` fail to boot on main, because `ItemA` declared `@JoinColumn(name = "id")` alongside `@Id int id`.

This renames the join column to `itemBId`, matching the convention in `JoinSelectQueryIntegrationTests`, and updates the six expected `localField` values.

The guard is over-broad for this shape. It runs before `setIdentifierColumnName`, so it compares pre-rename SQL column names; after the rename the identifier's column is `_id` while the association's is still `id`. They are distinct `Column` instances, both fields are written on insert, and the `$lookup` resolves correctly — which is why this test passed before the guard existed. Narrowing the guard to associations that do not own their columns is tracked by HIBERNATE-245.
