### PR TITLE
Attach test results from all modules in Evergreen; fix naming test cleanup

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -175,6 +175,8 @@ functions:
         files:
           - src/build/test-results/test/TEST-*.xml
           - src/build/test-results/integrationTest/TEST-*.xml
+          - src/*/build/test-results/test/TEST-*.xml
+          - src/*/build/test-results/integrationTest/TEST-*.xml
 
   cleanup:
     - command: subprocess.exec

--- a/mongodb-hibernate-spring-boot-autoconfigure/src/integrationTest/java/com/mongodb/hibernate/naming/MongoHibernateDefaultNamingIntegrationTests.java
+++ b/mongodb-hibernate-spring-boot-autoconfigure/src/integrationTest/java/com/mongodb/hibernate/naming/MongoHibernateDefaultNamingIntegrationTests.java
@@ -43,7 +43,7 @@ class MongoHibernateDefaultNamingIntegrationTests {
 
     @AfterEach
     void cleanUp() {
-        repository.deleteAll();
+        NamingTestSupport.dropBooksCollection(connectionString);
     }
 
     @Test

--- a/mongodb-hibernate-spring-boot-autoconfigure/src/integrationTest/java/com/mongodb/hibernate/naming/MongoHibernateSnakeCaseNamingIntegrationTests.java
+++ b/mongodb-hibernate-spring-boot-autoconfigure/src/integrationTest/java/com/mongodb/hibernate/naming/MongoHibernateSnakeCaseNamingIntegrationTests.java
@@ -45,7 +45,7 @@ class MongoHibernateSnakeCaseNamingIntegrationTests {
 
     @AfterEach
     void cleanUp() {
-        repository.deleteAll();
+        NamingTestSupport.dropBooksCollection(connectionString);
     }
 
     @Test

--- a/mongodb-hibernate-spring-boot-autoconfigure/src/integrationTest/java/com/mongodb/hibernate/naming/NamingBook.java
+++ b/mongodb-hibernate-spring-boot-autoconfigure/src/integrationTest/java/com/mongodb/hibernate/naming/NamingBook.java
@@ -25,8 +25,10 @@ import org.bson.types.ObjectId;
 // snake_case physical naming strategies; only the unannotated multi-word field `publishYear` varies
 // (publishYear vs publish_year), which is what the naming tests assert.
 @Entity
-@Table(name = "namingbook")
+@Table(name = NamingBook.COLLECTION_NAME)
 public class NamingBook {
+
+    public static final String COLLECTION_NAME = "namingbook";
 
     @Id
     public ObjectId id;

--- a/mongodb-hibernate-spring-boot-autoconfigure/src/integrationTest/java/com/mongodb/hibernate/naming/NamingTestSupport.java
+++ b/mongodb-hibernate-spring-boot-autoconfigure/src/integrationTest/java/com/mongodb/hibernate/naming/NamingTestSupport.java
@@ -27,6 +27,18 @@ final class NamingTestSupport {
 
     private NamingTestSupport() {}
 
+    // Drops the collection via the Mongo client rather than emptying it through the repository: the
+    // collection is shared by the two naming tests, whose naming strategies store different field keys,
+    // and repository.deleteAll would fail to hydrate documents written under the other strategy.
+    static void dropBooksCollection(String connectionString) {
+        try (var client = MongoClients.create(connectionString)) {
+            var databaseName = Objects.requireNonNull(
+                    new ConnectionString(connectionString).getDatabase(),
+                    "connection string must include a database name");
+            client.getDatabase(databaseName).getCollection("namingbook").drop();
+        }
+    }
+
     // Reads the raw stored document straight from MongoDB (bypassing Hibernate) so the test inspects the
     // actual persisted field keys rather than the entity's Java property names.
     static BsonDocument readStoredBook(String connectionString, ObjectId id) {

--- a/mongodb-hibernate-spring-boot-autoconfigure/src/integrationTest/java/com/mongodb/hibernate/naming/NamingTestSupport.java
+++ b/mongodb-hibernate-spring-boot-autoconfigure/src/integrationTest/java/com/mongodb/hibernate/naming/NamingTestSupport.java
@@ -35,7 +35,7 @@ final class NamingTestSupport {
             var databaseName = Objects.requireNonNull(
                     new ConnectionString(connectionString).getDatabase(),
                     "connection string must include a database name");
-            client.getDatabase(databaseName).getCollection("namingbook").drop();
+            client.getDatabase(databaseName).getCollection(NamingBook.COLLECTION_NAME).drop();
         }
     }
 
@@ -47,7 +47,7 @@ final class NamingTestSupport {
                     new ConnectionString(connectionString).getDatabase(),
                     "connection string must include a database name");
             var document = client.getDatabase(databaseName)
-                    .getCollection("namingbook", BsonDocument.class)
+                    .getCollection(NamingBook.COLLECTION_NAME, BsonDocument.class)
                     .find(new BsonDocument("_id", new BsonObjectId(id)))
                     .first();
             return Objects.requireNonNull(document, () -> "no stored document for id " + id);


### PR DESCRIPTION
## Attach test results from all modules in Evergreen

The `upload-test-results` function attached only the root module's `build/test-results` paths, so the spring-boot-autoconfigure module's unit and integration test results never appeared in Evergreen's test-results view even though the tasks executed them. This adds the `src/*/build/test-results` globs, matching the convention the `trace-artifacts` function already uses.

## Drop the namingbook collection via the Mongo client in naming test cleanup

`repository.deleteAll()` hydrates every document in the namingbook collection, which the two naming tests share while storing different field keys (`publishYear` vs `publish_year`) under their different physical naming strategies. A document written by one test leaves the other test's primitive `int publishYear` null when hydrated, and Hibernate's generated access optimizer throws NullPointerException unboxing it. Once such a document is left behind by an interrupted run, every later run of both tests fails, because the failing cleanup never removes the offending documents. Dropping the collection through the client never hydrates anything, so cleanup is unaffected by documents written under either naming strategy.
