### PR TITLE
HIBERNATE-224: unwrap domain values in @Struct fields and HQL literals

### DIFF
--- a/src/integrationTest/java/com/mongodb/hibernate/embeddable/StructAggregateEmbeddableIntegrationTests.java
+++ b/src/integrationTest/java/com/mongodb/hibernate/embeddable/StructAggregateEmbeddableIntegrationTests.java
@@ -36,7 +36,6 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import java.math.BigDecimal;
-import java.sql.SQLFeatureNotSupportedException;
 import java.time.Instant;
 import java.util.Collection;
 import java.util.HashSet;
@@ -63,7 +62,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
             StructAggregateEmbeddableIntegrationTests.ItemWithNestedValueHavingArraysAndCollections.class,
             StructAggregateEmbeddableIntegrationTests.Unsupported.ItemWithNestedValueHavingNonInsertable.class,
             StructAggregateEmbeddableIntegrationTests.Unsupported.ItemWithNestedValueHavingNonUpdatable.class,
-            StructAggregateEmbeddableIntegrationTests.Unsupported.ItemWithNestedValueHavingEmbeddable.class
+            StructAggregateEmbeddableIntegrationTests.ItemWithNestedValueHavingEmbeddable.class
         })
 @ExtendWith(MongoExtension.class)
 public class StructAggregateEmbeddableIntegrationTests
@@ -533,6 +532,42 @@ public class StructAggregateEmbeddableIntegrationTests
         assertEq(expectedItem, loadedItem);
     }
 
+    /**
+     * A flattened {@code @Embeddable} contributes its columns to the enclosing {@code @Struct} one, so it lands as
+     * fields of the same subdocument.
+     */
+    @Test
+    void testNestedValueHavingFlattenedEmbeddable() {
+        var item = new ItemWithNestedValueHavingEmbeddable(
+                1, new SingleHavingEmbeddable(new EmbeddableIntegrationTests.Single(2)));
+        sessionFactoryScope.inTransaction(session -> session.persist(item));
+        assertCollectionContainsExactly("""
+                                        {_id: 1, nested: {a: 2}}""");
+        var loadedItem = sessionFactoryScope.fromTransaction(
+                session -> session.find(ItemWithNestedValueHavingEmbeddable.class, item.id));
+        assertEq(item, loadedItem);
+    }
+
+    @Entity
+    @Table(name = COLLECTION_NAME)
+    static class ItemWithNestedValueHavingEmbeddable {
+        @Id
+        int id;
+
+        SingleHavingEmbeddable nested;
+
+        ItemWithNestedValueHavingEmbeddable() {}
+
+        ItemWithNestedValueHavingEmbeddable(int id, SingleHavingEmbeddable nested) {
+            this.id = id;
+            this.nested = nested;
+        }
+    }
+
+    @Embeddable
+    @Struct(name = "SingleHavingEmbeddable")
+    record SingleHavingEmbeddable(EmbeddableIntegrationTests.Single flattened) {}
+
     private void assertCollectionContainsExactly(String documentAsJsonObject) {
         assertThat(mongoCollection.find()).containsExactly(BsonDocument.parse(documentAsJsonObject));
     }
@@ -784,14 +819,6 @@ public class StructAggregateEmbeddableIntegrationTests
         }
 
         @Test
-        void testEmbeddable() {
-            var item = new ItemWithNestedValueHavingEmbeddable(
-                    1, new SingleHavingEmbeddable(new EmbeddableIntegrationTests.Single(2)));
-            assertThatThrownBy(() -> sessionFactoryScope.inTransaction(session -> session.persist(item)))
-                    .hasRootCauseInstanceOf(SQLFeatureNotSupportedException.class);
-        }
-
-        @Test
         void testNoPersistentAttributes() {
             assertThatThrownBy(() -> new MetadataSources()
                             .addAnnotatedClass(ItemWithNestedValueHavingNoPersistentAttributes.class)
@@ -895,24 +922,6 @@ public class StructAggregateEmbeddableIntegrationTests
                 this.a = a;
             }
         }
-
-        @Entity
-        @Table(name = COLLECTION_NAME)
-        static class ItemWithNestedValueHavingEmbeddable {
-            @Id
-            int id;
-
-            SingleHavingEmbeddable nested;
-
-            ItemWithNestedValueHavingEmbeddable(int id, SingleHavingEmbeddable nested) {
-                this.id = id;
-                this.nested = nested;
-            }
-        }
-
-        @Embeddable
-        @Struct(name = "SingleHavingEmbeddable")
-        record SingleHavingEmbeddable(EmbeddableIntegrationTests.Single flattened) {}
 
         @Entity
         @Table(name = COLLECTION_NAME)

--- a/src/integrationTest/java/com/mongodb/hibernate/query/select/QueryLiteralConstants.java
+++ b/src/integrationTest/java/com/mongodb/hibernate/query/select/QueryLiteralConstants.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2025-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.hibernate.query.select;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import org.bson.types.ObjectId;
+
+/**
+ * Holds one constant per supported scalar type, referenced by fully-qualified name in HQL. A static field reference is
+ * what produces a literal of an arbitrary type; numeric HQL literals such as {@code 1L} take a different translator
+ * path.
+ */
+public final class QueryLiteralConstants {
+
+    public static final String STRING = "War & Peace";
+    public static final Character CHARACTER = 'c';
+    public static final int INT = 42;
+    public static final long LONG = 43L;
+    public static final double DOUBLE = 4.5;
+    public static final boolean BOOLEAN = true;
+    public static final BigDecimal BIG_DECIMAL = new BigDecimal("4.25");
+    public static final ObjectId OBJECT_ID = new ObjectId("000000000000000000000001");
+    public static final Instant INSTANT = Instant.parse("2025-01-04T10:05:01Z");
+
+    private QueryLiteralConstants() {}
+}

--- a/src/integrationTest/java/com/mongodb/hibernate/query/select/QueryLiteralIntegrationTests.java
+++ b/src/integrationTest/java/com/mongodb/hibernate/query/select/QueryLiteralIntegrationTests.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2025-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.hibernate.query.select;
+
+import static java.lang.String.format;
+
+import com.mongodb.hibernate.query.AbstractQueryIntegrationTests;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+import org.bson.types.ObjectId;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Every inlined HQL literal is unwrapped through its {@code ValueBinder}, so each supported scalar type needs its own
+ * assertion of the value the translator emits.
+ */
+@DomainModel(annotatedClasses = {QueryLiteralIntegrationTests.Item.class})
+class QueryLiteralIntegrationTests extends AbstractQueryIntegrationTests {
+
+    private static final String COLLECTION_NAME = "items";
+    private static final String CONSTANTS = QueryLiteralConstants.class.getName();
+
+    @BeforeEach
+    void beforeEach() {
+        getSessionFactoryScope().inTransaction(session -> {
+            session.persist(new Item(1));
+            session.persist(new Item(2));
+        });
+    }
+
+    private static Stream<Arguments> literals() {
+        return Stream.of(
+                Arguments.of("stringValue", "STRING", """
+                        "War & Peace\""""),
+                Arguments.of("characterValue", "CHARACTER", """
+                        "c\""""),
+                Arguments.of("intValue", "INT", "42"),
+                Arguments.of("longValue", "LONG", """
+                        {"$numberLong": "43"}"""),
+                Arguments.of("doubleValue", "DOUBLE", "4.5"),
+                Arguments.of("booleanValue", "BOOLEAN", "true"),
+                Arguments.of(
+                        "bigDecimalValue", "BIG_DECIMAL", """
+                        {"$numberDecimal": "4.25"}"""),
+                Arguments.of(
+                        "objectIdValue",
+                        "OBJECT_ID",
+                        """
+                        {"$oid": "000000000000000000000001"}"""),
+                Arguments.of(
+                        "instantValue", "INSTANT", """
+                        {"$date": "2025-01-04T10:05:01Z"}"""));
+    }
+
+    @ParameterizedTest(name = "testLiteralPredicate: {0}")
+    @MethodSource("literals")
+    void testLiteralPredicate(String attribute, String constant, String expectedBson) {
+        assertSelectionQuery(
+                format("select id from Item where %s = %s.%s", attribute, CONSTANTS, constant),
+                Integer.class,
+                format(
+                        """
+                        {
+                          "aggregate": "items",
+                          "pipeline": [
+                            {"$match": {"%s": {"$eq": %s}}},
+                            {"$project": {"_id": true}}
+                          ]
+                        }""",
+                        attribute, expectedBson),
+                List.of(1),
+                Set.of(COLLECTION_NAME));
+    }
+
+    @Entity(name = "Item")
+    @Table(name = COLLECTION_NAME)
+    static class Item {
+        @Id
+        int id;
+
+        String stringValue;
+        Character characterValue;
+        int intValue;
+        long longValue;
+        double doubleValue;
+        boolean booleanValue;
+        BigDecimal bigDecimalValue;
+        ObjectId objectIdValue;
+        Instant instantValue;
+
+        Item() {}
+
+        /** Item 1 holds every constant's value; item 2 holds values none of the constants match. */
+        Item(int id) {
+            this.id = id;
+            var matching = id == 1;
+            this.stringValue = matching ? QueryLiteralConstants.STRING : "Anna Karenina";
+            this.characterValue = matching ? QueryLiteralConstants.CHARACTER : 'z';
+            this.intValue = matching ? QueryLiteralConstants.INT : -1;
+            this.longValue = matching ? QueryLiteralConstants.LONG : -1L;
+            this.doubleValue = matching ? QueryLiteralConstants.DOUBLE : -1.5;
+            this.booleanValue = matching ? QueryLiteralConstants.BOOLEAN : !QueryLiteralConstants.BOOLEAN;
+            this.bigDecimalValue = matching ? QueryLiteralConstants.BIG_DECIMAL : new BigDecimal("-1.25");
+            this.objectIdValue = matching ? QueryLiteralConstants.OBJECT_ID : new ObjectId("000000000000000000000002");
+            this.instantValue = matching ? QueryLiteralConstants.INSTANT : Instant.parse("1999-01-04T10:05:01Z");
+        }
+    }
+}

--- a/src/integrationTest/java/com/mongodb/hibernate/query/select/QueryLiteralIntegrationTests.java
+++ b/src/integrationTest/java/com/mongodb/hibernate/query/select/QueryLiteralIntegrationTests.java
@@ -47,9 +47,39 @@ class QueryLiteralIntegrationTests extends AbstractQueryIntegrationTests {
     @BeforeEach
     void beforeEach() {
         getSessionFactoryScope().inTransaction(session -> {
-            session.persist(new Item(1));
-            session.persist(new Item(2));
+            session.persist(matchingItem());
+            session.persist(nonMatchingItem());
         });
+    }
+
+    private static Item matchingItem() {
+        var item = new Item();
+        item.id = 1;
+        item.stringValue = QueryLiteralConstants.STRING;
+        item.characterValue = QueryLiteralConstants.CHARACTER;
+        item.intValue = QueryLiteralConstants.INT;
+        item.longValue = QueryLiteralConstants.LONG;
+        item.doubleValue = QueryLiteralConstants.DOUBLE;
+        item.booleanValue = QueryLiteralConstants.BOOLEAN;
+        item.bigDecimalValue = QueryLiteralConstants.BIG_DECIMAL;
+        item.objectIdValue = QueryLiteralConstants.OBJECT_ID;
+        item.instantValue = QueryLiteralConstants.INSTANT;
+        return item;
+    }
+
+    private static Item nonMatchingItem() {
+        var item = new Item();
+        item.id = 2;
+        item.stringValue = "Anna Karenina";
+        item.characterValue = 'z';
+        item.intValue = -1;
+        item.longValue = -1L;
+        item.doubleValue = -1.5;
+        item.booleanValue = false;
+        item.bigDecimalValue = new BigDecimal("-1.25");
+        item.objectIdValue = new ObjectId("000000000000000000000002");
+        item.instantValue = Instant.parse("1999-01-04T10:05:01Z");
+        return item;
     }
 
     private static Stream<Arguments> literals() {
@@ -113,20 +143,5 @@ class QueryLiteralIntegrationTests extends AbstractQueryIntegrationTests {
         Instant instantValue;
 
         Item() {}
-
-        /** Item 1 holds every constant's value; item 2 holds values none of the constants match. */
-        Item(int id) {
-            this.id = id;
-            var matching = id == 1;
-            this.stringValue = matching ? QueryLiteralConstants.STRING : "Anna Karenina";
-            this.characterValue = matching ? QueryLiteralConstants.CHARACTER : 'z';
-            this.intValue = matching ? QueryLiteralConstants.INT : -1;
-            this.longValue = matching ? QueryLiteralConstants.LONG : -1L;
-            this.doubleValue = matching ? QueryLiteralConstants.DOUBLE : -1.5;
-            this.booleanValue = matching ? QueryLiteralConstants.BOOLEAN : !QueryLiteralConstants.BOOLEAN;
-            this.bigDecimalValue = matching ? QueryLiteralConstants.BIG_DECIMAL : new BigDecimal("-1.25");
-            this.objectIdValue = matching ? QueryLiteralConstants.OBJECT_ID : new ObjectId("000000000000000000000002");
-            this.instantValue = matching ? QueryLiteralConstants.INSTANT : Instant.parse("1999-01-04T10:05:01Z");
-        }
     }
 }

--- a/src/integrationTest/java/com/mongodb/hibernate/type/UnwrappedDomainTypeConstants.java
+++ b/src/integrationTest/java/com/mongodb/hibernate/type/UnwrappedDomainTypeConstants.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2025-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.hibernate.type;
+
+import java.time.Duration;
+import java.time.Year;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.TimeZone;
+
+/**
+ * Holds constants referenced by fully-qualified name in HQL, which is how a literal of an arbitrary type is written.
+ * Each {@code FIRST_}/{@code THIRD_} pair holds the values of the correspondingly numbered seed item in
+ * {@link UnwrappedDomainTypeIntegrationTests}.
+ */
+public final class UnwrappedDomainTypeConstants {
+
+    public static final Duration FIRST_DURATION = Duration.ofSeconds(90, 500);
+    public static final Year FIRST_YEAR = Year.of(2024);
+    public static final ZoneId FIRST_ZONE_ID = ZoneId.of("Europe/Paris");
+    public static final ZoneOffset FIRST_ZONE_OFFSET = ZoneOffset.of("+02:00");
+    public static final TimeZone FIRST_TIME_ZONE = TimeZone.getTimeZone("America/New_York");
+
+    public static final Duration THIRD_DURATION = Duration.ofSeconds(180, 1);
+    public static final Year THIRD_YEAR = Year.of(2026);
+    public static final ZoneId THIRD_ZONE_ID = ZoneId.of("Asia/Tokyo");
+    public static final ZoneOffset THIRD_ZONE_OFFSET = ZoneOffset.of("+09:00");
+    public static final TimeZone THIRD_TIME_ZONE = TimeZone.getTimeZone("Asia/Tokyo");
+
+    private UnwrappedDomainTypeConstants() {}
+}

--- a/src/integrationTest/java/com/mongodb/hibernate/type/UnwrappedDomainTypeIntegrationTests.java
+++ b/src/integrationTest/java/com/mongodb/hibernate/type/UnwrappedDomainTypeIntegrationTests.java
@@ -1,0 +1,521 @@
+/*
+ * Copyright 2025-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.hibernate.type;
+
+import static com.mongodb.hibernate.internal.MongoAssertions.fail;
+import static com.mongodb.hibernate.type.UnwrappedDomainTypeConstants.FIRST_DURATION;
+import static com.mongodb.hibernate.type.UnwrappedDomainTypeConstants.FIRST_TIME_ZONE;
+import static com.mongodb.hibernate.type.UnwrappedDomainTypeConstants.FIRST_YEAR;
+import static com.mongodb.hibernate.type.UnwrappedDomainTypeConstants.FIRST_ZONE_ID;
+import static com.mongodb.hibernate.type.UnwrappedDomainTypeConstants.FIRST_ZONE_OFFSET;
+import static com.mongodb.hibernate.type.UnwrappedDomainTypeConstants.THIRD_DURATION;
+import static com.mongodb.hibernate.type.UnwrappedDomainTypeConstants.THIRD_TIME_ZONE;
+import static com.mongodb.hibernate.type.UnwrappedDomainTypeConstants.THIRD_YEAR;
+import static com.mongodb.hibernate.type.UnwrappedDomainTypeConstants.THIRD_ZONE_ID;
+import static com.mongodb.hibernate.type.UnwrappedDomainTypeConstants.THIRD_ZONE_OFFSET;
+import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.mongodb.client.MongoCollection;
+import com.mongodb.hibernate.junit.InjectMongoCollection;
+import com.mongodb.hibernate.query.AbstractQueryIntegrationTests;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.Duration;
+import java.time.Year;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.TimeZone;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+import org.bson.BsonDocument;
+import org.bson.BsonInt32;
+import org.hibernate.annotations.Struct;
+import org.hibernate.query.MutationQuery;
+import org.hibernate.testing.orm.junit.DomainModel;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Covers the types {@code ValueConversions} does not recognize by domain class, and which therefore reach BSON only by
+ * being unwrapped through their {@code JavaType}: {@link Duration}, {@link Year}, {@link ZoneId}, {@link ZoneOffset}
+ * and {@link TimeZone}.
+ */
+@DomainModel(annotatedClasses = {UnwrappedDomainTypeIntegrationTests.Item.class})
+class UnwrappedDomainTypeIntegrationTests extends AbstractQueryIntegrationTests {
+
+    private static final String COLLECTION_NAME = "items";
+    private static final String CONSTANTS = UnwrappedDomainTypeConstants.class.getName();
+
+    private static final String PROJECT_ALL_FIELDS =
+            """
+            {
+              "$project": {
+                "_id": true,
+                "aggregateEmbeddable": true,
+                "duration": true,
+                "durations": true,
+                "flattenedDuration": true,
+                "flattenedTimeZone": true,
+                "flattenedYear": true,
+                "flattenedZoneId": true,
+                "flattenedZoneOffset": true,
+                "timeZone": true,
+                "timeZones": true,
+                "year": true,
+                "years": true,
+                "zoneId": true,
+                "zoneIds": true,
+                "zoneOffset": true,
+                "zoneOffsets": true
+              }
+            }""";
+
+    private static final List<Item> ITEMS = List.of(
+            new Item(1, FIRST_DURATION, FIRST_YEAR, FIRST_ZONE_ID, FIRST_ZONE_OFFSET, FIRST_TIME_ZONE),
+            new Item(
+                    2,
+                    Duration.ofSeconds(120),
+                    Year.of(2025),
+                    ZoneId.of("America/New_York"),
+                    ZoneOffset.of("-05:00"),
+                    TimeZone.getTimeZone("Europe/Paris")),
+            new Item(3, THIRD_DURATION, THIRD_YEAR, THIRD_ZONE_ID, THIRD_ZONE_OFFSET, THIRD_TIME_ZONE));
+
+    @InjectMongoCollection(COLLECTION_NAME)
+    private MongoCollection<BsonDocument> mongoCollection;
+
+    @BeforeEach
+    void beforeEach() {
+        getSessionFactoryScope().inTransaction(session -> ITEMS.forEach(session::persist));
+    }
+
+    private static List<Item> items(int... ids) {
+        return Arrays.stream(ids)
+                .mapToObj(id -> ITEMS.stream()
+                        .filter(item -> item.id == id)
+                        .findAny()
+                        .orElseThrow(() -> fail("id does not exist: " + id)))
+                .toList();
+    }
+
+    /**
+     * @param first The value of {@linkplain #ITEMS seed item} 1, {@code third} that of seed item 3.
+     * @param ascendingIds The seed item ids ordered by ascending attribute value.
+     */
+    private record TypeCase<T>(
+            String attribute,
+            Class<T> javaType,
+            T first,
+            String firstBson,
+            String firstLiteral,
+            T third,
+            String thirdBson,
+            String thirdLiteral,
+            int[] ascendingIds) {
+        @Override
+        public String toString() {
+            return attribute;
+        }
+    }
+
+    private static Stream<Arguments> types() {
+        return Stream.of(
+                Arguments.of(new TypeCase<>(
+                        "duration",
+                        Duration.class,
+                        FIRST_DURATION,
+                        """
+                        {"$numberDecimal": "90000000500"}""",
+                        CONSTANTS + ".FIRST_DURATION",
+                        THIRD_DURATION,
+                        """
+                        {"$numberDecimal": "180000000001"}""",
+                        CONSTANTS + ".THIRD_DURATION",
+                        new int[] {1, 2, 3})),
+                Arguments.of(new TypeCase<>(
+                        "year",
+                        Year.class,
+                        FIRST_YEAR,
+                        "2024",
+                        CONSTANTS + ".FIRST_YEAR",
+                        THIRD_YEAR,
+                        "2026",
+                        CONSTANTS + ".THIRD_YEAR",
+                        new int[] {1, 2, 3})),
+                Arguments.of(new TypeCase<>(
+                        "zoneId",
+                        ZoneId.class,
+                        FIRST_ZONE_ID,
+                        """
+                        "Europe/Paris\"""",
+                        CONSTANTS + ".FIRST_ZONE_ID",
+                        THIRD_ZONE_ID,
+                        """
+                        "Asia/Tokyo\"""",
+                        CONSTANTS + ".THIRD_ZONE_ID",
+                        new int[] {2, 3, 1})),
+                Arguments.of(new TypeCase<>(
+                        "zoneOffset",
+                        ZoneOffset.class,
+                        FIRST_ZONE_OFFSET,
+                        """
+                        "+02:00\"""",
+                        CONSTANTS + ".FIRST_ZONE_OFFSET",
+                        THIRD_ZONE_OFFSET,
+                        """
+                        "+09:00\"""",
+                        CONSTANTS + ".THIRD_ZONE_OFFSET",
+                        new int[] {1, 3, 2})),
+                Arguments.of(new TypeCase<>(
+                        "timeZone",
+                        TimeZone.class,
+                        FIRST_TIME_ZONE,
+                        """
+                        "America/New_York\"""",
+                        CONSTANTS + ".FIRST_TIME_ZONE",
+                        THIRD_TIME_ZONE,
+                        """
+                        "Asia/Tokyo\"""",
+                        CONSTANTS + ".THIRD_TIME_ZONE",
+                        new int[] {1, 3, 2})));
+    }
+
+    @Test
+    void testRoundTrip() {
+        assertThat(mongoCollection.find(new BsonDocument("_id", new BsonInt32(1))))
+                .containsExactly(
+                        BsonDocument.parse(
+                                """
+                                {
+                                  "_id": 1,
+                                  "duration": {"$numberDecimal": "90000000500"},
+                                  "year": 2024,
+                                  "zoneId": "Europe/Paris",
+                                  "zoneOffset": "+02:00",
+                                  "timeZone": "America/New_York",
+                                  "durations": [{"$numberDecimal": "90000000500"}],
+                                  "years": [2024],
+                                  "zoneIds": ["Europe/Paris"],
+                                  "zoneOffsets": ["+02:00"],
+                                  "timeZones": ["America/New_York"],
+                                  "aggregateEmbeddable": {
+                                    "duration": {"$numberDecimal": "90000000500"},
+                                    "year": 2024,
+                                    "zoneId": "Europe/Paris",
+                                    "zoneOffset": "+02:00",
+                                    "timeZone": "America/New_York"
+                                  },
+                                  "flattenedDuration": {"$numberDecimal": "90000000500"},
+                                  "flattenedYear": 2024,
+                                  "flattenedZoneId": "Europe/Paris",
+                                  "flattenedZoneOffset": "+02:00",
+                                  "flattenedTimeZone": "America/New_York"
+                                }"""));
+    }
+
+    @ParameterizedTest(name = "testProjection: {0}")
+    @MethodSource("types")
+    <T> void testProjection(TypeCase<T> c) {
+        assertSelectionQuery(
+                format("select %s from Item where id = 1", c.attribute()),
+                c.javaType(),
+                format(
+                        """
+                        {
+                          "aggregate": "items",
+                          "pipeline": [
+                            {"$match": {"_id": {"$eq": 1}}},
+                            {"$project": {"%s": true}}
+                          ]
+                        }""",
+                        c.attribute()),
+                List.of(c.first()),
+                Set.of(COLLECTION_NAME));
+    }
+
+    @ParameterizedTest(name = "testParameterPredicate: {0}")
+    @MethodSource("types")
+    <T> void testParameterPredicate(TypeCase<T> c) {
+        assertSelectionQuery(
+                format("from Item where %s = :v", c.attribute()),
+                Item.class,
+                q -> q.setParameter("v", c.first()),
+                matchAndProjectAll(
+                        format("""
+                        {"%s": {"$eq": %s}}""", c.attribute(), c.firstBson())),
+                items(1),
+                Set.of(COLLECTION_NAME));
+    }
+
+    @ParameterizedTest(name = "testLiteralPredicate: {0}")
+    @MethodSource("types")
+    <T> void testLiteralPredicate(TypeCase<T> c) {
+        assertSelectionQuery(
+                format("from Item where %s = %s", c.attribute(), c.firstLiteral()),
+                Item.class,
+                matchAndProjectAll(
+                        format("""
+                        {"%s": {"$eq": %s}}""", c.attribute(), c.firstBson())),
+                items(1),
+                Set.of(COLLECTION_NAME));
+    }
+
+    @ParameterizedTest(name = "testInWithParameters: {0}")
+    @MethodSource("types")
+    <T> void testInWithParameters(TypeCase<T> c) {
+        assertSelectionQuery(
+                format("from Item where %s in (:a, :b)", c.attribute()),
+                Item.class,
+                q -> q.setParameter("a", c.first()).setParameter("b", c.third()),
+                matchAndProjectAll(format(
+                        """
+                        {"%s": {"$in": [%s, %s]}}""",
+                        c.attribute(), c.firstBson(), c.thirdBson())),
+                items(1, 3),
+                Set.of(COLLECTION_NAME));
+    }
+
+    @ParameterizedTest(name = "testInWithLiterals: {0}")
+    @MethodSource("types")
+    <T> void testInWithLiterals(TypeCase<T> c) {
+        assertSelectionQuery(
+                format("from Item where %s in (%s, %s)", c.attribute(), c.firstLiteral(), c.thirdLiteral()),
+                Item.class,
+                matchAndProjectAll(format(
+                        """
+                        {"%s": {"$in": [%s, %s]}}""",
+                        c.attribute(), c.firstBson(), c.thirdBson())),
+                items(1, 3),
+                Set.of(COLLECTION_NAME));
+    }
+
+    @ParameterizedTest(name = "testIsNull: {0}")
+    @MethodSource("types")
+    <T> void testIsNull(TypeCase<T> c) {
+        assertSelectionQuery(
+                format("from Item where %s is null", c.attribute()),
+                Item.class,
+                matchAndProjectAll(format("""
+                               {"%s": {"$eq": null}}""", c.attribute())),
+                List.of(),
+                Set.of(COLLECTION_NAME));
+    }
+
+    @ParameterizedTest(name = "testIsNotNull: {0}")
+    @MethodSource("types")
+    <T> void testIsNotNull(TypeCase<T> c) {
+        assertSelectionQuery(
+                format("from Item where %s is not null", c.attribute()),
+                Item.class,
+                matchAndProjectAll(format("""
+                               {"%s": {"$ne": null}}""", c.attribute())),
+                items(1, 2, 3),
+                Set.of(COLLECTION_NAME));
+    }
+
+    @ParameterizedTest(name = "testOrderByAscending: {0}")
+    @MethodSource("types")
+    <T> void testOrderByAscending(TypeCase<T> c) {
+        assertSelectionQuery(
+                format("from Item order by %s asc", c.attribute()),
+                Item.class,
+                sortAndProjectAll(c.attribute(), 1),
+                items(c.ascendingIds()),
+                Set.of(COLLECTION_NAME));
+    }
+
+    @ParameterizedTest(name = "testOrderByDescending: {0}")
+    @MethodSource("types")
+    <T> void testOrderByDescending(TypeCase<T> c) {
+        var descendingIds = c.ascendingIds().clone();
+        for (var i = 0; i < descendingIds.length / 2; i++) {
+            var swap = descendingIds[i];
+            descendingIds[i] = descendingIds[descendingIds.length - 1 - i];
+            descendingIds[descendingIds.length - 1 - i] = swap;
+        }
+        assertSelectionQuery(
+                format("from Item order by %s desc", c.attribute()),
+                Item.class,
+                sortAndProjectAll(c.attribute(), -1),
+                items(descendingIds),
+                Set.of(COLLECTION_NAME));
+    }
+
+    @ParameterizedTest(name = "testMutationSetWithParameter: {0}")
+    @MethodSource("types")
+    <T> void testMutationSetWithParameter(TypeCase<T> c) {
+        assertMutationSetsThirdItemToFirstValue(
+                format("update Item set %s = :v where id = 3", c.attribute()), q -> q.setParameter("v", c.first()), c);
+    }
+
+    @ParameterizedTest(name = "testMutationSetWithLiteral: {0}")
+    @MethodSource("types")
+    <T> void testMutationSetWithLiteral(TypeCase<T> c) {
+        assertMutationSetsThirdItemToFirstValue(
+                format("update Item set %s = %s where id = 3", c.attribute(), c.firstLiteral()), query -> {}, c);
+    }
+
+    private <T> void assertMutationSetsThirdItemToFirstValue(
+            String hql, Consumer<MutationQuery> queryPostProcessor, TypeCase<T> c) {
+        getSessionFactoryScope().inTransaction(session -> {
+            var query = session.createMutationQuery(hql);
+            queryPostProcessor.accept(query);
+            assertThat(query.executeUpdate()).isEqualTo(1);
+            assertActualCommandsInOrder(BsonDocument.parse(format(
+                    """
+                    {
+                      "update": "items",
+                      "updates": [
+                        {
+                          "multi": true,
+                          "q": {"_id": {"$eq": 3}},
+                          "u": {"$set": {"%s": %s}}
+                        }
+                      ]
+                    }""",
+                    c.attribute(), c.firstBson())));
+        });
+        assertThat(mongoCollection
+                        .find(new BsonDocument("_id", new BsonInt32(3)))
+                        .first())
+                .isNotNull()
+                .extracting(document -> document.get(c.attribute()))
+                .isEqualTo(
+                        BsonDocument.parse(format("{\"v\": %s}", c.firstBson())).get("v"));
+    }
+
+    private static String matchAndProjectAll(String matchFilter) {
+        return format(
+                """
+                {
+                  "aggregate": "items",
+                  "pipeline": [
+                    {"$match": %s},
+                    %s
+                  ]
+                }""",
+                matchFilter, PROJECT_ALL_FIELDS);
+    }
+
+    private static String sortAndProjectAll(String attribute, int direction) {
+        return format(
+                """
+                {
+                  "aggregate": "items",
+                  "pipeline": [
+                    {"$sort": {"%s": %d}},
+                    %s
+                  ]
+                }""",
+                attribute, direction, PROJECT_ALL_FIELDS);
+    }
+
+    @Entity(name = "Item")
+    @Table(name = COLLECTION_NAME)
+    static class Item {
+        @Id
+        int id;
+
+        Duration duration;
+        Year year;
+        ZoneId zoneId;
+        ZoneOffset zoneOffset;
+        TimeZone timeZone;
+
+        Collection<Duration> durations;
+        Collection<Year> years;
+        Collection<ZoneId> zoneIds;
+        Collection<ZoneOffset> zoneOffsets;
+        Collection<TimeZone> timeZones;
+
+        AggregateEmbeddable aggregateEmbeddable;
+        FlattenedEmbeddable flattenedEmbeddable;
+
+        Item() {}
+
+        Item(int id, Duration duration, Year year, ZoneId zoneId, ZoneOffset zoneOffset, TimeZone timeZone) {
+            this.id = id;
+            this.duration = duration;
+            this.year = year;
+            this.zoneId = zoneId;
+            this.zoneOffset = zoneOffset;
+            this.timeZone = timeZone;
+            this.durations = List.of(duration);
+            this.years = List.of(year);
+            this.zoneIds = List.of(zoneId);
+            this.zoneOffsets = List.of(zoneOffset);
+            this.timeZones = List.of(timeZone);
+            this.aggregateEmbeddable = new AggregateEmbeddable(duration, year, zoneId, zoneOffset, timeZone);
+            this.flattenedEmbeddable = new FlattenedEmbeddable(duration, year, zoneId, zoneOffset, timeZone);
+        }
+
+        @Override
+        public String toString() {
+            return "Item{id=" + id + ", duration=" + duration + ", year=" + year + ", zoneId=" + zoneId
+                    + ", zoneOffset=" + zoneOffset + ", timeZone=" + timeZone.getID() + '}';
+        }
+    }
+
+    @Embeddable
+    @Struct(name = "AggregateEmbeddable")
+    static class AggregateEmbeddable {
+        Duration duration;
+        Year year;
+        ZoneId zoneId;
+        ZoneOffset zoneOffset;
+        TimeZone timeZone;
+
+        AggregateEmbeddable() {}
+
+        AggregateEmbeddable(Duration duration, Year year, ZoneId zoneId, ZoneOffset zoneOffset, TimeZone timeZone) {
+            this.duration = duration;
+            this.year = year;
+            this.zoneId = zoneId;
+            this.zoneOffset = zoneOffset;
+            this.timeZone = timeZone;
+        }
+    }
+
+    @Embeddable
+    static class FlattenedEmbeddable {
+        Duration flattenedDuration;
+        Year flattenedYear;
+        ZoneId flattenedZoneId;
+        ZoneOffset flattenedZoneOffset;
+        TimeZone flattenedTimeZone;
+
+        FlattenedEmbeddable() {}
+
+        FlattenedEmbeddable(Duration duration, Year year, ZoneId zoneId, ZoneOffset zoneOffset, TimeZone timeZone) {
+            this.flattenedDuration = duration;
+            this.flattenedYear = year;
+            this.flattenedZoneId = zoneId;
+            this.flattenedZoneOffset = zoneOffset;
+            this.flattenedTimeZone = timeZone;
+        }
+    }
+}

--- a/src/main/java/com/mongodb/hibernate/internal/translate/AbstractMqlTranslator.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/AbstractMqlTranslator.java
@@ -265,6 +265,7 @@ import org.hibernate.sql.model.internal.TableUpdateStandard;
 import org.hibernate.sql.results.graph.DomainResult;
 import org.hibernate.type.BasicType;
 import org.hibernate.type.SqlTypes;
+import org.hibernate.type.descriptor.ValueBinder;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -1036,8 +1037,28 @@ public abstract class AbstractMqlTranslator<T extends JdbcOperation> implements 
 
     @Override
     public void visitQueryLiteral(QueryLiteral<?> queryLiteral) {
-        var bsonValue = toBsonValue(queryLiteral.getLiteralValue());
+        var bsonValue = toBsonValue(toBindValue(queryLiteral));
         yieldValueOrExpression(new AstLiteral(bsonValue), needsLiteralWrapping(bsonValue));
+    }
+
+    /**
+     * Unwraps the literal's domain value the way binding a parameter of that type would, so that
+     * {@link ValueConversions} sees the JDBC-level value.
+     */
+    private @Nullable Object toBindValue(QueryLiteral<?> queryLiteral) {
+        var literalValue = queryLiteral.getLiteralValue();
+        if (literalValue == null) {
+            return null;
+        }
+        @SuppressWarnings("unchecked")
+        ValueBinder<Object> valueBinder = queryLiteral.getJdbcMapping().getJdbcValueBinder();
+        try {
+            return valueBinder.getBindValue(literalValue, getSessionFactory().getWrapperOptions());
+        } catch (SQLFeatureNotSupportedException e) {
+            throw new FeatureNotSupportedException(e);
+        } catch (SQLException e) {
+            throw fail(e.toString());
+        }
     }
 
     @Override

--- a/src/main/java/com/mongodb/hibernate/internal/type/MongoStructJdbcType.java
+++ b/src/main/java/com/mongodb/hibernate/internal/type/MongoStructJdbcType.java
@@ -25,6 +25,8 @@ import static com.mongodb.hibernate.internal.type.ValueConversions.isNull;
 import static com.mongodb.hibernate.internal.type.ValueConversions.toArrayDomainValue;
 import static com.mongodb.hibernate.internal.type.ValueConversions.toBsonValue;
 import static com.mongodb.hibernate.internal.type.ValueConversions.toDomainValue;
+import static org.hibernate.type.descriptor.jdbc.StructHelper.getAttributeValues;
+import static org.hibernate.type.descriptor.jdbc.StructHelper.getJdbcValues;
 import static org.hibernate.type.descriptor.jdbc.StructHelper.instantiate;
 
 import com.mongodb.hibernate.internal.FeatureNotSupportedException;
@@ -41,7 +43,6 @@ import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
 import java.sql.Struct;
 import org.bson.BsonDocument;
-import org.bson.BsonValue;
 import org.hibernate.metamodel.mapping.EmbeddableMappingType;
 import org.hibernate.metamodel.spi.RuntimeModelCreationContext;
 import org.hibernate.type.SqlTypes;
@@ -52,7 +53,6 @@ import org.hibernate.type.descriptor.java.JavaType;
 import org.hibernate.type.descriptor.jdbc.AggregateJdbcType;
 import org.hibernate.type.descriptor.jdbc.BasicBinder;
 import org.hibernate.type.descriptor.jdbc.BasicExtractor;
-import org.hibernate.type.descriptor.jdbc.StructAttributeValues;
 import org.hibernate.type.descriptor.jdbc.StructuredJdbcType;
 import org.jspecify.annotations.Nullable;
 
@@ -126,6 +126,11 @@ public final class MongoStructJdbcType implements StructuredJdbcType {
             return null;
         }
         var embeddableMappingType = getEmbeddableMappingType();
+        // `StructHelper` flattens the domain value to one JDBC value per column, applying each column's
+        // `ValueBinder` on the way, which is the unwrap this method needs, and yielding the `BsonDocument` a nested
+        // `@Struct` binds to. The order mapping is null because this type writes fields by selectable name rather
+        // than by physical position.
+        var jdbcValues = getJdbcValues(embeddableMappingType, null, domainValue, options);
         var result = new BsonDocument();
         var jdbcValueCount = embeddableMappingType.getJdbcValueCount();
         for (var columnIndex = 0; columnIndex < jdbcValueCount; columnIndex++) {
@@ -139,26 +144,7 @@ public final class MongoStructJdbcType implements StructuredJdbcType {
                 throw new FeatureNotSupportedException(
                         "Persistent attributes of a `@Struct @Embeddable` must be updatable");
             }
-            var fieldName = jdbcValueSelectable.getSelectableName();
-            var value = embeddableMappingType.getValue(domainValue, columnIndex);
-            BsonValue bsonValue;
-            if (value == null) {
-                bsonValue = toBsonValue(value);
-            } else {
-                var jdbcMapping = jdbcValueSelectable.getJdbcMapping();
-                var jdbcTypeCode = jdbcMapping.getJdbcType().getJdbcTypeCode();
-                if (jdbcTypeCode == getJdbcTypeCode()) {
-                    var structValueBinder = assertInstanceOf(jdbcMapping.getJdbcValueBinder(), Binder.class);
-                    bsonValue = structValueBinder.getJdbcType().createBindValue(value, options);
-                } else if (jdbcTypeCode == MongoArrayJdbcType.JDBC_TYPE.getVendorTypeNumber()) {
-                    @SuppressWarnings("unchecked")
-                    ValueBinder<Object> valueBinder = jdbcMapping.getJdbcValueBinder();
-                    bsonValue = toBsonValue(valueBinder.getBindValue(value, options));
-                } else {
-                    bsonValue = toBsonValue(value);
-                }
-            }
-            result.append(fieldName, bsonValue);
+            result.append(jdbcValueSelectable.getSelectableName(), toBsonValue(jdbcValues[columnIndex]));
         }
         return result;
     }
@@ -199,8 +185,17 @@ public final class MongoStructJdbcType implements StructuredJdbcType {
                 domainValue =
                         arrayJdbcType.getArray(jdbcValueExtractor, toArrayDomainValue(assertNotNull(value)), options);
             } else {
-                domainValue = toDomainValue(
-                        assertNotNull(value), jdbcMapping.getMappedJavaType().getJavaTypeClass());
+                // The inverse of `createBindValue`: read the JDBC-level value the binder would have written, then
+                // wrap it back into the domain type. A `JdbcType` reporting no preferred Java type binds the domain
+                // value unchanged, so it is read back unchanged.
+                var preferredJavaTypeClass = jdbcMapping.getJdbcType().getPreferredJavaTypeClass(options);
+                var mappedJavaType = jdbcMapping.getMappedJavaType();
+                if (preferredJavaTypeClass == null) {
+                    domainValue = toDomainValue(assertNotNull(value), mappedJavaType.getJavaTypeClass());
+                } else {
+                    domainValue =
+                            mappedJavaType.wrap(toDomainValue(assertNotNull(value), preferredJavaTypeClass), options);
+                }
             }
             result[columnIndex] = domainValue;
         }
@@ -278,7 +273,8 @@ public final class MongoStructJdbcType implements StructuredJdbcType {
             } else {
                 var embeddableMappingType = getEmbeddableMappingType();
                 assertTrue(classX.equals(embeddableMappingType.getJavaType().getJavaTypeClass()));
-                result = instantiate(embeddableMappingType, new StructAttributeValues(jdbcValues.length, jdbcValues));
+                result = instantiate(
+                        embeddableMappingType, getAttributeValues(embeddableMappingType, jdbcValues, options));
             }
             return classX.cast(result);
         }

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -94,6 +94,18 @@ import org.hibernate.service.spi.ServiceContributor;
  *       <td>BSON {@code Date}</td>
  *     </tr>
  *     <tr>
+ *       <td>{@link java.time.Duration}</td>
+ *       <td>BSON {@code Decimal128} holding the number of nanoseconds</td>
+ *     </tr>
+ *     <tr>
+ *       <td>{@link java.time.Year}</td>
+ *       <td>BSON {@code 32-bit integer}</td>
+ *     </tr>
+ *     <tr>
+ *       <td>{@link java.time.ZoneId}, {@link java.time.ZoneOffset}, {@link java.util.TimeZone}</td>
+ *       <td>BSON {@code String} holding the zone or offset ID</td>
+ *     </tr>
+ *     <tr>
  *       <td>{@link java.sql.Struct} <a
  *           href="https://docs.hibernate.org/orm/6.6/userguide/html_single/#embeddable-mapping-aggregate">aggregate
  *           embeddable</a></td>


### PR DESCRIPTION
`ValueConversions.toBsonValue` dispatches on the runtime class of a value and recognizes only JDBC-level classes. Every write path reaches it through BasicBinder.getBindValue, which first unwraps the domain value to the `JdbcType`'s preferred Java type, so what reaches `toBsonValue` is always a class it recognizes. Two paths skipped that step and passed the domain value straight through: the fields of a @Struct aggregate embeddable, and an inlined HQL literal. A type whose domain class is not itself a JDBC-level class therefore worked in every position except those two.

The HQL literal path now unwraps through the same `ValueBinder` that binding a parameter of that type already uses. The @Struct write path delegates to Hibernate's own `StructHelper.getJdbcValues`, which flattens the domain value to one JDBC value per column and applies each column's `ValueBinder` on the way, subsuming both the per-column unwrap and the existing array special case.

Delegating in this way also promotes a shape we previously refused: a flattened @Embeddable nested in a @Struct one now stores as fields of the enclosing subdocument and reads back intact, because StructHelper recurses into an embeddable-valued attribute.

The @Struct read path has a similar defect and gets the inverse change: read the JDBC-level value the binder would have written, then wrap it back through the mapped JavaType. This is not symmetric in form with the write side, because an ordinary column has `BasicExtractor.doExtract` do the wrapping while the @Struct read path has no `ValueExtractor.` A JdbcType reporting no preferred Java type binds the domain value unchanged, so it is read back unchanged. Materializing the embeddable itself, rather than reading its fields, uses `StructHelper.getAttributeValues`, the inverse of `getJdbcValues`, so that an attribute spanning more than one column is recomposed from its columns rather than taken one column per attribute.

Additionally the types java.time.Duration, java.time.Year, java.time.ZoneId, java.time.ZoneOffset and java.util.TimeZone already mapped correctly, but now they are documented and tested.

 Note this is a pre-condition for HIBERNATE-225 because `ZonedDateTime/OffsetDateTime` will fail to convert when in a @Struct embeddable field or an HQL literal.

HIBERNATE-224