### PR TITLE
HIBERNATE-246: report authorized publication of release artifacts to papertrail

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -80,8 +80,9 @@ functions:
     - command: expansions.update
       params:
         file: src/ssdlc-expansions.yml
-    # The set Maven Central receives. papertrail.trace rejects two patterns matching the same
-    # basename, and the glob has no `**`.
+    # The set Maven Central receives, which the publish tasks mirror into build/repo. Signatures get
+    # their own checksums, and there is no sha256/sha512 because publish.sh publishes only md5 and sha1.
+    # The glob has no `**` and papertrail.trace rejects two patterns matching the same basename.
     - command: papertrail.trace
       params:
         key_id: ${papertrail_key_id}
@@ -90,21 +91,23 @@ functions:
         version: ${product_version}
         filenames:
           - src/build/repo/org/mongodb/*/*/*.jar
-          - src/build/repo/org/mongodb/*/*/*.jar.asc
-          - src/build/repo/org/mongodb/*/*/*.jar*.md5
-          - src/build/repo/org/mongodb/*/*/*.jar*.sha1
           - src/build/repo/org/mongodb/*/*/*.pom
-          - src/build/repo/org/mongodb/*/*/*.pom.asc
-          - src/build/repo/org/mongodb/*/*/*.pom*.md5
-          - src/build/repo/org/mongodb/*/*/*.pom*.sha1
+          - src/build/repo/org/mongodb/*/*/*.asc
+          - src/build/repo/org/mongodb/*/*/*.jar.md5
+          - src/build/repo/org/mongodb/*/*/*.pom.md5
+          - src/build/repo/org/mongodb/*/*/*.asc.md5
+          - src/build/repo/org/mongodb/*/*/*.jar.sha1
+          - src/build/repo/org/mongodb/*/*/*.pom.sha1
+          - src/build/repo/org/mongodb/*/*/*.asc.sha1
           - src/*/build/repo/org/mongodb/*/*/*.jar
-          - src/*/build/repo/org/mongodb/*/*/*.jar.asc
-          - src/*/build/repo/org/mongodb/*/*/*.jar*.md5
-          - src/*/build/repo/org/mongodb/*/*/*.jar*.sha1
           - src/*/build/repo/org/mongodb/*/*/*.pom
-          - src/*/build/repo/org/mongodb/*/*/*.pom.asc
-          - src/*/build/repo/org/mongodb/*/*/*.pom*.md5
-          - src/*/build/repo/org/mongodb/*/*/*.pom*.sha1
+          - src/*/build/repo/org/mongodb/*/*/*.asc
+          - src/*/build/repo/org/mongodb/*/*/*.jar.md5
+          - src/*/build/repo/org/mongodb/*/*/*.pom.md5
+          - src/*/build/repo/org/mongodb/*/*/*.asc.md5
+          - src/*/build/repo/org/mongodb/*/*/*.jar.sha1
+          - src/*/build/repo/org/mongodb/*/*/*.pom.sha1
+          - src/*/build/repo/org/mongodb/*/*/*.asc.sha1
 
   upload-test-results:
     - command: attach.xunit_results

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -66,6 +66,46 @@ functions:
         args:
           - ${DRIVERS_TOOLS}/.evergreen/stop-orchestration.sh
 
+  trace-artifacts:
+    - command: subprocess.exec
+      params:
+        working_dir: src
+        binary: bash
+        add_to_path:
+          - .evergreen
+        env:
+          PRODUCT_NAME: ${product_name}
+        args:
+          - ssdlc-expansions.sh
+    - command: expansions.update
+      params:
+        file: src/ssdlc-expansions.yml
+    # The set Maven Central receives. papertrail.trace rejects two patterns matching the same
+    # basename, and the glob has no `**`.
+    - command: papertrail.trace
+      params:
+        key_id: ${papertrail_key_id}
+        secret_key: ${papertrail_secret_key}
+        product: ${product_name}
+        version: ${product_version}
+        filenames:
+          - src/build/repo/org/mongodb/*/*/*.jar
+          - src/build/repo/org/mongodb/*/*/*.jar.asc
+          - src/build/repo/org/mongodb/*/*/*.jar*.md5
+          - src/build/repo/org/mongodb/*/*/*.jar*.sha1
+          - src/build/repo/org/mongodb/*/*/*.pom
+          - src/build/repo/org/mongodb/*/*/*.pom.asc
+          - src/build/repo/org/mongodb/*/*/*.pom*.md5
+          - src/build/repo/org/mongodb/*/*/*.pom*.sha1
+          - src/*/build/repo/org/mongodb/*/*/*.jar
+          - src/*/build/repo/org/mongodb/*/*/*.jar.asc
+          - src/*/build/repo/org/mongodb/*/*/*.jar*.md5
+          - src/*/build/repo/org/mongodb/*/*/*.jar*.sha1
+          - src/*/build/repo/org/mongodb/*/*/*.pom
+          - src/*/build/repo/org/mongodb/*/*/*.pom.asc
+          - src/*/build/repo/org/mongodb/*/*/*.pom*.md5
+          - src/*/build/repo/org/mongodb/*/*/*.pom*.sha1
+
   upload-test-results:
     - command: attach.xunit_results
       params:
@@ -171,6 +211,9 @@ tasks:
             RELEASE: "false"
           args:
             - .evergreen/publish.sh
+      - func: trace-artifacts
+        vars:
+          product_name: mongo-hibernate-snapshot
 
   - name: publish-release
     git_tag_only: true
@@ -189,6 +232,9 @@ tasks:
             RELEASE: "true"
           args:
             - .evergreen/publish.sh
+      - func: trace-artifacts
+        vars:
+          product_name: mongo-hibernate
 
 ########################################
 #              Axes                    #

--- a/.evergreen/ssdlc-expansions.sh
+++ b/.evergreen/ssdlc-expansions.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -o xtrace   # Write all commands first to stderr
+set -o errexit  # Exit the script with error if any of the commands fail
+
+############################################
+#            Main Program                  #
+############################################
+
+PRODUCT_NAME="${PRODUCT_NAME:?must be passed in from the calling function}"
+
+# Release tags are `r<version>`, stripped below.
+PRODUCT_VERSION="$(git describe --tags --always --dirty)"
+
+cat <<EOT >ssdlc-expansions.yml
+product_name: "${PRODUCT_NAME}"
+product_version: "${PRODUCT_VERSION#r}"
+EOT
+
+cat ssdlc-expansions.yml


### PR DESCRIPTION
Traces the published jar, pom, signature and checksum files from the publish-snapshot and publish-release Evergreen tasks, 24 per module.

Note that I scheduled the publish-snapshot task manually so you can see it in action.