### PR TITLE
HIBERNATE-208 exclude _id from $project when unspecified

### DIFF
--- a/src/integrationTest/java/com/mongodb/hibernate/query/function/DateFunctionIntegrationTests.java
+++ b/src/integrationTest/java/com/mongodb/hibernate/query/function/DateFunctionIntegrationTests.java
@@ -120,7 +120,8 @@ public class DateFunctionIntegrationTests extends AbstractQueryIntegrationTests 
                             "format": { "$literal": "%2$s" },
                             "timezone": { "$literal": "%1$s" }
                           }
-                        }
+                        },
+                        "_id": 0
                       }
                     }
                   ]
@@ -148,7 +149,8 @@ public class DateFunctionIntegrationTests extends AbstractQueryIntegrationTests 
                             "format": "%%Y-%%m-%%d %%H:%%M:%%S",
                             "timezone": { "$literal": "%1$s" }
                           }
-                        }
+                        },
+                        "_id": 0
                       }
                     }
                   ]
@@ -211,7 +213,8 @@ public class DateFunctionIntegrationTests extends AbstractQueryIntegrationTests 
                               "time": "$before"
                             }
                           }
-                        }
+                        },
+                        "_id": 0
                       }
                     }
                   ]
@@ -238,7 +241,8 @@ public class DateFunctionIntegrationTests extends AbstractQueryIntegrationTests 
                               "$literal": "%1$s"
                             }
                           }
-                        }
+                        },
+                        "_id": 0
                       }
                     }
                   ]
@@ -265,7 +269,8 @@ public class DateFunctionIntegrationTests extends AbstractQueryIntegrationTests 
                               "$literal": "%1$s"
                             }
                           }
-                        }
+                        },
+                        "_id": 0
                       }
                     }
                   ]
@@ -293,7 +298,8 @@ public class DateFunctionIntegrationTests extends AbstractQueryIntegrationTests 
                               "$literal": "%1$s"
                             }
                           }
-                        }
+                        },
+                        "_id": 0
                       }
                     }
                   ]
@@ -320,7 +326,8 @@ public class DateFunctionIntegrationTests extends AbstractQueryIntegrationTests 
                               "$literal": "%1$s"
                             }
                           }
-                        }
+                        },
+                        "_id": 0
                       }
                     }
                   ]
@@ -347,7 +354,8 @@ public class DateFunctionIntegrationTests extends AbstractQueryIntegrationTests 
                               "$literal": "%1$s"
                             }
                           }
-                        }
+                        },
+                        "_id": 0
                       }
                     }
                   ]
@@ -385,7 +393,8 @@ public class DateFunctionIntegrationTests extends AbstractQueryIntegrationTests 
                               ]
                             }
                           }
-                        }
+                        },
+                        "_id": 0
                       }
                     }
                   ]
@@ -439,7 +448,8 @@ public class DateFunctionIntegrationTests extends AbstractQueryIntegrationTests 
                             },
                             "vars": { "time": "$before" }
                           }
-                        }
+                        },
+                        "_id": 0
                       }
                     }
                   ]
@@ -475,7 +485,8 @@ public class DateFunctionIntegrationTests extends AbstractQueryIntegrationTests 
                               "$literal": "%1$s"
                             }
                           }
-                        }
+                        },
+                        "_id": 0
                       }
                     }
                   ]
@@ -539,7 +550,8 @@ public class DateFunctionIntegrationTests extends AbstractQueryIntegrationTests 
                               "time": "$after"
                             }
                           }
-                        }
+                        },
+                        "_id": 0
                       }
                     }
                   ]
@@ -566,7 +578,8 @@ public class DateFunctionIntegrationTests extends AbstractQueryIntegrationTests 
                               "$literal": "%1$s"
                             }
                           }
-                        }
+                        },
+                        "_id": 0
                       }
                     }
                   ]
@@ -593,7 +606,8 @@ public class DateFunctionIntegrationTests extends AbstractQueryIntegrationTests 
                               "$literal": "%1$s"
                             }
                           }
-                        }
+                        },
+                        "_id": 0
                       }
                     }
                   ]
@@ -624,7 +638,8 @@ public class DateFunctionIntegrationTests extends AbstractQueryIntegrationTests 
                               }
                             ]
                           }
-                        }
+                        },
+                        "_id": 0
                       }
                     }
                   ]
@@ -686,7 +701,8 @@ public class DateFunctionIntegrationTests extends AbstractQueryIntegrationTests 
                               "time": "$before"
                             }
                           }
-                        }
+                        },
+                        "_id": 0
                       }
                     }
                   ]
@@ -750,7 +766,8 @@ public class DateFunctionIntegrationTests extends AbstractQueryIntegrationTests 
                               "time": "$newYears"
                             }
                           }
-                        }
+                        },
+                        "_id": 0
                       }
                     }
                   ]
@@ -814,7 +831,8 @@ public class DateFunctionIntegrationTests extends AbstractQueryIntegrationTests 
                               "time": "$earlyJanuary"
                             }
                           }
-                        }
+                        },
+                        "_id": 0
                       }
                     }
                   ]
@@ -878,7 +896,8 @@ public class DateFunctionIntegrationTests extends AbstractQueryIntegrationTests 
                               "time": "$startOfMay"
                             }
                           }
-                        }
+                        },
+                        "_id": 0
                       }
                     }
                   ]
@@ -905,7 +924,8 @@ public class DateFunctionIntegrationTests extends AbstractQueryIntegrationTests 
                               "$literal": "%1$s"
                             }
                           }
-                        }
+                        },
+                        "_id": 0
                       }
                     }
                   ]
@@ -932,7 +952,8 @@ public class DateFunctionIntegrationTests extends AbstractQueryIntegrationTests 
                               "$literal": "%1$s"
                             }
                           }
-                        }
+                        },
+                        "_id": 0
                       }
                     }
                   ]
@@ -959,7 +980,8 @@ public class DateFunctionIntegrationTests extends AbstractQueryIntegrationTests 
                               "$literal": "%1$s"
                             }
                           }
-                        }
+                        },
+                        "_id": 0
                       }
                     }
                   ]
@@ -986,7 +1008,8 @@ public class DateFunctionIntegrationTests extends AbstractQueryIntegrationTests 
                               "$literal": "%1$s"
                             }
                           }
-                        }
+                        },
+                        "_id": 0
                       }
                     }
                   ]
@@ -1013,7 +1036,8 @@ public class DateFunctionIntegrationTests extends AbstractQueryIntegrationTests 
                               "$literal": "%1$s"
                             }
                           }
-                        }
+                        },
+                        "_id": 0
                       }
                     }
                   ]
@@ -1040,7 +1064,8 @@ public class DateFunctionIntegrationTests extends AbstractQueryIntegrationTests 
                               "$literal": "%1$s"
                             }
                           }
-                        }
+                        },
+                        "_id": 0
                       }
                     }
                   ]
@@ -1078,7 +1103,8 @@ public class DateFunctionIntegrationTests extends AbstractQueryIntegrationTests 
                               ]
                             }
                           }
-                        }
+                        },
+                        "_id": 0
                       }
                     }
                   ]
@@ -1105,7 +1131,8 @@ public class DateFunctionIntegrationTests extends AbstractQueryIntegrationTests 
                               "$literal": "%1$s"
                             }
                           }
-                        }
+                        },
+                        "_id": 0
                       }
                     }
                   ]
@@ -1132,7 +1159,8 @@ public class DateFunctionIntegrationTests extends AbstractQueryIntegrationTests 
                               "$literal": "%1$s"
                             }
                           }
-                        }
+                        },
+                        "_id": 0
                       }
                     }
                   ]
@@ -1185,7 +1213,8 @@ public class DateFunctionIntegrationTests extends AbstractQueryIntegrationTests 
                               "time": "$newYears"
                             }
                           }
-                        }
+                        },
+                        "_id": 0
                       }
                     }
                   ]
@@ -1213,7 +1242,8 @@ public class DateFunctionIntegrationTests extends AbstractQueryIntegrationTests 
                               "$literal": "%1$s"
                             }
                           }
-                        }
+                        },
+                        "_id": 0
                       }
                     }
                   ]
@@ -1240,7 +1270,8 @@ public class DateFunctionIntegrationTests extends AbstractQueryIntegrationTests 
                               "$literal": "%1$s"
                             }
                           }
-                        }
+                        },
+                        "_id": 0
                       }
                     }
                   ]

--- a/src/integrationTest/java/com/mongodb/hibernate/query/function/string/StringFunctionIntegrationTests.java
+++ b/src/integrationTest/java/com/mongodb/hibernate/query/function/string/StringFunctionIntegrationTests.java
@@ -61,7 +61,8 @@ public class StringFunctionIntegrationTests extends AbstractQueryIntegrationTest
                       "$project": {
                         "#c_1": {
                           "$strLenCP": "$s"
-                        }
+                        },
+                        "_id": 0
                       }
                     }
                   ]
@@ -89,7 +90,8 @@ public class StringFunctionIntegrationTests extends AbstractQueryIntegrationTest
                               "$toString": "$s"
                             }
                           ]
-                        }
+                        },
+                        "_id": 0
                       }
                     }
                   ]
@@ -117,7 +119,8 @@ public class StringFunctionIntegrationTests extends AbstractQueryIntegrationTest
                               "$toString": 3
                             }
                           ]
-                        }
+                        },
+                        "_id": 0
                       }
                     }
                   ]
@@ -145,7 +148,8 @@ public class StringFunctionIntegrationTests extends AbstractQueryIntegrationTest
                               "$toString": "!"
                             }
                           ]
-                        }
+                        },
+                        "_id": 0
                       }
                     }
                   ]
@@ -176,7 +180,8 @@ public class StringFunctionIntegrationTests extends AbstractQueryIntegrationTest
                               "$literal": 1
                             }
                           ]
-                        }
+                        },
+                        "_id": 0
                       }
                     }
                   ]
@@ -222,7 +227,8 @@ public class StringFunctionIntegrationTests extends AbstractQueryIntegrationTest
                               "$literal": 1
                             }
                           ]
-                        }
+                        },
+                        "_id": 0
                       }
                     }
                   ]
@@ -268,7 +274,8 @@ public class StringFunctionIntegrationTests extends AbstractQueryIntegrationTest
                               "$literal": 1
                             }
                           ]
-                        }
+                        },
+                        "_id": 0
                       }
                     }
                   ]
@@ -314,7 +321,8 @@ public class StringFunctionIntegrationTests extends AbstractQueryIntegrationTest
                               "$literal": 1
                             }
                           ]
-                        }
+                        },
+                        "_id": 0
                       }
                     }
                   ]
@@ -360,7 +368,8 @@ public class StringFunctionIntegrationTests extends AbstractQueryIntegrationTest
                               "$literal": 1
                             }
                           ]
-                        }
+                        },
+                        "_id": 0
                       }
                     }
                   ]
@@ -391,7 +400,8 @@ public class StringFunctionIntegrationTests extends AbstractQueryIntegrationTest
                               "$literal": 1
                             }
                           ]
-                        }
+                        },
+                        "_id": 0
                       }
                     }
                   ]
@@ -412,7 +422,8 @@ public class StringFunctionIntegrationTests extends AbstractQueryIntegrationTest
                       "$project": {
                         "#c_1": {
                           "$toLower": "$s"
-                        }
+                        },
+                        "_id": 0
                       }
                     }
                   ]
@@ -459,7 +470,8 @@ public class StringFunctionIntegrationTests extends AbstractQueryIntegrationTest
                                               "repeatStr": "$s"
                                             }
                                           }
-                                        }
+                                        },
+                                        "_id": 0
                                       }
                                     }
                                   ]
@@ -595,7 +607,8 @@ public class StringFunctionIntegrationTests extends AbstractQueryIntegrationTest
                                       "targetLen": 20
                                     }
                                   }
-                                }
+                                },
+                                "_id": 0
                               }
                             }
                           ]
@@ -729,7 +742,8 @@ public class StringFunctionIntegrationTests extends AbstractQueryIntegrationTest
                               "targetLen": 20
                             }
                           }
-                        }
+                        },
+                        "_id": 0
                       }
                     }
                   ]
@@ -865,7 +879,8 @@ public class StringFunctionIntegrationTests extends AbstractQueryIntegrationTest
                                               "targetLen": 20
                                             }
                                           }
-                                        }
+                                        },
+                                        "_id": 0
                                       }
                                     }
                                   ]
@@ -999,7 +1014,8 @@ public class StringFunctionIntegrationTests extends AbstractQueryIntegrationTest
                               "targetLen": 20
                             }
                           }
-                        }
+                        },
+                        "_id": 0
                       }
                     }
                   ]
@@ -1133,7 +1149,8 @@ public class StringFunctionIntegrationTests extends AbstractQueryIntegrationTest
                               "targetLen": 6
                             }
                           }
-                        }
+                        },
+                        "_id": 0
                       }
                     }
                   ]
@@ -1267,7 +1284,8 @@ public class StringFunctionIntegrationTests extends AbstractQueryIntegrationTest
                               "targetLen": 6
                             }
                           }
-                        }
+                        },
+                        "_id": 0
                       }
                     }
                   ]
@@ -1401,7 +1419,8 @@ public class StringFunctionIntegrationTests extends AbstractQueryIntegrationTest
                               "targetLen": 60
                             }
                           }
-                        }
+                        },
+                        "_id": 0
                       }
                     }
                   ]
@@ -1535,7 +1554,8 @@ public class StringFunctionIntegrationTests extends AbstractQueryIntegrationTest
                               "targetLen": 60
                             }
                           }
-                        }
+                        },
+                        "_id": 0
                       }
                     }
                   ]
@@ -1671,7 +1691,8 @@ public class StringFunctionIntegrationTests extends AbstractQueryIntegrationTest
                               "targetLen": 3
                             }
                           }
-                        }
+                        },
+                        "_id": 0
                       }
                     }
                   ]
@@ -1807,7 +1828,8 @@ public class StringFunctionIntegrationTests extends AbstractQueryIntegrationTest
                               "targetLen": 3
                             }
                           }
-                        }
+                        },
+                        "_id": 0
                       }
                     }
                   ]
@@ -1943,7 +1965,8 @@ public class StringFunctionIntegrationTests extends AbstractQueryIntegrationTest
                               "targetLen": -1
                             }
                           }
-                        }
+                        },
+                        "_id": 0
                       }
                     }
                   ]
@@ -2079,7 +2102,8 @@ public class StringFunctionIntegrationTests extends AbstractQueryIntegrationTest
                               "targetLen": -1
                             }
                           }
-                        }
+                        },
+                        "_id": 0
                       }
                     }
                   ]
@@ -2213,7 +2237,8 @@ public class StringFunctionIntegrationTests extends AbstractQueryIntegrationTest
                               "targetLen": 6
                             }
                           }
-                        }
+                        },
+                        "_id": 0
                       }
                     }
                   ]
@@ -2347,7 +2372,8 @@ public class StringFunctionIntegrationTests extends AbstractQueryIntegrationTest
                               "targetLen": 6
                             }
                           }
-                        }
+                        },
+                        "_id": 0
                       }
                     }
                   ]
@@ -2481,7 +2507,8 @@ public class StringFunctionIntegrationTests extends AbstractQueryIntegrationTest
                               "targetLen": 3
                             }
                           }
-                        }
+                        },
+                        "_id": 0
                       }
                     }
                   ]
@@ -2615,7 +2642,8 @@ public class StringFunctionIntegrationTests extends AbstractQueryIntegrationTest
                               "targetLen": 3
                             }
                           }
-                        }
+                        },
+                        "_id": 0
                       }
                     }
                   ]
@@ -2679,7 +2707,8 @@ public class StringFunctionIntegrationTests extends AbstractQueryIntegrationTest
                               "str": "$s"
                             }
                           }
-                        }
+                        },
+                        "_id": 0
                       }
                     }
                   ]
@@ -2759,7 +2788,8 @@ public class StringFunctionIntegrationTests extends AbstractQueryIntegrationTest
                               "str": "$s"
                             }
                           }
-                        }
+                        },
+                        "_id": 0
                       }
                     }
                   ]
@@ -2823,7 +2853,8 @@ public class StringFunctionIntegrationTests extends AbstractQueryIntegrationTest
                               "str": "$s"
                             }
                           }
-                        }
+                        },
+                        "_id": 0
                       }
                     }
                   ]
@@ -2903,7 +2934,8 @@ public class StringFunctionIntegrationTests extends AbstractQueryIntegrationTest
                               "str": "$s"
                             }
                           }
-                        }
+                        },
+                        "_id": 0
                       }
                     }
                   ]
@@ -2983,7 +3015,8 @@ public class StringFunctionIntegrationTests extends AbstractQueryIntegrationTest
                               "str": "$s"
                             }
                           }
-                        }
+                        },
+                        "_id": 0
                       }
                     }
                   ]
@@ -3063,7 +3096,8 @@ public class StringFunctionIntegrationTests extends AbstractQueryIntegrationTest
                               "str": "$s"
                             }
                           }
-                        }
+                        },
+                        "_id": 0
                       }
                     }
                   ]
@@ -3087,7 +3121,8 @@ public class StringFunctionIntegrationTests extends AbstractQueryIntegrationTest
                             "chars": " ",
                             "input": "$s"
                           }
-                        }
+                        },
+                        "_id": 0
                       }
                     }
                   ]
@@ -3111,7 +3146,8 @@ public class StringFunctionIntegrationTests extends AbstractQueryIntegrationTest
                              "chars": " ",
                              "input": "$s"
                            }
-                         }
+                         },
+                         "_id": 0
                        }
                      }
                    ]
@@ -3135,7 +3171,8 @@ public class StringFunctionIntegrationTests extends AbstractQueryIntegrationTest
                             "chars": " ",
                             "input": "$s"
                           }
-                        }
+                        },
+                        "_id": 0
                       }
                     }
                   ]
@@ -3159,7 +3196,8 @@ public class StringFunctionIntegrationTests extends AbstractQueryIntegrationTest
                                         "chars": " ",
                                         "input": "$s"
                                        }
-                                    }
+                                    },
+                                "_id": 0
                                 }
                         }
                     ]
@@ -3183,7 +3221,8 @@ public class StringFunctionIntegrationTests extends AbstractQueryIntegrationTest
                             "chars": "_",
                             "input": "$u"
                           }
-                        }
+                        },
+                        "_id": 0
                       }
                     }
                   ]
@@ -3207,7 +3246,8 @@ public class StringFunctionIntegrationTests extends AbstractQueryIntegrationTest
                             "chars": "_",
                             "input": "$u"
                           }
-                        }
+                        },
+                        "_id": 0
                       }
                     }
                   ]
@@ -3231,7 +3271,8 @@ public class StringFunctionIntegrationTests extends AbstractQueryIntegrationTest
                             "chars": "_",
                             "input": "$u"
                           }
-                        }
+                        },
+                        "_id": 0
                       }
                     }
                   ]
@@ -3252,7 +3293,8 @@ public class StringFunctionIntegrationTests extends AbstractQueryIntegrationTest
                       "$project": {
                         "#c_1": {
                           "$toUpper": "$s"
-                        }
+                        },
+                        "_id": 0
                       }
                     }
                   ]

--- a/src/integrationTest/java/com/mongodb/hibernate/query/select/CompositePrimaryKeyIntegrationTests.java
+++ b/src/integrationTest/java/com/mongodb/hibernate/query/select/CompositePrimaryKeyIntegrationTests.java
@@ -234,7 +234,8 @@ class CompositePrimaryKeyIntegrationTests extends AbstractQueryIntegrationTests 
                           "$project": {
                             "_id#bookNo": "$_id.bookNo",
                             "_id#publisherId": "$_id.publisherId",
-                            "title": true
+                            "title": true,
+                            "_id": 0
                           }
                         }
                       ]
@@ -276,7 +277,8 @@ class CompositePrimaryKeyIntegrationTests extends AbstractQueryIntegrationTests 
                           "$project": {
                             "_id#bookNo": "$_id.bookNo",
                             "_id#publisherId": "$_id.publisherId",
-                            "title": true
+                            "title": true,
+                            "_id": 0
                           }
                         }
                       ]
@@ -307,7 +309,8 @@ class CompositePrimaryKeyIntegrationTests extends AbstractQueryIntegrationTests 
                           "$project": {
                             "_id#bookNo": "$_id.bookNo",
                             "_id#publisherId": "$_id.publisherId",
-                            "title": true
+                            "title": true,
+                            "_id": 0
                           }
                         }
                       ]
@@ -355,7 +358,8 @@ class CompositePrimaryKeyIntegrationTests extends AbstractQueryIntegrationTests 
                           "$project": {
                             "_id#bookNo": "$_id.bookNo",
                             "_id#publisherId": "$_id.publisherId",
-                            "title": true
+                            "title": true,
+                            "_id": 0
                           }
                         }
                       ]
@@ -389,7 +393,8 @@ class CompositePrimaryKeyIntegrationTests extends AbstractQueryIntegrationTests 
                           "$project": {
                             "_id#bookNo": "$_id.bookNo",
                             "_id#publisherId": "$_id.publisherId",
-                            "title": true
+                            "title": true,
+                            "_id": 0
                           }
                         }
                       ]
@@ -417,7 +422,8 @@ class CompositePrimaryKeyIntegrationTests extends AbstractQueryIntegrationTests 
                         {
                           "$project": {
                             "_id#bookNo": "$_id.bookNo",
-                            "_id#publisherId": "$_id.publisherId"
+                            "_id#publisherId": "$_id.publisherId",
+                            "_id": 0
                           }
                         }
                       ]
@@ -444,7 +450,8 @@ class CompositePrimaryKeyIntegrationTests extends AbstractQueryIntegrationTests 
                         },
                         {
                           "$project": {
-                            "_id#bookNo": "$_id.bookNo"
+                            "_id#bookNo": "$_id.bookNo",
+                            "_id": 0
                           }
                         }
                       ]
@@ -473,7 +480,8 @@ class CompositePrimaryKeyIntegrationTests extends AbstractQueryIntegrationTests 
                           "$project": {
                             "_id#bookNo": "$_id.bookNo",
                             "_id#publisherId": "$_id.publisherId",
-                            "title": true
+                            "title": true,
+                            "_id": 0
                           }
                         }
                       ]

--- a/src/integrationTest/java/com/mongodb/hibernate/query/select/ExpressionIntegrationTests.java
+++ b/src/integrationTest/java/com/mongodb/hibernate/query/select/ExpressionIntegrationTests.java
@@ -66,7 +66,8 @@ class ExpressionIntegrationTests extends AbstractQueryIntegrationTests {
                       "pipeline": [
                         {
                           "$project": {
-                            "#c_1": {"$add": ["$x", {"$numberInt": "1"}]}
+                            "#c_1": {"$add": ["$x", {"$numberInt": "1"}]},
+                            "_id": 0
                           }
                         }
                       ]
@@ -86,7 +87,8 @@ class ExpressionIntegrationTests extends AbstractQueryIntegrationTests {
                       "pipeline": [
                         {
                           "$project": {
-                            "#c_1": {"$subtract": ["$x", {"$numberInt": "1"}]}
+                            "#c_1": {"$subtract": ["$x", {"$numberInt": "1"}]},
+                            "_id": 0
                           }
                         }
                       ]
@@ -106,7 +108,8 @@ class ExpressionIntegrationTests extends AbstractQueryIntegrationTests {
                       "pipeline": [
                         {
                           "$project": {
-                            "#c_1": {"$multiply": ["$x", {"$numberInt": "2"}]}
+                            "#c_1": {"$multiply": ["$x", {"$numberInt": "2"}]},
+                            "_id": 0
                           }
                         }
                       ]
@@ -126,7 +129,8 @@ class ExpressionIntegrationTests extends AbstractQueryIntegrationTests {
                       "pipeline": [
                         {
                           "$project": {
-                            "#c_1": {"$divide": ["$x", 2.0]}
+                            "#c_1": {"$divide": ["$x", 2.0]},
+                            "_id": 0
                           }
                         }
                       ]
@@ -148,7 +152,8 @@ class ExpressionIntegrationTests extends AbstractQueryIntegrationTests {
                       "pipeline": [
                         {
                           "$project": {
-                            "#c_1": {"$toInt": {"$divide": ["$x", "$y"]}}
+                            "#c_1": {"$toInt": {"$divide": ["$x", "$y"]}},
+                            "_id": 0
                           }
                         }
                       ]
@@ -168,7 +173,8 @@ class ExpressionIntegrationTests extends AbstractQueryIntegrationTests {
                       "pipeline": [
                         {
                           "$project": {
-                            "#c_1": {"$add": [{"$multiply": ["$x", "$y"]}, {"$numberInt": "1"}]}
+                            "#c_1": {"$add": [{"$multiply": ["$x", "$y"]}, {"$numberInt": "1"}]},
+                            "_id": 0
                           }
                         }
                       ]
@@ -188,7 +194,8 @@ class ExpressionIntegrationTests extends AbstractQueryIntegrationTests {
                       "pipeline": [
                         {
                           "$project": {
-                            "total": {"$add": ["$x", {"$numberInt": "1"}]}
+                            "total": {"$add": ["$x", {"$numberInt": "1"}]},
+                            "_id": 0
                           }
                         }
                       ]
@@ -209,7 +216,8 @@ class ExpressionIntegrationTests extends AbstractQueryIntegrationTests {
                       "pipeline": [
                         {
                           "$project": {
-                            "#c_1": {"$add": [{"$numberInt": "5"}, "$x"]}
+                            "#c_1": {"$add": [{"$numberInt": "5"}, "$x"]},
+                            "_id": 0
                           }
                         }
                       ]
@@ -229,7 +237,8 @@ class ExpressionIntegrationTests extends AbstractQueryIntegrationTests {
                       "pipeline": [
                         {
                           "$project": {
-                            "#c_1": {"$add": ["$x", {"$numberInt": "100"}]}
+                            "#c_1": {"$add": ["$x", {"$numberInt": "100"}]},
+                            "_id": 0
                           }
                         }
                       ]
@@ -261,7 +270,8 @@ class ExpressionIntegrationTests extends AbstractQueryIntegrationTests {
                         {
                           "$project": {
                             "x": true,
-                            "#c_2": {"$add": ["$x", {"$numberInt": "1"}]}
+                            "#c_2": {"$add": ["$x", {"$numberInt": "1"}]},
+                            "_id": 0
                           }
                         }
                       ]
@@ -454,7 +464,8 @@ class ExpressionIntegrationTests extends AbstractQueryIntegrationTests {
                       "pipeline": [
                         {
                           "$project": {
-                            "#c_1": {"$multiply": [{"$numberInt": "-1"}, "$x"]}
+                            "#c_1": {"$multiply": [{"$numberInt": "-1"}, "$x"]},
+                            "_id": 0
                           }
                         }
                       ]
@@ -474,7 +485,8 @@ class ExpressionIntegrationTests extends AbstractQueryIntegrationTests {
                       "pipeline": [
                         {
                           "$project": {
-                            "#c_1": "$x"
+                            "#c_1": "$x",
+                            "_id": 0
                           }
                         }
                       ]
@@ -495,7 +507,8 @@ class ExpressionIntegrationTests extends AbstractQueryIntegrationTests {
                         {
                           "$project": {
                             "a": {"$add": ["$x", {"$numberInt": "1"}]},
-                            "b": {"$add": ["$y", {"$numberInt": "2"}]}
+                            "b": {"$add": ["$y", {"$numberInt": "2"}]},
+                            "_id": 0
                           }
                         }
                       ]
@@ -519,7 +532,8 @@ class ExpressionIntegrationTests extends AbstractQueryIntegrationTests {
                         {
                           "$project": {
                             "#c_2": {"$add": ["$y", {"$numberInt": "1"}]},
-                            "#c_1": {"$add": ["$x", {"$numberInt": "1"}]}
+                            "#c_1": {"$add": ["$x", {"$numberInt": "1"}]},
+                            "_id": 0
                           }
                         }
                       ]
@@ -540,7 +554,8 @@ class ExpressionIntegrationTests extends AbstractQueryIntegrationTests {
                         {
                           "$project": {
                             "#c_1": {"$add": ["$x", {"$numberInt": "1"}]},
-                            "b": {"$add": ["$y", {"$numberInt": "2"}]}
+                            "b": {"$add": ["$y", {"$numberInt": "2"}]},
+                            "_id": 0
                           }
                         }
                       ]
@@ -585,7 +600,8 @@ class ExpressionIntegrationTests extends AbstractQueryIntegrationTests {
                       "pipeline": [
                         {
                           "$project": {
-                            "#c_1": {"$gt": ["$x", {"$numberInt": "1"}]}
+                            "#c_1": {"$gt": ["$x", {"$numberInt": "1"}]},
+                            "_id": 0
                           }
                         }
                       ]
@@ -603,7 +619,7 @@ class ExpressionIntegrationTests extends AbstractQueryIntegrationTests {
                     {
                       "aggregate": "items",
                       "pipeline": [
-                        {"$project": {"#c_1": {"$ne": ["$x", {"$numberInt": "4"}]}}}
+                        {"$project": {"#c_1": {"$ne": ["$x", {"$numberInt": "4"}]}, "_id": 0}}
                       ]
                     }""",
                     List.of(true, false, true),
@@ -619,7 +635,7 @@ class ExpressionIntegrationTests extends AbstractQueryIntegrationTests {
                     {
                       "aggregate": "items",
                       "pipeline": [
-                        {"$project": {"#c_1": {"$lt": ["$x", {"$numberInt": "5"}]}}}
+                        {"$project": {"#c_1": {"$lt": ["$x", {"$numberInt": "5"}]}, "_id": 0}}
                       ]
                     }""",
                     List.of(false, true, false),
@@ -635,7 +651,7 @@ class ExpressionIntegrationTests extends AbstractQueryIntegrationTests {
                     {
                       "aggregate": "items",
                       "pipeline": [
-                        {"$project": {"#c_1": {"$lte": ["$x", {"$numberInt": "5"}]}}}
+                        {"$project": {"#c_1": {"$lte": ["$x", {"$numberInt": "5"}]}, "_id": 0}}
                       ]
                     }""",
                     List.of(false, true, true),
@@ -651,7 +667,7 @@ class ExpressionIntegrationTests extends AbstractQueryIntegrationTests {
                     {
                       "aggregate": "items",
                       "pipeline": [
-                        {"$project": {"#c_1": {"$gte": ["$x", {"$numberInt": "5"}]}}}
+                        {"$project": {"#c_1": {"$gte": ["$x", {"$numberInt": "5"}]}, "_id": 0}}
                       ]
                     }""",
                     List.of(true, false, true),
@@ -669,7 +685,7 @@ class ExpressionIntegrationTests extends AbstractQueryIntegrationTests {
                     {
                       "aggregate": "items",
                       "pipeline": [
-                        {"$project": {"#c_1": {"$eq": ["a", {"$literal": "$foo"}]}}}
+                        {"$project": {"#c_1": {"$eq": ["a", {"$literal": "$foo"}]}, "_id": 0}}
                       ]
                     }""",
                     List.of(false, false, false),
@@ -688,7 +704,7 @@ class ExpressionIntegrationTests extends AbstractQueryIntegrationTests {
                     {
                       "aggregate": "items",
                       "pipeline": [
-                        {"$project": {"#c_1": {"$eq": ["a", {"$literal": "$x"}]}}}
+                        {"$project": {"#c_1": {"$eq": ["a", {"$literal": "$x"}]}, "_id": 0}}
                       ]
                     }""",
                     List.of(false, false, false),
@@ -714,7 +730,8 @@ class ExpressionIntegrationTests extends AbstractQueryIntegrationTests {
                                 ],
                                 "default": {"$numberInt": "0"}
                               }
-                            }
+                            },
+                            "_id": 0
                           }
                         }
                       ]
@@ -743,7 +760,8 @@ class ExpressionIntegrationTests extends AbstractQueryIntegrationTests {
                                 ],
                                 "default": {"$numberInt": "0"}
                               }
-                            }
+                            },
+                            "_id": 0
                           }
                         }
                       ]
@@ -771,7 +789,8 @@ class ExpressionIntegrationTests extends AbstractQueryIntegrationTests {
                                 ],
                                 "default": null
                               }
-                            }
+                            },
+                            "_id": 0
                           }
                         }
                       ]
@@ -800,7 +819,8 @@ class ExpressionIntegrationTests extends AbstractQueryIntegrationTests {
                                 ],
                                 "default": "$x"
                               }
-                            }
+                            },
+                            "_id": 0
                           }
                         }
                       ]
@@ -828,7 +848,8 @@ class ExpressionIntegrationTests extends AbstractQueryIntegrationTests {
                                 ],
                                 "default": {"$numberInt": "0"}
                               }
-                            }
+                            },
+                            "_id": 0
                           }
                         }
                       ]
@@ -859,7 +880,8 @@ class ExpressionIntegrationTests extends AbstractQueryIntegrationTests {
                                 ],
                                 "default": {"$numberInt": "0"}
                               }
-                            }
+                            },
+                            "_id": 0
                           }
                         }
                       ]
@@ -943,7 +965,8 @@ class ExpressionIntegrationTests extends AbstractQueryIntegrationTests {
                       "pipeline": [
                         {
                           "$project": {
-                            "#c_1": {"$toInt": {"$divide": ["$x", "$y"]}}
+                            "#c_1": {"$toInt": {"$divide": ["$x", "$y"]}},
+                            "_id": 0
                           }
                         }
                       ]
@@ -1066,7 +1089,7 @@ class ExpressionIntegrationTests extends AbstractQueryIntegrationTests {
                                 {
                                   "aggregate": "items",
                                   "pipeline": [
-                                    {"$project": {"#c_1": {"$toInt": {"$divide": ["$x", "$y"]}}}}
+                                    {"$project": {"#c_1": {"$toInt": {"$divide": ["$x", "$y"]}}, "_id": 0}}
                                   ]
                                 }"""));
                 assertThat(results).containsExactly(3, 0, 1);
@@ -1089,7 +1112,7 @@ class ExpressionIntegrationTests extends AbstractQueryIntegrationTests {
                                 {
                                   "aggregate": "items",
                                   "pipeline": [
-                                    {"$project": {"#c_1": {"$mod": ["$x", "$y"]}}}
+                                    {"$project": {"#c_1": {"$mod": ["$x", "$y"]}, "_id": 0}}
                                   ]
                                 }"""));
                 assertThat(results).containsExactly(1, 4, 1);
@@ -1118,7 +1141,8 @@ class ExpressionIntegrationTests extends AbstractQueryIntegrationTests {
                       "pipeline": [
                         {
                           "$project": {
-                            "#c_1": {"$toLong": {"$divide": ["$a", "$b"]}}
+                            "#c_1": {"$toLong": {"$divide": ["$a", "$b"]}},
+                            "_id": 0
                           }
                         }
                       ]

--- a/src/integrationTest/java/com/mongodb/hibernate/query/select/GroupByHavingIntegrationTests.java
+++ b/src/integrationTest/java/com/mongodb/hibernate/query/select/GroupByHavingIntegrationTests.java
@@ -128,7 +128,8 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                     },
                     {
                       "$project": {
-                        "_id#primitiveInt": "$_id.primitiveInt"
+                        "_id#primitiveInt": "$_id.primitiveInt",
+                        "_id": 0
                       }
                     }
                   ]
@@ -150,7 +151,7 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                   "aggregate": "Item",
                   "pipeline": [
                     {"$group": {"_id": {"itemStruct#primitiveInt": "$itemStruct.primitiveInt"}}},
-                    {"$project": {"_id#itemStruct#primitiveInt": "$_id.itemStruct#primitiveInt"}}
+                    {"$project": {"_id#itemStruct#primitiveInt": "$_id.itemStruct#primitiveInt", "_id": 0}}
                   ]
                 }
                 """,
@@ -181,7 +182,8 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                        },
                        {
                          "$project": {
-                           "_id#primitiveInt": "$_id.primitiveInt"
+                           "_id#primitiveInt": "$_id.primitiveInt",
+                           "_id": 0
                          }
                        }
                      ]
@@ -202,7 +204,7 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                   "pipeline": [
                     {"$group": {"_id": {"itemStruct#primitiveInt": "$itemStruct.primitiveInt"}}},
                     {"$sort": {"_id.itemStruct#primitiveInt": 1}},
-                    {"$project": {"_id#itemStruct#primitiveInt": "$_id.itemStruct#primitiveInt"}}
+                    {"$project": {"_id#itemStruct#primitiveInt": "$_id.itemStruct#primitiveInt", "_id": 0}}
                   ]
                 }
                 """,
@@ -230,7 +232,8 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                       {
                         "$project": {
                           "_id#primitiveInt": "$_id.primitiveInt",
-                          "_id#primitiveBoolean": "$_id.primitiveBoolean"
+                          "_id#primitiveBoolean": "$_id.primitiveBoolean",
+                          "_id": 0
                         }
                       }
                     ]
@@ -301,7 +304,8 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                         },
                         {
                           "$project": {
-                            "_id##ib1_0#primitiveInt": "$_id.#ib1_0#primitiveInt"
+                            "_id##ib1_0#primitiveInt": "$_id.#ib1_0#primitiveInt",
+                            "_id": 0
                           }
                         }
                       ]
@@ -345,7 +349,8 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                         },
                         {
                           "$project": {
-                            "_id#_id": "$_id._id"
+                            "_id#_id": "$_id._id",
+                            "_id": 0
                           }
                         }
                       ]
@@ -394,7 +399,8 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                         },
                         {
                           "$project": {
-                            "_id##ib1_0#primitiveInt": "$_id.#ib1_0#primitiveInt"
+                            "_id##ib1_0#primitiveInt": "$_id.#ib1_0#primitiveInt",
+                            "_id": 0
                           }
                         }
                       ]
@@ -443,7 +449,8 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                         },
                         {
                           "$project": {
-                            "_id#_id": "$_id._id"
+                            "_id#_id": "$_id._id",
+                            "_id": 0
                           }
                         }
                       ]
@@ -498,7 +505,8 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                         {
                           "$project": {
                             "_id#_id": "$_id._id",
-                            "_id##ib1_0#primitiveInt": "$_id.#ib1_0#primitiveInt"
+                            "_id##ib1_0#primitiveInt": "$_id.#ib1_0#primitiveInt",
+                            "_id": 0
                           }
                         }
                       ]
@@ -545,7 +553,8 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                         {
                           "$project": {
                             "_id#_id": "$_id._id",
-                            "_id##ib1_0#primitiveInt": "$_id.#ib1_0#primitiveInt"
+                            "_id##ib1_0#primitiveInt": "$_id.#ib1_0#primitiveInt",
+                            "_id": 0
                           }
                         }
                       ]
@@ -638,7 +647,7 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                       "aggregate": "Item",
                       "pipeline": [
                         {"$group": {"_id": {"k0": {"$add": ["$primitiveInt", 1]}}}},
-                        {"$project": {"#c_1": "$_id.k0"}}
+                        {"$project": {"#c_1": "$_id.k0", "_id": 0}}
                       ]
                     }
                     """,
@@ -656,7 +665,7 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                       "aggregate": "Item",
                       "pipeline": [
                         {"$group": {"_id": {"primitiveInt": "$primitiveInt"}}},
-                        {"$project": {"#c_1": {"$add": ["$_id.primitiveInt", 1]}}}
+                        {"$project": {"#c_1": {"$add": ["$_id.primitiveInt", 1]}, "_id": 0}}
                       ]
                     }
                     """,
@@ -674,7 +683,7 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                       "aggregate": "Item",
                       "pipeline": [
                         {"$group": {"_id": {"k0": {"$add": ["$primitiveInt", 1]}}}},
-                        {"$project": {"#c_1": {"$multiply": ["$_id.k0", 2]}}}
+                        {"$project": {"#c_1": {"$multiply": ["$_id.k0", 2]}, "_id": 0}}
                       ]
                     }
                     """,
@@ -695,7 +704,7 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                           "primitiveInt": "$primitiveInt",
                           "k1": {"$add": ["$primitiveInt", 1]}
                         }}},
-                        {"$project": {"#c_1": "$_id.k1"}}
+                        {"$project": {"#c_1": "$_id.k1", "_id": 0}}
                       ]
                     }
                     """,
@@ -713,7 +722,7 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                       "aggregate": "Item",
                       "pipeline": [
                         {"$group": {"_id": {"k0": {"$multiply": [-1, "$primitiveInt"]}}}},
-                        {"$project": {"#c_1": "$_id.k0"}}
+                        {"$project": {"#c_1": "$_id.k0", "_id": 0}}
                       ]
                     }
                     """,
@@ -734,7 +743,7 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                           "primitiveInt": "$primitiveInt",
                           "k1": {"$add": ["$primitiveInt", 1]}
                         }}},
-                        {"$project": {"#c_1": "$_id.k1", "_id#primitiveInt": "$_id.primitiveInt"}}
+                        {"$project": {"#c_1": "$_id.k1", "_id#primitiveInt": "$_id.primitiveInt", "_id": 0}}
                       ]
                     }
                     """,
@@ -758,7 +767,7 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                       "aggregate": "Item",
                       "pipeline": [
                         {"$group": {"_id": {"k0": {"$add": ["$primitiveInt", 10]}}}},
-                        {"$project": {"#c_1": "$_id.k0"}}
+                        {"$project": {"#c_1": "$_id.k0", "_id": 0}}
                       ]
                     }
                     """,
@@ -780,7 +789,7 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                       "pipeline": [
                         {"$group": {"_id": {"k0": {"$add": ["$primitiveInt", 1]}}}},
                         {"$match": {"_id.k0": {"$gt": 2}}},
-                        {"$project": {"#c_1": "$_id.k0"}}
+                        {"$project": {"#c_1": "$_id.k0", "_id": 0}}
                       ]
                     }
                     """,
@@ -803,7 +812,7 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                           {"_id.k0": {"$gt": 2}},
                           {"_id.k0": {"$lt": 5}}
                         ]}},
-                        {"$project": {"#c_1": "$_id.k0"}}
+                        {"$project": {"#c_1": "$_id.k0", "_id": 0}}
                       ]
                     }
                     """,
@@ -827,7 +836,7 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                         {"$project": {"#c_1": {"$switch": {
                           "branches": [{"case": {"$gt": ["$_id.primitiveInt", 2]}, "then": 1}],
                           "default": 0
-                        }}}}
+                        }}, "_id": 0}}
                       ]
                     }
                     """,
@@ -856,7 +865,7 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                             {"$lt": ["$_id.primitiveInt", 4]}
                           ]}, "then": 1}],
                           "default": 0
-                        }}}}
+                        }}, "_id": 0}}
                       ]
                     }
                     """,
@@ -877,7 +886,7 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                       "aggregate": "Item",
                       "pipeline": [
                         {"$group": {"_id": {"k0": {"$strLenCP": "$string"}}}},
-                        {"$project": {"#c_1": "$_id.k0"}}
+                        {"$project": {"#c_1": "$_id.k0", "_id": 0}}
                       ]
                     }
                     """,
@@ -898,7 +907,7 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                       "aggregate": "Item",
                       "pipeline": [
                         {"$group": {"_id": {"k0": {"$strLenCP": "$string"}}}},
-                        {"$project": {"#c_1": {"$add": ["$_id.k0", 1]}}}
+                        {"$project": {"#c_1": {"$add": ["$_id.k0", 1]}, "_id": 0}}
                       ]
                     }
                     """,
@@ -918,7 +927,7 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                       "aggregate": "Item",
                       "pipeline": [
                         {"$group": {"_id": {"k0": {"$toUpper": {"$toLower": "$string"}}}}},
-                        {"$project": {"#c_1": "$_id.k0"}}
+                        {"$project": {"#c_1": "$_id.k0", "_id": 0}}
                       ]
                     }
                     """,
@@ -939,7 +948,7 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                       "aggregate": "Item",
                       "pipeline": [
                         {"$group": {"_id": {"k0": {"$toLower": "$string"}}}},
-                        {"$project": {"#c_1": {"$toUpper": "$_id.k0"}}}
+                        {"$project": {"#c_1": {"$toUpper": "$_id.k0"}, "_id": 0}}
                       ]
                     }
                     """,
@@ -960,7 +969,7 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                       "aggregate": "Item",
                       "pipeline": [
                         {"$group": {"_id": {"k0": {"$strLenCP": "$string"}}}},
-                        {"$project": {"#c_1": "$_id.k0", "#c_2": {"$add": ["$_id.k0", 1]}}}
+                        {"$project": {"#c_1": "$_id.k0", "#c_2": {"$add": ["$_id.k0", 1]}, "_id": 0}}
                       ]
                     }
                     """,
@@ -985,7 +994,7 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                       "pipeline": [
                         {"$group": {"_id": {"k0": {"$strLenCP": "$string"}}}},
                         {"$match": {"_id.k0": {"$gt": 0}}},
-                        {"$project": {"#c_1": "$_id.k0"}}
+                        {"$project": {"#c_1": "$_id.k0", "_id": 0}}
                       ]
                     }
                     """,
@@ -1010,7 +1019,7 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                         {"$project": {"#c_1": {"$switch": {
                           "branches": [{"case": {"$gt": ["$_id.k0", 0]}, "then": 1}],
                           "default": 0
-                        }}}}
+                        }}, "_id": 0}}
                       ]
                     }
                     """,
@@ -1035,7 +1044,7 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                           {"$toString": "$string"},
                           {"$toString": "$string"}
                         ]}}}}},
-                        {"$project": {"#c_1": "$_id.k0"}}
+                        {"$project": {"#c_1": "$_id.k0", "_id": 0}}
                       ]
                     }
                     """,
@@ -1060,7 +1069,7 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                           "primitiveInt": "$primitiveInt",
                           "k1": {"$toUpper": "$string"}
                         }}},
-                        {"$project": {"_id#primitiveInt": "$_id.primitiveInt", "#c_2": "$_id.k1"}}
+                        {"$project": {"_id#primitiveInt": "$_id.primitiveInt", "#c_2": "$_id.k1", "_id": 0}}
                       ]
                     }
                     """,
@@ -1102,7 +1111,8 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                          },
                          {
                            "$project": {
-                             "_id#primitiveInt": "$_id.primitiveInt"
+                             "_id#primitiveInt": "$_id.primitiveInt",
+                             "_id": 0
                            }
                          }
                        ]
@@ -1124,7 +1134,7 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                     {"$group": {"_id": {"itemStruct#primitiveInt": "$itemStruct.primitiveInt"}}},
                     {"$match": {"_id.itemStruct#primitiveInt": {"$gt": 1}}},
                     {"$sort": {"_id.itemStruct#primitiveInt": 1}},
-                    {"$project": {"_id#itemStruct#primitiveInt": "$_id.itemStruct#primitiveInt"}}
+                    {"$project": {"_id#itemStruct#primitiveInt": "$_id.itemStruct#primitiveInt", "_id": 0}}
                   ]
                 }
                 """,
@@ -1144,7 +1154,7 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                     {"$match": {"primitiveInt": {"$gt": 1}}},
                     {"$group": {"_id": {"primitiveInt": "$primitiveInt"}}},
                     {"$sort": {"_id.primitiveInt": 1}},
-                    {"$project": {"_id#primitiveInt": "$_id.primitiveInt"}}
+                    {"$project": {"_id#primitiveInt": "$_id.primitiveInt", "_id": 0}}
                   ]
                 }
                 """,
@@ -1164,7 +1174,7 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                     {"$match": {"itemStruct.primitiveInt": {"$gt": 1}}},
                     {"$group": {"_id": {"itemStruct#primitiveInt": "$itemStruct.primitiveInt"}}},
                     {"$sort": {"_id.itemStruct#primitiveInt": 1}},
-                    {"$project": {"_id#itemStruct#primitiveInt": "$_id.itemStruct#primitiveInt"}}
+                    {"$project": {"_id#itemStruct#primitiveInt": "$_id.itemStruct#primitiveInt", "_id": 0}}
                   ]
                 }
                 """,
@@ -1183,7 +1193,7 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                   "pipeline": [
                     {"$group": {"_id": {"_id": "$_id"}}},
                     {"$sort": {"_id._id": 1}},
-                    {"$project": {"_id#_id": "$_id._id"}}
+                    {"$project": {"_id#_id": "$_id._id", "_id": 0}}
                   ]
                 }
                 """,

--- a/src/integrationTest/java/com/mongodb/hibernate/query/select/JoinSelectQueryIntegrationTests.java
+++ b/src/integrationTest/java/com/mongodb/hibernate/query/select/JoinSelectQueryIntegrationTests.java
@@ -1956,7 +1956,8 @@ class JoinSelectQueryIntegrationTests extends AbstractQueryIntegrationTests {
                         { "$unwind": "$#sl1_0" },
                         {
                           "$project": {
-                            "sl1_0#stringsList": "$#sl1_0.stringsList"
+                            "sl1_0#stringsList": "$#sl1_0.stringsList",
+                            "_id": 0
                           }
                         }
                       ]

--- a/src/integrationTest/java/com/mongodb/hibernate/query/select/NativeQueryIntegrationTests.java
+++ b/src/integrationTest/java/com/mongodb/hibernate/query/select/NativeQueryIntegrationTests.java
@@ -747,6 +747,39 @@ class NativeQueryIntegrationTests extends AbstractQueryIntegrationTests {
         }
     }
 
+    /**
+     * A {@code $project} that does not specify {@code _id} is normalized to exclude it, so the query returns exactly
+     * the projected fields instead of MongoDB's implicitly retained {@code _id}. A native query that binds to something
+     * needing the id column must therefore project {@code _id} explicitly.
+     */
+    @Nested
+    class OmittedId implements MongoServiceRegistryProducer {
+        @Test
+        void testScalar() {
+            getSessionFactoryScope().inSession(session -> {
+                var mql = mql(COLLECTION_NAME, List.of(match(eq(item.id)), project(include("string"))));
+                assertEq(
+                        item.string,
+                        session.createNativeQuery(mql, String.class).getSingleResult());
+                assertActualCommandsInOrder(BsonDocument.parse(
+                        """
+                        {"aggregate": "%s", "pipeline": [{"$match": {"%s": %d}}, {"$project": {"string": 1, "%s": 0}}]}"""
+                                .formatted(COLLECTION_NAME, ID_FIELD_NAME, item.id, ID_FIELD_NAME)));
+            });
+        }
+
+        @Test
+        void testEntity() {
+            getSessionFactoryScope().inSession(session -> {
+                var mql = mql(COLLECTION_NAME, List.of(match(eq(item.id)), omitId(Item.projectAll())));
+                assertThatThrownBy(
+                                () -> session.createNativeQuery(mql, Item.class).getSingleResult())
+                        .hasRootCauseInstanceOf(SQLException.class)
+                        .hasMessageContaining("Unknown column label [%s]".formatted(ID_FIELD_NAME));
+            });
+        }
+    }
+
     @Nested
     class Unsupported implements MongoServiceRegistryProducer {
         /**
@@ -807,6 +840,12 @@ class NativeQueryIntegrationTests extends AbstractQueryIntegrationTests {
 
     private static Bson excludeId(Bson projectStage) {
         return exclude(projectStage, singleton(ID_FIELD_NAME));
+    }
+
+    private static Bson omitId(Bson projectStage) {
+        var fields = projectStage.toBsonDocument().clone().getDocument("$project");
+        fields.remove(ID_FIELD_NAME);
+        return project(fields);
     }
 
     @Entity

--- a/src/integrationTest/java/com/mongodb/hibernate/query/select/PredicateExpressionIntegrationTests.java
+++ b/src/integrationTest/java/com/mongodb/hibernate/query/select/PredicateExpressionIntegrationTests.java
@@ -55,7 +55,7 @@ class PredicateExpressionIntegrationTests extends AbstractQueryIntegrationTests 
                     {
                       "aggregate": "widgets",
                       "pipeline": [
-                        {"$project": {"#c_1": {"$and": [{"$gt": ["$x", {"$numberInt": "1"}]}, {"$lt": ["$y", {"$numberInt": "5"}]}]}}}
+                        {"$project": {"#c_1": {"$and": [{"$gt": ["$x", {"$numberInt": "1"}]}, {"$lt": ["$y", {"$numberInt": "5"}]}]}, "_id": 0}}
                       ]
                     }""",
                     List.of(true, false, true),
@@ -71,7 +71,7 @@ class PredicateExpressionIntegrationTests extends AbstractQueryIntegrationTests 
                     {
                       "aggregate": "widgets",
                       "pipeline": [
-                        {"$project": {"#c_1": {"$or": [{"$gt": ["$x", {"$numberInt": "8"}]}, {"$lt": ["$y", {"$numberInt": "5"}]}]}}}
+                        {"$project": {"#c_1": {"$or": [{"$gt": ["$x", {"$numberInt": "8"}]}, {"$lt": ["$y", {"$numberInt": "5"}]}]}, "_id": 0}}
                       ]
                     }""",
                     List.of(true, false, true),
@@ -87,7 +87,7 @@ class PredicateExpressionIntegrationTests extends AbstractQueryIntegrationTests 
                     {
                       "aggregate": "widgets",
                       "pipeline": [
-                        {"$project": {"#c_1": {"$and": [{"$gt": ["$x", {"$numberInt": "1"}]}, {"$not": [{"$lt": ["$y", {"$numberInt": "5"}]}]}]}}}
+                        {"$project": {"#c_1": {"$and": [{"$gt": ["$x", {"$numberInt": "1"}]}, {"$not": [{"$lt": ["$y", {"$numberInt": "5"}]}]}]}, "_id": 0}}
                       ]
                     }""",
                     List.of(false, true, false),
@@ -103,7 +103,7 @@ class PredicateExpressionIntegrationTests extends AbstractQueryIntegrationTests 
                     {
                       "aggregate": "widgets",
                       "pipeline": [
-                        {"$project": {"#c_1": {"$and": [{"$gt": ["$x", {"$numberInt": "1"}]}, {"$eq": ["$flag", true]}]}}}
+                        {"$project": {"#c_1": {"$and": [{"$gt": ["$x", {"$numberInt": "1"}]}, {"$eq": ["$flag", true]}]}, "_id": 0}}
                       ]
                     }""",
                     List.of(true, false, true),
@@ -121,7 +121,7 @@ class PredicateExpressionIntegrationTests extends AbstractQueryIntegrationTests 
                     {
                       "aggregate": "widgets",
                       "pipeline": [
-                        {"$project": {"#c_1": {"$and": [{"$gt": ["$x", {"$numberInt": "1"}]}, {"$eq": ["$flag", false]}]}}}
+                        {"$project": {"#c_1": {"$and": [{"$gt": ["$x", {"$numberInt": "1"}]}, {"$eq": ["$flag", false]}]}, "_id": 0}}
                       ]
                     }""",
                     List.of(false, true, false),
@@ -137,7 +137,7 @@ class PredicateExpressionIntegrationTests extends AbstractQueryIntegrationTests 
                     {
                       "aggregate": "widgets",
                       "pipeline": [
-                        {"$project": {"#c_1": {"$in": ["$x", [{"$numberInt": "4"}, {"$numberInt": "5"}]]}}}
+                        {"$project": {"#c_1": {"$in": ["$x", [{"$numberInt": "4"}, {"$numberInt": "5"}]]}, "_id": 0}}
                       ]
                     }""",
                     List.of(false, true, true),
@@ -153,7 +153,7 @@ class PredicateExpressionIntegrationTests extends AbstractQueryIntegrationTests 
                     {
                       "aggregate": "widgets",
                       "pipeline": [
-                        {"$project": {"#c_1": {"$in": ["$name", ["alpha", "beta"]]}}}
+                        {"$project": {"#c_1": {"$in": ["$name", ["alpha", "beta"]]}, "_id": 0}}
                       ]
                     }""",
                     List.of(true, true, false),
@@ -169,7 +169,7 @@ class PredicateExpressionIntegrationTests extends AbstractQueryIntegrationTests 
                     {
                       "aggregate": "widgets",
                       "pipeline": [
-                        {"$project": {"#c_1": {"$not": [{"$in": ["$x", [{"$numberInt": "4"}, {"$numberInt": "5"}]]}]}}}
+                        {"$project": {"#c_1": {"$not": [{"$in": ["$x", [{"$numberInt": "4"}, {"$numberInt": "5"}]]}]}, "_id": 0}}
                       ]
                     }""",
                     List.of(true, false, false),
@@ -185,7 +185,7 @@ class PredicateExpressionIntegrationTests extends AbstractQueryIntegrationTests 
                     {
                       "aggregate": "widgets",
                       "pipeline": [
-                        {"$project": {"#c_1": {"$in": ["$name", [{"$literal": "$x"}, "alpha"]]}}}
+                        {"$project": {"#c_1": {"$in": ["$name", [{"$literal": "$x"}, "alpha"]]}, "_id": 0}}
                       ]
                     }""",
                     List.of(true, false, false),
@@ -201,7 +201,7 @@ class PredicateExpressionIntegrationTests extends AbstractQueryIntegrationTests 
                     {
                       "aggregate": "widgets",
                       "pipeline": [
-                        {"$project": {"#c_1": {"$regexMatch": {"input": "$name", "regex": "^a.*$", "options": "s"}}}}
+                        {"$project": {"#c_1": {"$regexMatch": {"input": "$name", "regex": "^a.*$", "options": "s"}}, "_id": 0}}
                       ]
                     }""",
                     List.of(true, false, false),
@@ -217,7 +217,7 @@ class PredicateExpressionIntegrationTests extends AbstractQueryIntegrationTests 
                     {
                       "aggregate": "widgets",
                       "pipeline": [
-                        {"$project": {"#c_1": {"$not": [{"$regexMatch": {"input": "$name", "regex": "^a.*$", "options": "s"}}]}}}
+                        {"$project": {"#c_1": {"$not": [{"$regexMatch": {"input": "$name", "regex": "^a.*$", "options": "s"}}]}, "_id": 0}}
                       ]
                     }""",
                     List.of(false, true, true),
@@ -233,7 +233,7 @@ class PredicateExpressionIntegrationTests extends AbstractQueryIntegrationTests 
                     {
                       "aggregate": "widgets",
                       "pipeline": [
-                        {"$project": {"#c_1": {"$eq": ["$nn", null]}}}
+                        {"$project": {"#c_1": {"$eq": ["$nn", null]}, "_id": 0}}
                       ]
                     }""",
                     List.of(false, true, false),
@@ -249,7 +249,7 @@ class PredicateExpressionIntegrationTests extends AbstractQueryIntegrationTests 
                     {
                       "aggregate": "widgets",
                       "pipeline": [
-                        {"$project": {"#c_1": {"$ne": ["$nn", null]}}}
+                        {"$project": {"#c_1": {"$ne": ["$nn", null]}, "_id": 0}}
                       ]
                     }""",
                     List.of(true, false, true),
@@ -265,7 +265,7 @@ class PredicateExpressionIntegrationTests extends AbstractQueryIntegrationTests 
                     {
                       "aggregate": "widgets",
                       "pipeline": [
-                        {"$project": {"#c_1": {"$eq": [{"$add": ["$x", "$nn"]}, null]}}}
+                        {"$project": {"#c_1": {"$eq": [{"$add": ["$x", "$nn"]}, null]}, "_id": 0}}
                       ]
                     }""",
                     List.of(false, true, false),
@@ -281,7 +281,7 @@ class PredicateExpressionIntegrationTests extends AbstractQueryIntegrationTests 
                     {
                       "aggregate": "widgets",
                       "pipeline": [
-                        {"$project": {"#c_1": {"$and": [{"$gt": ["$x", {"$numberInt": "1"}]}, {"$in": ["$name", ["alpha", "beta"]]}]}}}
+                        {"$project": {"#c_1": {"$and": [{"$gt": ["$x", {"$numberInt": "1"}]}, {"$in": ["$name", ["alpha", "beta"]]}]}, "_id": 0}}
                       ]
                     }""",
                     List.of(true, true, false),
@@ -297,7 +297,7 @@ class PredicateExpressionIntegrationTests extends AbstractQueryIntegrationTests 
                     {
                       "aggregate": "widgets",
                       "pipeline": [
-                        {"$project": {"#c_1": {"$and": [{"$gte": ["$x", {"$numberInt": "4"}]}, {"$lte": ["$x", {"$numberInt": "6"}]}]}}}
+                        {"$project": {"#c_1": {"$and": [{"$gte": ["$x", {"$numberInt": "4"}]}, {"$lte": ["$x", {"$numberInt": "6"}]}]}, "_id": 0}}
                       ]
                     }""",
                     List.of(false, true, true),
@@ -313,7 +313,7 @@ class PredicateExpressionIntegrationTests extends AbstractQueryIntegrationTests 
                     {
                       "aggregate": "widgets",
                       "pipeline": [
-                        {"$project": {"#c_1": {"$or": [{"$lt": ["$x", {"$numberInt": "4"}]}, {"$gt": ["$x", {"$numberInt": "6"}]}]}}}
+                        {"$project": {"#c_1": {"$or": [{"$lt": ["$x", {"$numberInt": "4"}]}, {"$gt": ["$x", {"$numberInt": "6"}]}]}, "_id": 0}}
                       ]
                     }""",
                     List.of(true, false, false),
@@ -332,7 +332,7 @@ class PredicateExpressionIntegrationTests extends AbstractQueryIntegrationTests 
                     {
                       "aggregate": "widgets",
                       "pipeline": [
-                        {"$project": {"#c_1": {"$and": [{"$gte": [{"$add": ["$x", {"$numberInt": "5"}]}, {"$numberInt": "10"}]}, {"$lte": [{"$add": ["$x", {"$numberInt": "5"}]}, {"$numberInt": "16"}]}]}}}
+                        {"$project": {"#c_1": {"$and": [{"$gte": [{"$add": ["$x", {"$numberInt": "5"}]}, {"$numberInt": "10"}]}, {"$lte": [{"$add": ["$x", {"$numberInt": "5"}]}, {"$numberInt": "16"}]}]}, "_id": 0}}
                       ]
                     }""",
                     List.of(true, false, true),
@@ -350,7 +350,7 @@ class PredicateExpressionIntegrationTests extends AbstractQueryIntegrationTests 
                     {
                       "aggregate": "widgets",
                       "pipeline": [
-                        {"$project": {"#c_1": {"$and": [{"$gte": [{"$add": ["$x", "$y"]}, {"$numberInt": "8"}]}, {"$lte": [{"$add": ["$x", "$y"]}, {"$numberInt": "12"}]}]}}}
+                        {"$project": {"#c_1": {"$and": [{"$gte": [{"$add": ["$x", "$y"]}, {"$numberInt": "8"}]}, {"$lte": [{"$add": ["$x", "$y"]}, {"$numberInt": "12"}]}]}, "_id": 0}}
                       ]
                     }""",
                     List.of(false, true, true),

--- a/src/integrationTest/java/com/mongodb/hibernate/query/select/RowValuePredicateIntegrationTests.java
+++ b/src/integrationTest/java/com/mongodb/hibernate/query/select/RowValuePredicateIntegrationTests.java
@@ -376,7 +376,8 @@ class RowValuePredicateIntegrationTests extends AbstractQueryIntegrationTests {
                     { "$sort": { "_id": 1 } },
                     {
                       "$project": {
-                        "#c_1": { "$and": [ { "$eq": ["$a", 10] }, { "$eq": ["$b", 20] } ] }
+                        "#c_1": { "$and": [ { "$eq": ["$a", 10] }, { "$eq": ["$b", 20] } ] },
+                        "_id": 0
                       }
                     }
                   ]
@@ -397,7 +398,8 @@ class RowValuePredicateIntegrationTests extends AbstractQueryIntegrationTests {
                     { "$sort": { "_id": 1 } },
                     {
                       "$project": {
-                        "#c_1": { "$not": [ { "$and": [ { "$eq": ["$a", 10] }, { "$eq": ["$b", 20] } ] } ] }
+                        "#c_1": { "$not": [ { "$and": [ { "$eq": ["$a", 10] }, { "$eq": ["$b", 20] } ] } ] },
+                        "_id": 0
                       }
                     }
                   ]
@@ -423,7 +425,8 @@ class RowValuePredicateIntegrationTests extends AbstractQueryIntegrationTests {
                             { "$and": [ { "$eq": ["$a", 10] }, { "$eq": ["$b", 20] } ] },
                             { "$and": [ { "$eq": ["$a", 30] }, { "$eq": ["$b", 40] } ] }
                           ]
-                        }
+                        },
+                        "_id": 0
                       }
                     }
                   ]
@@ -676,7 +679,8 @@ class RowValuePredicateIntegrationTests extends AbstractQueryIntegrationTests {
                               ]
                             }
                           ]
-                        }
+                        },
+                        "_id": 0
                       }
                     }
                   ]
@@ -731,7 +735,7 @@ class RowValuePredicateIntegrationTests extends AbstractQueryIntegrationTests {
                   "aggregate": "row_value",
                   "pipeline": [
                     { "$sort": { "_id": 1 } },
-                    { "$project": { "#c_1": { "$literal": false } } }
+                    { "$project": { "#c_1": { "$literal": false }, "_id": 0 } }
                   ]
                 }""",
                 List.of(false, false, false),
@@ -748,7 +752,7 @@ class RowValuePredicateIntegrationTests extends AbstractQueryIntegrationTests {
                   "aggregate": "row_value",
                   "pipeline": [
                     { "$sort": { "_id": 1 } },
-                    { "$project": { "#c_1": { "$literal": true } } }
+                    { "$project": { "#c_1": { "$literal": true }, "_id": 0 } }
                   ]
                 }""",
                 List.of(true, true, true),

--- a/src/integrationTest/java/com/mongodb/hibernate/query/select/SimpleSelectQueryIntegrationTests.java
+++ b/src/integrationTest/java/com/mongodb/hibernate/query/select/SimpleSelectQueryIntegrationTests.java
@@ -721,7 +721,8 @@ class SimpleSelectQueryIntegrationTests extends AbstractQueryIntegrationTests {
                         {
                           "$project": {
                             "name": true,
-                            "age": true
+                            "age": true,
+                            "_id": 0
                           }
                         }
                       ]
@@ -750,7 +751,8 @@ class SimpleSelectQueryIntegrationTests extends AbstractQueryIntegrationTests {
                         {
                           "$project": {
                             "name": true,
-                            "age": true
+                            "age": true,
+                            "_id": 0
                           }
                         }
                       ]
@@ -789,7 +791,8 @@ class SimpleSelectQueryIntegrationTests extends AbstractQueryIntegrationTests {
                             "name": true,
                             "seven": {
                               "$literal": 7
-                            }
+                            },
+                            "_id": 0
                           }
                         }
                       ]
@@ -1617,7 +1620,8 @@ class SimpleSelectQueryIntegrationTests extends AbstractQueryIntegrationTests {
                       "pipeline": [
                         {
                           "$project": {
-                            "nested#a": "$nested.a"
+                            "nested#a": "$nested.a",
+                            "_id": 0
                           }
                         }
                       ],
@@ -1645,7 +1649,8 @@ class SimpleSelectQueryIntegrationTests extends AbstractQueryIntegrationTests {
                         },
                         {
                           "$project": {
-                            "nested#a": "$nested.a"
+                            "nested#a": "$nested.a",
+                            "_id": 0
                           }
                         }
                       ],
@@ -1679,7 +1684,8 @@ class SimpleSelectQueryIntegrationTests extends AbstractQueryIntegrationTests {
                         {
                           "$project": {
                             "pair#a": "$pair.a",
-                            "pair#b": "$pair.b"
+                            "pair#b": "$pair.b",
+                            "_id": 0
                           }
                         }
                       ],
@@ -1752,7 +1758,8 @@ class SimpleSelectQueryIntegrationTests extends AbstractQueryIntegrationTests {
                       "pipeline": [
                         {
                           "$project": {
-                            "outer#inner#a": "$outer.inner.a"
+                            "outer#inner#a": "$outer.inner.a",
+                            "_id": 0
                           }
                         }
                       ],

--- a/src/integrationTest/java/com/mongodb/hibernate/query/select/SortingSelectQueryIntegrationTests.java
+++ b/src/integrationTest/java/com/mongodb/hibernate/query/select/SortingSelectQueryIntegrationTests.java
@@ -213,7 +213,8 @@ class SortingSelectQueryIntegrationTests extends AbstractQueryIntegrationTests {
                     {
                       "$project": {
                         "title": true,
-                        "publishYear": true
+                        "publishYear": true,
+                        "_id": 0
                       }
                     }
                   ]
@@ -246,7 +247,8 @@ class SortingSelectQueryIntegrationTests extends AbstractQueryIntegrationTests {
                     {
                       "$project": {
                         "title": true,
-                        "publishYear": true
+                        "publishYear": true,
+                        "_id": 0
                       }
                     }
                   ]

--- a/src/integrationTest/java/com/mongodb/hibernate/type/UnwrappedDomainTypeIntegrationTests.java
+++ b/src/integrationTest/java/com/mongodb/hibernate/type/UnwrappedDomainTypeIntegrationTests.java
@@ -249,7 +249,7 @@ class UnwrappedDomainTypeIntegrationTests extends AbstractQueryIntegrationTests 
                           "aggregate": "items",
                           "pipeline": [
                             {"$match": {"_id": {"$eq": 1}}},
-                            {"$project": {"%s": true}}
+                            {"$project": {"%s": true, "_id": 0}}
                           ]
                         }""",
                         c.attribute()),

--- a/src/main/java/com/mongodb/hibernate/internal/jdbc/MongoStatement.java
+++ b/src/main/java/com/mongodb/hibernate/internal/jdbc/MongoStatement.java
@@ -65,6 +65,7 @@ import java.util.Set;
 import org.bson.BSONException;
 import org.bson.BsonArray;
 import org.bson.BsonDocument;
+import org.bson.BsonInt32;
 import org.bson.BsonInvalidOperationException;
 import org.bson.BsonString;
 import org.bson.BsonValue;
@@ -119,8 +120,14 @@ class MongoStatement implements StatementAdapter {
                 throw createSyntaxErrorException("%s. $project stage is missing [%s]", command, null);
             }
             var projectStageIndex = pipeline.size() - 1;
-            var fieldNames = getFieldNamesFromProjectStage(
-                    pipeline.get(projectStageIndex).getDocument("$project"));
+            var projectStage = pipeline.get(projectStageIndex).getDocument("$project");
+            // MongoDB implicitly retains `_id` unless the projection specifies it. Suppress it explicitly so the
+            // pipeline output contains exactly the projected fields (no unused `_id` on the wire), and so field names
+            // match the projection for both generated and native queries.
+            if (!projectStage.containsKey(ID_FIELD_NAME)) {
+                projectStage.put(ID_FIELD_NAME, new BsonInt32(0));
+            }
+            var fieldNames = getFieldNamesFromProjectStage(projectStage);
             startTransactionIfNeeded();
             return resultSet = new MongoResultSet(
                     collection.aggregate(clientSession, pipeline).cursor(), fieldNames);
@@ -133,15 +140,10 @@ class MongoStatement implements StatementAdapter {
 
     @VisibleForTesting(otherwise = PRIVATE)
     static List<String> getFieldNamesFromProjectStage(BsonDocument projectStage) {
-        var fieldNames = projectStage.entrySet().stream()
+        return projectStage.entrySet().stream()
                 .filter(specification -> !isExcludeProjectSpecification(specification))
                 .map(Map.Entry::getKey)
                 .collect(toCollection(ArrayList::new));
-        if (!projectStage.containsKey(ID_FIELD_NAME)) {
-            // MongoDB includes this field unless it is explicitly excluded
-            fieldNames.add(ID_FIELD_NAME);
-        }
-        return fieldNames;
     }
 
     /**

--- a/src/test/java/com/mongodb/hibernate/internal/jdbc/MongoStatementTests.java
+++ b/src/test/java/com/mongodb/hibernate/internal/jdbc/MongoStatementTests.java
@@ -206,18 +206,18 @@ class MongoStatementTests {
                 () -> successAsserter.accept("{_id: 1, title: 2}", List.of("_id", "title")),
                 () -> successAsserter.accept("{title: 1, _id: 0}", List.of("title")),
                 () -> successAsserter.accept("{title: 1, _id: false}", List.of("title")),
-                () -> successAsserter.accept("{title: 1, publishYear: 1}", List.of("title", "publishYear", "_id")),
+                () -> successAsserter.accept("{title: 1, publishYear: 1}", List.of("title", "publishYear")),
                 () -> failureAsserter.accept("{title: 1, publishYear: 0}", "Exclusions are not allowed"),
                 () -> failureAsserter.accept("{title: 1, publishYear: false}", "Exclusions are not allowed"),
                 () -> successAsserter.accept("{'o1_0#total': '$o1_0.total', _id: 1}", List.of("o1_0#total", "_id")),
                 () -> failureAsserter.accept("{title: '$$REMOVE'}", "Unsupported value in '$project' specification"),
-                () -> successAsserter.accept("{title: {$literal: 1}}", List.of("title", "_id")),
+                () -> successAsserter.accept("{title: {$literal: 1}}", List.of("title")),
                 () -> failureAsserter.accept(
                         "{title: 'string literal'}", "Unsupported value in '$project' specification"),
                 () -> failureAsserter.accept("{title: []}", "Unsupported value in '$project' specification"),
                 () -> failureAsserter.accept(
                         "{title: ['array literal']}", "Unsupported value in '$project' specification"),
-                () -> successAsserter.accept("{title: {fieldName: 'document literal'}}", List.of("title", "_id")));
+                () -> successAsserter.accept("{title: {fieldName: 'document literal'}}", List.of("title")));
     }
 
     @Nested


### PR DESCRIPTION
Inject _id: 0 into the terminal $project when it does not already specify _id, in the shared MongoStatement.executeQuery path, and stop appending _id to the result-set field names. Result-set columns now match exactly the projected fields, for both generated and native queries, and MongoDB no longer returns an unused _id per document.

Prototype: only one integration-test MQL assertion (testProjectUsingAlias) is updated; the remaining ~53 full-pipeline assertions still expect the old projection and will fail until updated.

HIBERNATE-208