### PR TITLE
HIBERNATE-247: analyze release refs with CodeQL

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,62 @@
+name: "CodeQL"
+
+on:
+  push:
+    # Release commits live on an A.B.x branch and are tagged there. The tag trigger is what
+    # gets the released commit analysed: bump-and-tag.sh tags between two version-bump
+    # commits, so the branch head is one commit past the tag.
+    branches: ["main", "*.x"]
+    tags: ["r*"]
+  pull_request:
+  schedule:
+    - cron: "17 10 * * 2"
+  workflow_call:
+    inputs:
+      ref:
+        required: true
+        type: string
+
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # A bare task name runs `classes` in the root project and in both Spring Boot
+          # subprojects, covering every published module. example-module is not in
+          # settings.gradle.kts, so it and all test sources stay out of the analysis.
+          - language: java-kotlin
+            build-mode: manual
+            manual-build-command: ./gradlew classes
+          - language: actions
+            build-mode: none
+
+    steps:
+      # The Gradle toolchain is pinned to 17 and settings.gradle.kts registers no toolchain
+      # resolver, so the JDK has to be on the runner already.
+      - if: matrix.language == 'java-kotlin'
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - uses: mongodb-labs/drivers-github-tools/codeql@2515c763d88282c570b47c895aa50e9e6f7ed32c # v3
+        with:
+          language: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          manual-build-command: ${{ matrix.manual-build-command }}
+          ref: ${{ inputs.ref }}
+          queries: security-extended

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -48,7 +48,7 @@ jobs:
       # The Gradle toolchain is pinned to 17 and settings.gradle.kts registers no toolchain
       # resolver, so the JDK has to be on the runner already.
       - if: matrix.language == 'java-kotlin'
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
         with:
           distribution: temurin
           java-version: 17


### PR DESCRIPTION
Replaces GitHub's default code-scanning setup with a workflow we own, ensuring that release commits
are analyzed. 

### Why

Default setup analyzed only `refs/heads/main` and `refs/pull/*`. No release tag or release
branch commit has been analyzed — e.g. the `r1.0.0-alpha1` tag commit was not scanned — so
exporting static analysis for a release, as required by DRIVERS-2894, would have nothing to
reference.

### Build mode

`java-kotlin` moves from GitHub's chosen `build-mode: none` to `manual` with `./gradlew
classes`.

### Query suite

`security-extended`, matching the action's default and the other drivers repos, rather than
default setup's `default` suite.

For reference, see https://github.com/mongodb/mongo-python-driver/blob/main/.github/workflows/codeql.yml

HIBERNATE-247