### PR TITLE
HIBERNATE-250: identify a query parameter across its occurrences in AstParameterMarker equality

### DIFF
--- a/src/main/java/com/mongodb/hibernate/internal/translate/AbstractMqlTranslator.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/AbstractMqlTranslator.java
@@ -557,7 +557,7 @@ public abstract class AbstractMqlTranslator<T extends JdbcOperation> implements 
     @Override
     public void visitParameter(JdbcParameter jdbcParameter) {
         yieldValueOrExpression(
-                new AstParameterMarker(jdbcParameter.getParameterBinder()),
+                new AstParameterMarker(jdbcParameter.getParameterBinder(), jdbcParameter.getParameterId()),
                 parameterNeedsLiteralWrapping(jdbcParameter));
     }
 
@@ -1258,7 +1258,8 @@ public abstract class AbstractMqlTranslator<T extends JdbcOperation> implements 
                 var parameter =
                         new ColumnValueParameter(new ColumnReference(mutatingTable, aggregate), ParameterUsage.SET);
                 updates.add(new AstFieldUpdate(
-                        aggregate.getSelectionExpression(), new AstParameterMarker(parameter.getParameterBinder())));
+                        aggregate.getSelectionExpression(),
+                        new AstParameterMarker(parameter.getParameterBinder(), parameter.getParameterId())));
             }
         }
         return updates;

--- a/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/AstParameterMarker.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/AstParameterMarker.java
@@ -19,17 +19,44 @@ package com.mongodb.hibernate.internal.translate.mongoast;
 import java.util.function.Consumer;
 import org.bson.BsonWriter;
 import org.hibernate.sql.exec.spi.JdbcParameterBinder;
+import org.jspecify.annotations.Nullable;
 
 /**
+ * @param parameterId {@link org.hibernate.sql.ast.tree.expression.JdbcParameter#getParameterId()} of the parameter this
+ *     marker stands for, or {@code null} where Hibernate supplies none.
  * @see org.hibernate.cfg.AvailableSettings#DIALECT_NATIVE_PARAM_MARKERS
  * @hidden
  */
 @SuppressWarnings("MissingSummary")
-public record AstParameterMarker(JdbcParameterBinder binder) implements AstValue {
+public record AstParameterMarker(
+        JdbcParameterBinder binder, @Nullable Integer parameterId) implements AstValue {
 
     @Override
     public void render(BsonWriter writer, Consumer<JdbcParameterBinder> binderConsumer) {
         writer.writeUndefined();
         binderConsumer.accept(binder);
+    }
+
+    /**
+     * Two markers stand for the same query parameter when Hibernate assigned them the same parameter id: one query
+     * parameter occurring in several clauses yields a separate {@code JdbcParameter} node, with its own binder, per
+     * occurrence. Where an id is absent, distinct parameters must not be conflated, so those markers compare by binder
+     * identity.
+     */
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof AstParameterMarker other)) {
+            return false;
+        }
+        if (parameterId == null || other.parameterId == null) {
+            return parameterId == null && other.parameterId == null && binder == other.binder;
+        } else {
+            return parameterId.equals(other.parameterId);
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        return parameterId != null ? parameterId.hashCode() : System.identityHashCode(binder);
     }
 }

--- a/src/test/java/com/mongodb/hibernate/internal/translate/AstVisitorValueHolderTests.java
+++ b/src/test/java/com/mongodb/hibernate/internal/translate/AstVisitorValueHolderTests.java
@@ -58,7 +58,7 @@ class AstVisitorValueHolderTests {
 
         Runnable tableInserter = () -> {
             Runnable fieldValueYielder = () -> {
-                astVisitorValueHolder.yield(VALUE, new AstParameterMarker(JdbcParameterBinder.NOOP, null));
+                astVisitorValueHolder.yield(VALUE, new AstParameterMarker(JdbcParameterBinder.NOOP, 0));
             };
             var fieldValue = astVisitorValueHolder.execute(VALUE, fieldValueYielder);
             AstElement astElement = new AstElement("province", fieldValue);

--- a/src/test/java/com/mongodb/hibernate/internal/translate/AstVisitorValueHolderTests.java
+++ b/src/test/java/com/mongodb/hibernate/internal/translate/AstVisitorValueHolderTests.java
@@ -58,7 +58,7 @@ class AstVisitorValueHolderTests {
 
         Runnable tableInserter = () -> {
             Runnable fieldValueYielder = () -> {
-                astVisitorValueHolder.yield(VALUE, new AstParameterMarker(JdbcParameterBinder.NOOP));
+                astVisitorValueHolder.yield(VALUE, new AstParameterMarker(JdbcParameterBinder.NOOP, null));
             };
             var fieldValue = astVisitorValueHolder.execute(VALUE, fieldValueYielder);
             AstElement astElement = new AstElement("province", fieldValue);

--- a/src/test/java/com/mongodb/hibernate/internal/translate/ParameterBinderCollectionTests.java
+++ b/src/test/java/com/mongodb/hibernate/internal/translate/ParameterBinderCollectionTests.java
@@ -37,8 +37,8 @@ class ParameterBinderCollectionTests {
         var second = binder();
 
         var document = new AstDocument(List.of(
-                new AstElement("a", new AstParameterMarker(second, null)),
-                new AstElement("b", new AstParameterMarker(first, null))));
+                new AstElement("a", new AstParameterMarker(second, 0)),
+                new AstElement("b", new AstParameterMarker(first, 1))));
         assertValueRendering("""
                 {"": {"a": ?, "b": ?}}""", List.of(second, first), document);
     }
@@ -46,7 +46,7 @@ class ParameterBinderCollectionTests {
     @Test
     void testMarkerRenderedTwiceContributesTwoBinders() {
         var shared = binder();
-        var marker = new AstParameterMarker(shared, null);
+        var marker = new AstParameterMarker(shared, 0);
 
         var document = new AstDocument(List.of(new AstElement("a", marker), new AstElement("b", marker)));
         assertValueRendering("""

--- a/src/test/java/com/mongodb/hibernate/internal/translate/ParameterBinderCollectionTests.java
+++ b/src/test/java/com/mongodb/hibernate/internal/translate/ParameterBinderCollectionTests.java
@@ -37,8 +37,8 @@ class ParameterBinderCollectionTests {
         var second = binder();
 
         var document = new AstDocument(List.of(
-                new AstElement("a", new AstParameterMarker(second)),
-                new AstElement("b", new AstParameterMarker(first))));
+                new AstElement("a", new AstParameterMarker(second, null)),
+                new AstElement("b", new AstParameterMarker(first, null))));
         assertValueRendering("""
                 {"": {"a": ?, "b": ?}}""", List.of(second, first), document);
     }
@@ -46,7 +46,7 @@ class ParameterBinderCollectionTests {
     @Test
     void testMarkerRenderedTwiceContributesTwoBinders() {
         var shared = binder();
-        var marker = new AstParameterMarker(shared);
+        var marker = new AstParameterMarker(shared, null);
 
         var document = new AstDocument(List.of(new AstElement("a", marker), new AstElement("b", marker)));
         assertValueRendering("""

--- a/src/test/java/com/mongodb/hibernate/internal/translate/mongoast/AstParameterMarkerTests.java
+++ b/src/test/java/com/mongodb/hibernate/internal/translate/mongoast/AstParameterMarkerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026-present MongoDB, Inc.
+ * Copyright 2025-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,21 +17,66 @@
 package com.mongodb.hibernate.internal.translate.mongoast;
 
 import static com.mongodb.hibernate.internal.translate.mongoast.AstNodeAssertions.assertValueRendering;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 import org.hibernate.sql.exec.spi.JdbcParameterBinder;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 public class AstParameterMarkerTests {
+
+    // Captures so that each call yields a distinct instance: a non-capturing lambda may be shared by the JVM.
     private static JdbcParameterBinder binder() {
-        return (statement, startPosition, jdbcParameterBindings, executionContext) -> {};
+        var distinct = new Object();
+        return (statement, startPosition, jdbcParameterBindings, executionContext) -> distinct.hashCode();
     }
 
     @Test
     void testRender() {
         var binder = binder();
-        var expr = new AstParameterMarker(binder);
+        var expr = new AstParameterMarker(binder, null);
         assertValueRendering("""
                              {"": ?}""", List.of(binder), expr);
+    }
+
+    @Nested
+    class Equality {
+        @Test
+        void testEqualWhenParameterIdMatchesDespiteDifferentBinders() {
+            var marker = new AstParameterMarker(binder(), 1);
+            var other = new AstParameterMarker(binder(), 1);
+            assertThat(marker).isEqualTo(other).hasSameHashCodeAs(other);
+        }
+
+        @Test
+        void testNotEqualWhenParameterIdDiffers() {
+            assertThat(new AstParameterMarker(binder(), 1)).isNotEqualTo(new AstParameterMarker(binder(), 2));
+        }
+
+        @Test
+        void testEqualWithoutParameterIdWhenBinderIsSame() {
+            var binder = binder();
+            var marker = new AstParameterMarker(binder, null);
+            var other = new AstParameterMarker(binder, null);
+            assertThat(marker).isEqualTo(other).hasSameHashCodeAs(other);
+        }
+
+        @Test
+        void testNotEqualWithoutParameterIdWhenBinderDiffers() {
+            assertThat(new AstParameterMarker(binder(), null)).isNotEqualTo(new AstParameterMarker(binder(), null));
+        }
+
+        @Test
+        void testNotEqualWhenOnlyOneHasParameterId() {
+            var binder = binder();
+            assertThat(new AstParameterMarker(binder, 1)).isNotEqualTo(new AstParameterMarker(binder, null));
+        }
+
+        @Test
+        void testEqualToItselfWithoutParameterId() {
+            var marker = new AstParameterMarker(binder(), null);
+            assertThat(marker).isEqualTo(marker);
+        }
     }
 }

--- a/src/test/java/com/mongodb/hibernate/internal/translate/mongoast/AstParameterMarkerTests.java
+++ b/src/test/java/com/mongodb/hibernate/internal/translate/mongoast/AstParameterMarkerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025-present MongoDB, Inc.
+ * Copyright 2026-present MongoDB, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/mongodb/hibernate/internal/translate/mongoast/AstParameterMarkerTests.java
+++ b/src/test/java/com/mongodb/hibernate/internal/translate/mongoast/AstParameterMarkerTests.java
@@ -35,7 +35,7 @@ public class AstParameterMarkerTests {
     @Test
     void testRender() {
         var binder = binder();
-        var expr = new AstParameterMarker(binder, null);
+        var expr = new AstParameterMarker(binder, 0);
         assertValueRendering("""
                              {"": ?}""", List.of(binder), expr);
     }

--- a/src/test/java/com/mongodb/hibernate/internal/translate/mongoast/command/AstInsertCommandTests.java
+++ b/src/test/java/com/mongodb/hibernate/internal/translate/mongoast/command/AstInsertCommandTests.java
@@ -38,13 +38,13 @@ class AstInsertCommandTests {
         var elements1 = List.of(
                 new AstElement("title", new AstLiteral(new BsonString("War and Peace"))),
                 new AstElement("year", new AstLiteral(new BsonInt32(1867))),
-                new AstElement("_id", new AstParameterMarker(JdbcParameterBinder.NOOP)));
+                new AstElement("_id", new AstParameterMarker(JdbcParameterBinder.NOOP, null)));
         var document1 = new AstDocument(elements1);
 
         var elements2 = List.of(
                 new AstElement("title", new AstLiteral(new BsonString("Crime and Punishment"))),
                 new AstElement("year", new AstLiteral(new BsonInt32(1868))),
-                new AstElement("_id", new AstParameterMarker(JdbcParameterBinder.NOOP)));
+                new AstElement("_id", new AstParameterMarker(JdbcParameterBinder.NOOP, null)));
         var document2 = new AstDocument(elements2);
 
         var insertCommand = new AstInsertCommand(collection, List.of(document1, document2));

--- a/src/test/java/com/mongodb/hibernate/internal/translate/mongoast/command/AstInsertCommandTests.java
+++ b/src/test/java/com/mongodb/hibernate/internal/translate/mongoast/command/AstInsertCommandTests.java
@@ -38,13 +38,13 @@ class AstInsertCommandTests {
         var elements1 = List.of(
                 new AstElement("title", new AstLiteral(new BsonString("War and Peace"))),
                 new AstElement("year", new AstLiteral(new BsonInt32(1867))),
-                new AstElement("_id", new AstParameterMarker(JdbcParameterBinder.NOOP, null)));
+                new AstElement("_id", new AstParameterMarker(JdbcParameterBinder.NOOP, 0)));
         var document1 = new AstDocument(elements1);
 
         var elements2 = List.of(
                 new AstElement("title", new AstLiteral(new BsonString("Crime and Punishment"))),
                 new AstElement("year", new AstLiteral(new BsonInt32(1868))),
-                new AstElement("_id", new AstParameterMarker(JdbcParameterBinder.NOOP, null)));
+                new AstElement("_id", new AstParameterMarker(JdbcParameterBinder.NOOP, 1)));
         var document2 = new AstDocument(elements2);
 
         var insertCommand = new AstInsertCommand(collection, List.of(document1, document2));

--- a/src/test/java/com/mongodb/hibernate/internal/translate/mongoast/filter/AstAllFilterOperationTests.java
+++ b/src/test/java/com/mongodb/hibernate/internal/translate/mongoast/filter/AstAllFilterOperationTests.java
@@ -34,7 +34,7 @@ class AstAllFilterOperationTests {
                 () -> assertRendering(
                         """
                         {"$all": ?}""",
-                        new AstAllFilterOperation(new AstParameterMarker(JdbcParameterBinder.NOOP))),
+                        new AstAllFilterOperation(new AstParameterMarker(JdbcParameterBinder.NOOP, null))),
                 () -> assertRendering(
                         """
                         {"$all": [null]}""",

--- a/src/test/java/com/mongodb/hibernate/internal/translate/mongoast/filter/AstAllFilterOperationTests.java
+++ b/src/test/java/com/mongodb/hibernate/internal/translate/mongoast/filter/AstAllFilterOperationTests.java
@@ -34,7 +34,7 @@ class AstAllFilterOperationTests {
                 () -> assertRendering(
                         """
                         {"$all": ?}""",
-                        new AstAllFilterOperation(new AstParameterMarker(JdbcParameterBinder.NOOP, null))),
+                        new AstAllFilterOperation(new AstParameterMarker(JdbcParameterBinder.NOOP, 0))),
                 () -> assertRendering(
                         """
                         {"$all": [null]}""",


### PR DESCRIPTION
Hibernate allocates a separate JdbcParameter per occurrence of a query parameter, so binder identity cannot tell one parameter used twice from two different parameters. JdbcParameter#getParameterId(), on the public SQL AST interface, is the same for every occurrence of one parameter, so the marker carries it and equality compares ids when both are present, falling back to binder identity when either is absent. The fallback keeps equals reflexive, which "a null id never matches" would not.

Structural equality of translated expressions reduces to marker equality, so this is a prerequisite for matching a GROUP BY expression against its occurrences in SELECT, HAVING, and ORDER BY.

HIBERNATE-250