### PR TITLE
Pin secure-checkout by commit sha

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
       - name: "Create release output"
         run: echo "🎬 Release process for version $INPUTS_VERSION started by @$GITHUB_TRIGGERING_ACTOR" >> $GITHUB_STEP_SUMMARY
 
-      - uses: mongodb-labs/drivers-github-tools/secure-checkout@v2
+      - uses: mongodb-labs/drivers-github-tools/secure-checkout@e5bd985711c11e488b42488df376ecf1a9d7b7a4 # v2
         with:
           app_id: ${{ vars.APP_ID }}
           private_key: ${{ secrets.APP_PRIVATE_KEY }}


### PR DESCRIPTION
`release.yml` referenced `mongodb-labs/drivers-github-tools/secure-checkout@v2`, a mutable
major-version tag. It can be repointed without this workflow changing, so the code that checks
out the repository during a release could change silently and a given run could not be tied to
known action code.

Pinned to `e5bd985711c11e488b42488df376ecf1a9d7b7a4`, the commit `v2` currently resolves to,
with the version kept in a trailing comment. Deliberately not a bump to `v3`: that is a
behaviour change on the release checkout step and deserves its own review.

Found by CodeQL's `actions/unpinned-tag` while verifying #215. That rule is in
`actions-security-extended`, which #215 switches to, so this alert will surface once that
merges. Semgrep raised the same class of finding on #215 itself.

HIBERNATE-249