### PR TITLE
HIBERNATE-248: publish the SSDLC compliance report and CodeQL SARIF files

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -109,6 +109,66 @@ functions:
           - src/*/build/repo/org/mongodb/*/*/*.pom.sha1
           - src/*/build/repo/org/mongodb/*/*/*.asc.sha1
 
+  create-and-upload-SSDLC-release-assets:
+    # Reading code-scanning/analyses is 401 for anonymous callers even though the repository
+    # is public, so the task mints an installation token scoped to that one permission.
+    - command: github.generate_token
+      params:
+        owner: mongodb
+        repo: mongo-hibernate
+        expansion_name: ssdlc_github_token
+        permissions:
+          security_events: read
+    - command: subprocess.exec
+      params:
+        working_dir: src
+        binary: python3
+        env:
+          GITHUB_TOKEN: ${ssdlc_github_token}
+        args:
+          - .evergreen/download-codeql-sarifs.py
+    - command: subprocess.exec
+      params:
+        working_dir: src
+        binary: bash
+        add_to_path:
+          - .evergreen
+        env:
+          PRODUCT_NAME: ${product_name}
+          PRODUCT_VERSION: ${product_version}
+          EVERGREEN_VERSION_ID: ${version_id}
+        args:
+          - ssdlc-report.sh
+    - command: ec2.assume_role
+      params:
+        role_arn: ${UPLOAD_SSDLC_RELEASE_ASSETS_ROLE_ARN}
+    - command: s3.put
+      params:
+        aws_key: ${AWS_ACCESS_KEY_ID}
+        aws_secret: ${AWS_SECRET_ACCESS_KEY}
+        aws_session_token: ${AWS_SESSION_TOKEN}
+        local_file: ./src/build/ssdlc/ssdlc_compliance_report.md
+        remote_file: ${product_name}/${product_version}/ssdlc_compliance_report.md
+        bucket: java-driver-release-assets
+        region: us-west-1
+        permissions: private
+        content_type: text/markdown
+        display_name: "ssdlc_compliance_report.md"
+    - command: s3.put
+      params:
+        aws_key: ${AWS_ACCESS_KEY_ID}
+        aws_secret: ${AWS_SECRET_ACCESS_KEY}
+        aws_session_token: ${AWS_SESSION_TOKEN}
+        local_files_include_filter:
+          - build/ssdlc/static-analysis-reports/*.sarif
+        local_files_include_filter_prefix: ./src/
+        remote_file: ${product_name}/${product_version}/static-analysis-reports/
+        bucket: java-driver-release-assets
+        region: us-west-1
+        permissions: private
+        content_type: application/sarif+json
+        display_name: "static-analysis-reports/"
+
   upload-test-results:
     - command: attach.xunit_results
       params:
@@ -217,6 +277,7 @@ tasks:
       - func: trace-artifacts
         vars:
           product_name: mongo-hibernate-snapshot
+      - func: create-and-upload-SSDLC-release-assets
 
   - name: publish-release
     git_tag_only: true
@@ -238,6 +299,7 @@ tasks:
       - func: trace-artifacts
         vars:
           product_name: mongo-hibernate
+      - func: create-and-upload-SSDLC-release-assets
 
 ########################################
 #              Axes                    #

--- a/.evergreen/download-codeql-sarifs.py
+++ b/.evergreen/download-codeql-sarifs.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Downloads the CodeQL SARIF reports for the checked out commit, one per analysed language.
+
+Supported/used environment variables:
+GITHUB_TOKEN -- needs code scanning alerts read access; the analyses API is 401 for
+                anonymous callers even though this repository is public.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+GITHUB_REPO = "mongodb/mongo-hibernate"
+ANALYSES_URL = "https://api.github.com/repos/{}/code-scanning/analyses".format(GITHUB_REPO)
+# Every CodeQL run uploads one analysis per language, under these categories, so a commit has
+# one analysis per entry and an export needs all of them.
+CODEQL_CATEGORIES = ("/language:java-kotlin", "/language:actions")
+POLL_TIMEOUT_SECS = 900
+POLL_INTERVAL_SECS = 20
+OUTPUT_DIR = Path(__file__).resolve().parent.parent / "build" / "ssdlc" / "static-analysis-reports"
+
+
+def github_get(url, accept, token):
+    request = urllib.request.Request(
+        url,
+        headers={
+            "Authorization": "Bearer {}".format(token),
+            "X-GitHub-Api-Version": "2022-11-28",
+            "Accept": accept,
+        },
+    )
+    try:
+        with urllib.request.urlopen(request) as response:
+            return response.read()
+    except urllib.error.HTTPError as error:
+        sys.exit("GET {} returned {}: {}".format(url, error.code, error.read().decode("utf-8", "replace")))
+
+
+def select_analysis_id(analyses, commit_sha, category):
+    matching = [a for a in analyses if a["commit_sha"] == commit_sha and a["category"] == category]
+    if not matching:
+        return None
+    return max(matching, key=lambda a: a["created_at"])["id"]
+
+
+def wait_for_analyses(commit_sha, token):
+    """Returns the newest analysis id per category, once every category has one."""
+    print("\nWaiting for CodeQL analyses of {}".format(commit_sha))
+    waited_secs = 0
+    while True:
+        analyses = json.loads(
+            github_get(ANALYSES_URL + "?per_page=100", "application/vnd.github+json", token)
+        )
+        analysis_ids = {
+            category: select_analysis_id(analyses, commit_sha, category)
+            for category in CODEQL_CATEGORIES
+        }
+        for category, analysis_id in analysis_ids.items():
+            print("{}: {}".format(category, analysis_id or "not yet uploaded"))
+        if all(analysis_ids.values()):
+            return analysis_ids
+        if waited_secs >= POLL_TIMEOUT_SECS:
+            sys.exit(
+                "\nERROR: gave up after {}s waiting for the CodeQL analyses of {}".format(
+                    waited_secs, commit_sha
+                )
+            )
+        time.sleep(POLL_INTERVAL_SECS)
+        waited_secs += POLL_INTERVAL_SECS
+
+
+def assert_sarif(sarif, commit_sha, language):
+    runs = sarif["runs"]
+    automation_ids = [run.get("automationDetails", {}).get("id", "") for run in runs]
+    if not any(language in automation_id for automation_id in automation_ids):
+        sys.exit("no run for language {}, automationDetails ids are {}".format(language, automation_ids))
+    revisions = [
+        provenance.get("revisionId")
+        for run in runs
+        for provenance in run.get("versionControlProvenance", [])
+    ]
+    if revisions and commit_sha not in revisions:
+        sys.exit("analysed revisions {} do not include {}".format(revisions, commit_sha))
+
+
+def main():
+    token = os.environ.get("GITHUB_TOKEN")
+    if not token:
+        sys.exit("GITHUB_TOKEN must be set to a non-empty string")
+    commit_sha = subprocess.check_output(["git", "rev-parse", "HEAD"]).decode().strip()
+
+    # Evergreen and the CodeQL workflow react to the same push concurrently, so the analyses
+    # of the commit being published do not exist yet when this task starts.
+    analysis_ids = wait_for_analyses(commit_sha, token)
+
+    print("\nDownloading CodeQL SARIF reports")
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    for category, analysis_id in analysis_ids.items():
+        language = category[len("/language:"):]
+        sarif = github_get(
+            "{}/{}".format(ANALYSES_URL, analysis_id), "application/sarif+json", token
+        )
+        assert_sarif(json.loads(sarif), commit_sha, language)
+        sarif_path = OUTPUT_DIR / "codeql_{}.sarif".format(language)
+        sarif_path.write_bytes(sarif)
+        print("{} ({} bytes)".format(sarif_path, sarif_path.stat().st_size))
+
+
+if __name__ == "__main__":
+    main()

--- a/.evergreen/ssdlc-report.sh
+++ b/.evergreen/ssdlc-report.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+
+set -eu
+
+# Supported/used environment variables:
+# PRODUCT_NAME
+# PRODUCT_VERSION
+# EVERGREEN_VERSION_ID
+
+if [ -z "${PRODUCT_NAME}" ]; then
+    printf "\nPRODUCT_NAME must be set to a non-empty string\n"
+    exit 1
+fi
+if [ -z "${PRODUCT_VERSION}" ]; then
+    printf "\nPRODUCT_VERSION must be set to a non-empty string\n"
+    exit 1
+fi
+if [ -z "${EVERGREEN_VERSION_ID}" ]; then
+    printf "\nEVERGREEN_VERSION_ID must be set to a non-empty string\n"
+    exit 1
+fi
+
+############################################
+#            Main Program                  #
+############################################
+RELATIVE_DIR_PATH="$(dirname "${BASH_SOURCE[0]:-$0}")"
+
+printf "\nCreating SSDLC reports\n"
+printf "\nProduct name: %s\n" "${PRODUCT_NAME}"
+printf "\nProduct version: %s\n" "${PRODUCT_VERSION}"
+
+declare -r SSDLC_PATH="${RELATIVE_DIR_PATH}/../build/ssdlc"
+mkdir -p "${SSDLC_PATH}"
+
+declare -r EVERGREEN_PROJECT_NAME_PREFIX="${PRODUCT_NAME//-/_}"
+declare -r EVERGREEN_BUILD_URL_PREFIX="https://spruce.mongodb.com/version"
+declare -r GIT_TAG="r${PRODUCT_VERSION}"
+GIT_COMMIT_HASH="$(git rev-list --ignore-missing -n 1 "${GIT_TAG}")"
+set +e
+    GIT_BRANCH_DEFAULT="$(git branch -a --contains "${GIT_TAG}" 2>/dev/null | grep 'main$')"
+    GIT_BRANCH_PATCH="$(git branch -a --contains "${GIT_TAG}" 2>/dev/null | grep '\.x$')"
+set -e
+# On a snapshot PRODUCT_VERSION is `git describe` output, which git resolves as a rev, so the
+# tag-based branches below cannot tell it apart from a release. Snapshots are matched first.
+if [[ "${PRODUCT_NAME}" == *'-snapshot' ]]; then
+    declare -r EVERGREEN_BUILD_URL="${EVERGREEN_BUILD_URL_PREFIX}/${EVERGREEN_VERSION_ID}"
+elif [ -n "${GIT_BRANCH_DEFAULT}" ]; then
+    declare -r EVERGREEN_BUILD_URL="${EVERGREEN_BUILD_URL_PREFIX}/${EVERGREEN_PROJECT_NAME_PREFIX}_${GIT_COMMIT_HASH}"
+elif [ -n "${GIT_BRANCH_PATCH}" ]; then
+    # A maintenance-branch project is named A.B, without the patch version.
+    declare -r EVERGREEN_PROJECT_NAME_SUFFIX="${PRODUCT_VERSION%.*}"
+    declare -r EVERGREEN_BUILD_URL="${EVERGREEN_BUILD_URL_PREFIX}/${EVERGREEN_PROJECT_NAME_PREFIX}_${EVERGREEN_PROJECT_NAME_SUFFIX}_${GIT_COMMIT_HASH}"
+else
+    printf "\nFailed to compute EVERGREEN_BUILD_URL\n"
+    exit 1
+fi
+printf "\nEvergreen build URL: %s\n" "${EVERGREEN_BUILD_URL}"
+
+ANALYSED_COMMIT_SHA="$(git rev-parse HEAD)"
+printf "\nAnalysed commit: %s\n" "${ANALYSED_COMMIT_SHA}"
+
+# HEAD is the commit being published, and on a release it is the tagged commit, so this is the
+# author of the release commit.
+PRODUCT_RELEASE_CREATOR="$(git log -1 --pretty='format:%aN' "${ANALYSED_COMMIT_SHA}")"
+printf "\nProduct release creator: %s\n" "${PRODUCT_RELEASE_CREATOR}"
+if [ -z "${PRODUCT_RELEASE_CREATOR}" ]; then
+    printf "\nFailed to determine the product release creator\n"
+    exit 1
+fi
+
+printf "\nCreating SSDLC compliance report\n"
+declare -r TEMPLATE_SSDLC_REPORT_PATH="${RELATIVE_DIR_PATH}/template_ssdlc_compliance_report.md"
+declare -r SSDLC_REPORT_PATH="${SSDLC_PATH}/ssdlc_compliance_report.md"
+cp "${TEMPLATE_SSDLC_REPORT_PATH}" "${SSDLC_REPORT_PATH}"
+declare -a SED_EDIT_IN_PLACE_OPTION
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    SED_EDIT_IN_PLACE_OPTION=(-i '')
+else
+    SED_EDIT_IN_PLACE_OPTION=(-i)
+fi
+sed "${SED_EDIT_IN_PLACE_OPTION[@]}" \
+    -e "s/\${product_name}/${PRODUCT_NAME}/g" \
+    -e "s/\${product_version}/${PRODUCT_VERSION}/g" \
+    -e "s/\${report_date_utc}/$(date -u +%Y-%m-%d)/g" \
+    -e "s/\${product_release_creator}/${PRODUCT_RELEASE_CREATOR}/g" \
+    -e "s/\${analysed_commit_sha}/${ANALYSED_COMMIT_SHA}/g" \
+    -e "s>\${evergreen_build_url}>${EVERGREEN_BUILD_URL}>g" \
+    "${SSDLC_REPORT_PATH}"
+if grep -q '\${' "${SSDLC_REPORT_PATH}"; then
+    printf "\nERROR: unsubstituted placeholders remain in %s\n" "${SSDLC_REPORT_PATH}"
+    grep -n '\${' "${SSDLC_REPORT_PATH}"
+    exit 1
+fi
+printf "%s\n" "${SSDLC_REPORT_PATH}"
+
+printf "\n"

--- a/.evergreen/template_ssdlc_compliance_report.md
+++ b/.evergreen/template_ssdlc_compliance_report.md
@@ -1,0 +1,67 @@
+# ${product_name} SSDLC compliance report
+
+This report is available at
+<https://d-9067613a84.awsapps.com/start/#/console?account_id=857654397073&role_name=Drivers.User&destination=https%3a%2f%2fus-west-1.console.aws.amazon.com%2fs3%2fobject%2fjava-driver-release-assets%3fregion%3dus-west-1%26bucketType%3dgeneral%26prefix%3d${product_name}%2f${product_version}%2fssdlc_compliance_report.md>.
+
+<table>
+  <tr>
+    <th>Product name</th>
+    <td><a href="https://github.com/mongodb/mongo-hibernate">${product_name}</a></td>
+  </tr>
+  <tr>
+    <th>Product version</th>
+    <td>${product_version}</td>
+  </tr>
+  <tr>
+    <th>Release creator</th>
+    <td>
+        ${product_release_creator}
+        <p>
+            Refer to data in Papertrail for more details.
+            There is currently no official way to serve that data.
+        </p>
+    </td>
+  </tr>
+  <tr>
+    <th>Report date, UTC</th>
+    <td>${report_date_utc}</td>
+  </tr>
+</table>
+
+## Process document
+
+Blocked on <https://jira.mongodb.org/browse/JAVA-5429>.
+
+The MongoDB SSDLC policy is available at
+<https://docs.google.com/document/d/1u0m4Kj2Ny30zU74KoEFCN4L6D_FbEYCaJ3CQdCYXTMc>.
+
+## Third-party dependency information
+
+This product depends on Hibernate ORM and the MongoDB Java driver, and its Spring Boot
+starter modules depend on Spring Boot.
+Our [SBOM](https://docs.devprod.prod.corp.mongodb.com/mms/python/src/sbom/silkbomb/docs/CYCLONEDX/) lite
+is <https://github.com/mongodb/mongo-hibernate/blob/r${product_version}/sbom.json>.
+
+## Static analysis findings
+
+The static analysis findings are available at
+<https://d-9067613a84.awsapps.com/start/#/console?account_id=857654397073&role_name=Drivers.User&destination=https%3a%2f%2fus-west-1.console.aws.amazon.com%2fs3%2fbuckets%2fjava-driver-release-assets%3fregion%3dus-west-1%26bucketType%3dgeneral%26prefix%3d${product_name}%2f${product_version}%2fstatic-analysis-reports%2f>.
+They are the CodeQL SARIF exports for commit ${analysed_commit_sha}, one for the Java sources
+and one for the GitHub Actions workflows.
+Each export lists every alert CodeQL reported for that commit.
+Alerts that are neither fixed nor open are dismissed in code scanning with a recorded reason,
+which is visible at <https://github.com/mongodb/mongo-hibernate/security/code-scanning>.
+
+## Security testing results
+
+The testing results are available at
+<${evergreen_build_url}>.
+
+That build runs the unit, integration and smoke test suites against MongoDB replica sets on
+every supported server version.
+
+## Signature information
+
+The product artifacts are signed.
+The signatures can be verified by following instructions at
+<https://github.com/mongodb/mongo-hibernate/releases/tag/r${product_version}>.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,7 +17,9 @@ on:
         type: string
 
 concurrency:
-  group: codeql-${{ github.ref }}
+  # A release or snapshot publish waits for the analyses of the exact commit it publishes, so
+  # every commit needs a group of its own. Cancellation then deduplicates runs of one commit.
+  group: codeql-${{ github.ref }}-${{ github.sha }}
   cancel-in-progress: true
 
 permissions:


### PR DESCRIPTION
Adds the two SSDLC release assets to publish-snapshot and publish-release, uploaded to the release-assets bucket alongside the papertrail trace.

download-codeql-sarifs.py polls the code-scanning analyses API for the commit being published until every CodeQL category has an analysis, then downloads and validates each SARIF. Evergreen and the CodeQL workflow react to the same push concurrently, so a lookup without polling may find nothing and upload an empty directory. The script fails the task instead.

ssdlc-report.sh renders template_ssdlc_compliance_report.md, ported from mongo-java-driver. The findings section describes CodeQL alerts and where their dismissal reasons live, and the dependency section lists Hibernate ORM, the Java driver and Spring Boot. The release creator comes from HEAD, which is the published commit on both paths; deriving it from the version leaves the field blank whenever git describe reports a dirty tree.

Keys the CodeQL concurrency group on the commit as well as the ref, giving every commit a group of its own so that its analysis run survives whatever lands next. A publish task waits for the analyses of the exact commit it publishes, and while all of main shared one group, the next push cancelled that run and left the task to fail on its poll timeout. Cancellation now only collapses two runs of the same commit.