### PR TITLE
HIBERNATE-255: forbid '.' in table and schema names

### DIFF
--- a/src/integrationTest/java/com/mongodb/hibernate/IdentifierIntegrationTests.java
+++ b/src/integrationTest/java/com/mongodb/hibernate/IdentifierIntegrationTests.java
@@ -43,7 +43,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 @SessionFactory(exportSchema = false)
 @DomainModel(
         annotatedClasses = {
-            IdentifierIntegrationTests.WithSpaceAndDotAndMixedCase.class,
+            IdentifierIntegrationTests.WithSpaceAndMixedCase.class,
             IdentifierIntegrationTests.StartingAndEndingWithBackticks.class,
             IdentifierIntegrationTests.StartingWithBacktick.class,
             IdentifierIntegrationTests.EndingWithBacktick.class,
@@ -56,8 +56,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
         })
 @ExtendWith(MongoExtension.class)
 class IdentifierIntegrationTests implements SessionFactoryScopeAware, MongoServiceRegistryProducer {
-    @InjectMongoCollection(WithSpaceAndDotAndMixedCase.COLLECTION_NAME)
-    private MongoCollection<BsonDocument> mongoCollectionWithSpaceAndDotAndMixedCase;
+    @InjectMongoCollection(WithSpaceAndMixedCase.COLLECTION_NAME)
+    private MongoCollection<BsonDocument> mongoCollectionWithSpaceAndMixedCase;
 
     @InjectMongoCollection(StartingAndEndingWithBackticks.ACTUAL_COLLECTION_NAME)
     private MongoCollection<BsonDocument> mongoCollectionStartingAndEndingWithBackticks;
@@ -94,14 +94,14 @@ class IdentifierIntegrationTests implements SessionFactoryScopeAware, MongoServi
     }
 
     @Test
-    void withSpaceAndDotAndMixedCase() {
-        var item = new WithSpaceAndDotAndMixedCase();
+    void withSpaceAndMixedCase() {
+        var item = new WithSpaceAndMixedCase();
         sessionFactoryScope.inTransaction(session -> session.persist(item));
-        assertThat(mongoCollectionWithSpaceAndDotAndMixedCase.find())
+        assertThat(mongoCollectionWithSpaceAndMixedCase.find())
                 .containsExactly(new BsonDocument()
                         .append(ID_FIELD_NAME, new BsonInt32(item.id))
-                        .append(WithSpaceAndDotAndMixedCase.FIELD_NAME, new BsonInt32(item.v)));
-        sessionFactoryScope.inTransaction(session -> session.find(WithSpaceAndDotAndMixedCase.class, item.id));
+                        .append(WithSpaceAndMixedCase.FIELD_NAME, new BsonInt32(item.v)));
+        sessionFactoryScope.inTransaction(session -> session.find(WithSpaceAndMixedCase.class, item.id));
     }
 
     @Test
@@ -204,15 +204,15 @@ class IdentifierIntegrationTests implements SessionFactoryScopeAware, MongoServi
     }
 
     @Entity
-    @Table(name = WithSpaceAndDotAndMixedCase.COLLECTION_NAME)
-    static class WithSpaceAndDotAndMixedCase {
-        static final String COLLECTION_NAME = "collection name with space and .dot and Mixed Case";
+    @Table(name = WithSpaceAndMixedCase.COLLECTION_NAME)
+    static class WithSpaceAndMixedCase {
+        static final String COLLECTION_NAME = "collection name with space and Mixed Case";
         static final String FIELD_NAME = "field name with space and Mixed Case";
 
         @Id
         int id;
 
-        @Column(name = WithSpaceAndDotAndMixedCase.FIELD_NAME)
+        @Column(name = WithSpaceAndMixedCase.FIELD_NAME)
         int v;
     }
 

--- a/src/integrationTest/java/com/mongodb/hibernate/boot/SchemaQualificationIntegrationTests.java
+++ b/src/integrationTest/java/com/mongodb/hibernate/boot/SchemaQualificationIntegrationTests.java
@@ -22,6 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hibernate.cfg.AvailableSettings.DEFAULT_CATALOG;
 import static org.hibernate.cfg.AvailableSettings.JAKARTA_JDBC_URL;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import com.mongodb.client.MongoCollection;
 import com.mongodb.hibernate.junit.InjectMongoCollection;
@@ -35,6 +36,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.SecondaryTable;
 import jakarta.persistence.Table;
 import java.util.Set;
+import java.util.stream.Stream;
 import org.bson.BsonDocument;
 import org.bson.BsonInt32;
 import org.bson.BsonString;
@@ -45,6 +47,9 @@ import org.hibernate.testing.orm.junit.DomainModel;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * {@code @Table(schema=...)} folds into a dotted collection name in the single database. Verified at three levels: the
@@ -54,7 +59,6 @@ import org.junit.jupiter.api.Test;
 @DomainModel(
         annotatedClasses = {
             SchemaQualificationIntegrationTests.Book.class,
-            SchemaQualificationIntegrationTests.DottedName.class,
             SchemaQualificationIntegrationTests.Article.class,
             SchemaQualificationIntegrationTests.Author.class,
             SchemaQualificationIntegrationTests.SharedOne.class,
@@ -67,9 +71,6 @@ class SchemaQualificationIntegrationTests extends AbstractQueryIntegrationTests 
     @InjectMongoCollection("library.books")
     private MongoCollection<BsonDocument> libraryBooks;
 
-    @InjectMongoCollection("archive.entries")
-    private MongoCollection<BsonDocument> archiveEntries;
-
     @InjectMongoCollection("shared.things")
     private MongoCollection<BsonDocument> sharedThings;
 
@@ -80,7 +81,6 @@ class SchemaQualificationIntegrationTests extends AbstractQueryIntegrationTests 
     void seed() {
         getSessionFactoryScope().inTransaction(session -> {
             session.persist(new Book(1, "MongoDB"));
-            session.persist(new DottedName(2, "x"));
             var author = new Author(10, "Alice");
             session.persist(author);
             session.persist(new Article(20, "Aggregation", author));
@@ -102,24 +102,12 @@ class SchemaQualificationIntegrationTests extends AbstractQueryIntegrationTests 
     }
 
     @Test
-    void dottedNameIsNotSplit() {
-        assertThat(archiveEntries.find())
-                .containsExactly(new BsonDocument()
-                        .append(ID_FIELD_NAME, new BsonInt32(2))
-                        .append("v", new BsonString("x")));
-    }
-
-    @Test
     void tableSharingIsAllowed() {
-        // Two distinct entities mapped to the same @Table share one Hibernate table, so the fold-collision check must
-        // not reject them (that is Hibernate-sanctioned table sharing).
         assertThat(sharedThings.find()).hasSize(2);
     }
 
     @Test
     void singleTableInheritanceFoldsAndPersists() {
-        // A SINGLE_TABLE hierarchy folds into one collection, its subclasses share the root's table (so the
-        // fold-collision check must not flag them), and a subclass persists and reads back.
         assertThat(zooAnimals.find()).hasSize(1);
         var loaded = getSessionFactoryScope()
                 .fromTransaction(session -> session.createSelectionQuery("from Animal", Animal.class)
@@ -218,22 +206,6 @@ class SchemaQualificationIntegrationTests extends AbstractQueryIntegrationTests 
         }
     }
 
-    @Entity(name = "DottedName")
-    @Table(name = "archive.entries")
-    static class DottedName {
-        @Id
-        int id;
-
-        String v;
-
-        DottedName() {}
-
-        DottedName(int id, String v) {
-            this.id = id;
-            this.v = v;
-        }
-    }
-
     @Entity(name = "Article")
     @Table(schema = "content", name = "articles")
     static class Article {
@@ -327,7 +299,6 @@ class SchemaQualificationIntegrationTests extends AbstractQueryIntegrationTests 
 
     @Nested
     class Unsupported implements MongoServiceRegistryProducer {
-
         @Test
         void catalogRejectedAtBoot() {
             assertThatThrownBy(() -> new MetadataSources()
@@ -362,12 +333,70 @@ class SchemaQualificationIntegrationTests extends AbstractQueryIntegrationTests 
         }
 
         @Test
-        void foldCollisionRejectedAtBoot() {
+        void dottedTableNameRejectedAtBoot() {
             assertThatThrownBy(() -> new MetadataSources()
-                            .addAnnotatedClass(SchemaAName.class)
-                            .addAnnotatedClass(DottedAB.class)
+                            .addAnnotatedClass(DottedTableName.class)
                             .buildMetadata())
-                    .hasMessageContaining("resolve to the same collection");
+                    .hasMessageContaining("The character [.] in a table name is not supported");
+        }
+
+        @Test
+        void dottedSchemaNameRejectedAtBoot() {
+            assertThatThrownBy(() -> new MetadataSources()
+                            .addAnnotatedClass(DottedSchemaName.class)
+                            .buildMetadata())
+                    .hasMessageContaining("The character [.] in a schema name is not supported");
+        }
+
+        /**
+         * Backticks, double quotes and square brackets are Hibernate ORM quoting markers, stripped before the name
+         * reaches the check, so the '.' is exposed. A single quote is not a quoting marker, so it stays in the name
+         * alongside the '.'. Neither form is exempt.
+         */
+        @ParameterizedTest
+        @MethodSource
+        void quotingDoesNotExemptADottedTableName(Class<?> annotatedClass, String reportedName) {
+            assertThatThrownBy(() -> new MetadataSources()
+                            .addAnnotatedClass(annotatedClass)
+                            .buildMetadata())
+                    .hasMessageContaining("The character [.] in a table name is not supported")
+                    .hasMessageContaining("is present in [" + reportedName + "]");
+        }
+
+        private static Stream<Arguments> quotingDoesNotExemptADottedTableName() {
+            return Stream.of(
+                    arguments(BacktickQuotedTableName.class, "a.b"),
+                    arguments(DoubleQuotedTableName.class, "a.b"),
+                    arguments(BracketQuotedTableName.class, "a.b"),
+                    arguments(SingleQuotedTableName.class, "'a.b'"));
+        }
+
+        @Entity(name = "BacktickQuotedTableName")
+        @Table(name = "`a.b`")
+        static class BacktickQuotedTableName {
+            @Id
+            int id;
+        }
+
+        @Entity(name = "DoubleQuotedTableName")
+        @Table(name = "\"a.b\"")
+        static class DoubleQuotedTableName {
+            @Id
+            int id;
+        }
+
+        @Entity(name = "BracketQuotedTableName")
+        @Table(name = "[a.b]")
+        static class BracketQuotedTableName {
+            @Id
+            int id;
+        }
+
+        @Entity(name = "SingleQuotedTableName")
+        @Table(name = "'a.b'")
+        static class SingleQuotedTableName {
+            @Id
+            int id;
         }
 
         @Entity(name = "WithCatalog")
@@ -392,18 +421,16 @@ class SchemaQualificationIntegrationTests extends AbstractQueryIntegrationTests 
             int id;
         }
 
-        // resolves to collection "a.b"
-        @Entity(name = "SchemaAName")
-        @Table(schema = "a", name = "b")
-        static class SchemaAName {
+        @Entity(name = "DottedTableName")
+        @Table(name = "a.b")
+        static class DottedTableName {
             @Id
             int id;
         }
 
-        // also resolves to collection "a.b", via a dotted name
-        @Entity(name = "DottedAB")
-        @Table(name = "a.b")
-        static class DottedAB {
+        @Entity(name = "DottedSchemaName")
+        @Table(schema = "a.b", name = "c")
+        static class DottedSchemaName {
             @Id
             int id;
         }

--- a/src/main/java/com/mongodb/hibernate/internal/boot/MongoAdditionalMappingContributor.java
+++ b/src/main/java/com/mongodb/hibernate/internal/boot/MongoAdditionalMappingContributor.java
@@ -39,7 +39,6 @@ import java.time.OffsetTime;
 import java.time.ZonedDateTime;
 import java.util.Calendar;
 import java.util.Date;
-import java.util.HashSet;
 import java.util.Set;
 import java.util.StringJoiner;
 import java.util.UUID;
@@ -157,7 +156,7 @@ public final class MongoAdditionalMappingContributor implements AdditionalMappin
             materializeUniqueColumns(persistentClass);
         });
         forbidCatalog(metadata, buildingContext);
-        forbidCollidingCollectionNames(metadata);
+        forbidDottedTableQualifiers(metadata);
     }
 
     /**
@@ -212,32 +211,30 @@ public final class MongoAdditionalMappingContributor implements AdditionalMappin
     }
 
     /**
-     * A schema folds into the collection name ({@code schema.name}), so two distinct table qualifiers can resolve to
-     * the same collection — e.g. {@code @Table(schema = "a", name = "b")} and {@code @Table(name = "a.b")} both resolve
-     * to {@code a.b}. Hibernate treats these as different tables and would not catch the clash, yet they would silently
-     * co-mingle in one collection. Distinct qualifiers that resolve to the same name are rejected. Hibernate-sanctioned
-     * table sharing (and a {@code SINGLE_TABLE} hierarchy's subclasses) share one {@link org.hibernate.mapping.Table}
-     * instance, so they appear once and are not flagged.
+     * A schema folds into the collection name as {@code schema.name}, so the '.' is the extension's own separator. A
+     * '.' written by the user makes the resolved name ambiguous: {@code @Table(schema = "a", name = "b")} and
+     * {@code @Table(name = "a.b")} would resolve to the same collection, and nothing downstream could tell the two
+     * qualifiers apart.
      */
-    private static void forbidCollidingCollectionNames(InFlightMetadataCollector metadata) {
-        // Hibernate registers one Table per distinct qualified name, and table sharing (including a SINGLE_TABLE
-        // hierarchy's subclasses) reuses that one Table. So a resolved collection name seen twice always comes from
-        // two distinct qualifiers that folding collapsed together — a genuine collision.
-        var resolvedNames = new HashSet<String>();
+    private static void forbidDottedTableQualifiers(InFlightMetadataCollector metadata) {
         for (var namespace : metadata.getDatabase().getNamespaces()) {
             var schema = namespace.getName().schema();
-            var schemaText = schema == null ? null : schema.getText();
-            for (var table : namespace.getTables()) {
-                var name = table.getName();
-                var resolved = schemaText == null ? name : schemaText + "." + name;
-                if (!resolvedNames.add(resolved)) {
-                    throw new FeatureNotSupportedException(format(
-                            "Two entities resolve to the same collection [%s] via distinct table qualifiers (schema"
-                                    + " folding makes e.g. @Table(schema = \"a\", name = \"b\") collide with"
-                                    + " @Table(name = \"a.b\")). Rename one so they resolve to different collections.",
-                            resolved));
-                }
+            if (schema != null) {
+                forbidDot(schema.getText(), "schema");
             }
+            for (var table : namespace.getTables()) {
+                forbidDot(table.getName(), "table");
+            }
+        }
+    }
+
+    private static void forbidDot(String name, String kind) {
+        if (name.contains(".")) {
+            throw new FeatureNotSupportedException(format(
+                    "The character [.] in a %s name is not supported, but is present in [%s]. A schema folds into the"
+                            + " collection name as [schema.name], so a '.' written by the user would make the resolved"
+                            + " collection name ambiguous.",
+                    kind, name));
         }
     }
 


### PR DESCRIPTION
A schema folds into the collection name as `schema.name`, so the `.` is the extension's own separator. A `.` written by the user made the resolved name ambiguous:

```java
@Table(schema = "a", name = "b")   // collection a.b
@Table(name = "a.b")               // collection a.b
```

Hibernate ORM keeps these as two distinct tables and does not object, so both entities read and write the same collection.

Schema names with `.` are rejected too, whether they come from the `schema` attribute or from `hibernate.default_schema`. With both banned, two different table qualifiers can never resolve to the same collection name.

### Compatibility

This removes a tested capability: a collection name containing a `.` can no longer be written directly as a table name. Names with exactly one dot are still possible through the `schema` attribute, which resolves to the same physical collection:

```java
@Table(name = "archive.entries")               // before
@Table(schema = "archive", name = "entries")   // after, same collection
```

Collection names with two or more dots become un-mappable. 

HIBERNATE-255