### PR TITLE
HIBERNATE-233: support sequence-style identifier generation for @GeneratedValue

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -24,12 +24,19 @@ than forwarding it verbatim.
 
 - Queries and mutations: the translators build a `mongoast` tree, which is serialized to Extended JSON
   and carried as the statement string, then executed by `MongoStatement` / `MongoPreparedStatement`.
-- Schema DDL: an `Exporter` produces the same kind of string, which `MongoStatement.execute(String)`
-  decodes into a typed command object before calling the driver.
+- Schema DDL: an `Exporter` produces the same kind of string. `MongoStatement.execute(String)` parses it,
+  routes a write command name to `executeUpdate(BsonDocument)`, and otherwise decodes it as an
+  `AdminCommand`.
 
 Two consequences worth internalizing. A statement string that looks like valid MQL is not proof the
 feature works --- something still has to parse it on the far side. And "the server accepted it" is a
 weaker claim than "the emitted command matches the mapping", because a dropped detail throws nothing.
+
+A command can also carry a field that is not MongoDB's at all: `nonTransactional` is a JDBC-adapter
+field that `MongoStatement` reads and acts on --- when `true`, it runs the command without a
+`ClientSession` and without starting a transaction --- and must never forward to the driver. A new
+command that forwards a document verbatim (rather than being decoded field by field, the way
+`findAndModify` and the write commands are) needs to strip it first.
 
 ## Translation goes through the visitor
 
@@ -184,7 +191,9 @@ That absence determines which mappings can be honoured. Hibernate models some co
 exportable --- `@Index` and `@Table(uniqueConstraints = ...)` --- and leaves others to be inlined into
 table DDL by the table exporter, `@Column(unique = true)` among them. Only the first group reaches an
 exporter here, so anything in the second group has to be handled off the exporter path to have any
-effect at all.
+effect at all. A Hibernate sequence is the other exportable this layer honours: `MongoDialect` returns
+`MongoSequenceSupport` from `getSequenceSupport()`, and `StandardSequenceExporter` calls it to render
+the create/drop commands for the counter collection backing `@GeneratedValue`.
 
 Export runs at `SessionFactory` build time, driven by
 `jakarta.persistence.schema-generation.database.action` --- so it is exercised by building a factory,

--- a/src/integrationTest/java/com/mongodb/hibernate/boot/NativeBootstrappingIntegrationTests.java
+++ b/src/integrationTest/java/com/mongodb/hibernate/boot/NativeBootstrappingIntegrationTests.java
@@ -25,7 +25,6 @@ import com.mongodb.hibernate.junit.MongoExtension;
 import com.mongodb.hibernate.junit.MongoServiceRegistryProducer;
 import com.mongodb.hibernate.query.AbstractQueryIntegrationTests;
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.persistence.Version;
@@ -130,16 +129,6 @@ class NativeBootstrappingIntegrationTests extends AbstractQueryIntegrationTests
             Instant version;
         }
 
-        @Entity(name = "ItemWithGeneratedValue")
-        @Table(name = "ItemWithGeneratedValue")
-        static class ItemWithGeneratedValue {
-            @Id
-            @GeneratedValue
-            int id;
-
-            String string;
-        }
-
         @Test
         void testForbidCurrentTimestampSourceDbAnnotation() {
             assertBootstrapThrows(() -> new MetadataSources()
@@ -161,18 +150,6 @@ class NativeBootstrappingIntegrationTests extends AbstractQueryIntegrationTests
                     .isInstanceOf(FeatureNotSupportedException.class)
                     .hasMessage(
                             "Field version of class com.mongodb.hibernate.boot.NativeBootstrappingIntegrationTests.Unsupported.ItemWithGenerated is not supported: Annotation org.hibernate.annotations.Generated is forbidden");
-        }
-
-        @Test
-        void testForbidGeneratedValueAnnotation() {
-            assertBootstrapThrows(() -> new MetadataSources()
-                            .addAnnotatedClass(
-                                    NativeBootstrappingIntegrationTests.Unsupported.ItemWithGeneratedValue.class)
-                            .buildMetadata(new StandardServiceRegistryBuilder().build())
-                            .buildSessionFactory())
-                    .isInstanceOf(FeatureNotSupportedException.class)
-                    .hasMessage(
-                            "Field id of class com.mongodb.hibernate.boot.NativeBootstrappingIntegrationTests.Unsupported.ItemWithGeneratedValue is not supported: Annotation jakarta.persistence.GeneratedValue is forbidden");
         }
 
         @Test

--- a/src/integrationTest/java/com/mongodb/hibernate/id/SequenceGeneratedIdIntegrationTests.java
+++ b/src/integrationTest/java/com/mongodb/hibernate/id/SequenceGeneratedIdIntegrationTests.java
@@ -1,0 +1,940 @@
+/*
+ * Copyright 2026-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.hibernate.id;
+
+import static com.mongodb.hibernate.internal.MongoConstants.MONGO_CONFIGURATION_CONTRIBUTOR_KEY;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import com.mongodb.client.MongoCollection;
+import com.mongodb.hibernate.internal.FeatureNotSupportedException;
+import com.mongodb.hibernate.junit.CommandHistory;
+import com.mongodb.hibernate.junit.InjectCommandHistory;
+import com.mongodb.hibernate.junit.InjectMongoCollection;
+import com.mongodb.hibernate.junit.MongoExtension;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+import jakarta.persistence.TableGenerator;
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.function.Function;
+import java.util.stream.LongStream;
+import java.util.stream.Stream;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.bson.BsonDocument;
+import org.hibernate.MappingException;
+import org.hibernate.Session;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Parameter;
+import org.hibernate.boot.MetadataSources;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * Sequence-style identifier generation, from schema export through allocation to drop.
+ *
+ * <p>Each test boots its own {@code SessionFactory} with {@code create-drop}. {@link MongoExtension} empties every
+ * collection in this class's database before each test, {@code hibernate_sequences} among them, so a
+ * {@code SessionFactory} shared across the class would leave later tests with no counter document. A pooled optimizer
+ * also holds its block in the generator, which lives in the {@code SessionFactory}, so any assertion about round trips
+ * needs a fresh one.
+ */
+@ExtendWith(MongoExtension.class)
+class SequenceGeneratedIdIntegrationTests {
+
+    private static final Map<String, Object> BASE_SETTINGS = Map.of(
+            "jakarta.persistence.schema-generation.database.action",
+            "create-drop",
+            "hibernate.hbm2ddl.halt_on_error",
+            "true");
+
+    @InjectCommandHistory
+    private CommandHistory commandHistory;
+
+    @InjectMongoCollection("hibernate_sequences")
+    private MongoCollection<BsonDocument> sequences;
+
+    @InjectMongoCollection("books")
+    private MongoCollection<BsonDocument> books;
+
+    /** What one booted {@code SessionFactory} produced: the commands sent, and whatever the body observed. */
+    private record Run<T>(List<BsonDocument> commands, T observed) {}
+
+    /** The identifiers a persist-then-reload round trip observed, and the counter document at that point. */
+    private record PersistedBook(long id, long reloadedId, BsonDocument sequenceDocument) {}
+
+    /**
+     * Boots a {@code SessionFactory} for {@code entityClasses} with {@code create-drop}, runs {@code body} while it is
+     * open, and returns the commands sent along with the body's result.
+     *
+     * <p>The registry is built by hand so it can apply the contributor that points the {@code SessionFactory} at this
+     * class's own database and installs that database's command listener.
+     */
+    private <T> Run<T> inRegistry(Function<Session, T> body, Class<?>... entityClasses) {
+        return inRegistry(Map.of(), body, entityClasses);
+    }
+
+    private <T> Run<T> inRegistry(
+            Map<String, Object> additionalSettings, Function<Session, T> body, Class<?>... entityClasses) {
+        try (var registry = new StandardServiceRegistryBuilder()
+                .applySettings(BASE_SETTINGS)
+                .applySettings(additionalSettings)
+                .applySetting(
+                        MONGO_CONFIGURATION_CONTRIBUTOR_KEY,
+                        MongoExtension.configurationContributorForClass(SequenceGeneratedIdIntegrationTests.class))
+                .build()) {
+            T observed;
+            var metadataSources = new MetadataSources();
+            for (var entityClass : entityClasses) {
+                metadataSources.addAnnotatedClass(entityClass);
+            }
+            try (var sessionFactory = metadataSources.buildMetadata(registry).buildSessionFactory();
+                    var session = sessionFactory.openSession()) {
+                observed = body.apply(session);
+            }
+            return new Run<>(commandHistory.getCommands(), observed);
+        }
+    }
+
+    /** The commands sent whose name matches {@code commandName}. */
+    private static List<BsonDocument> commandsNamed(List<BsonDocument> commands, String commandName) {
+        return commands.stream()
+                .filter(command -> commandName.equals(command.getFirstKey()))
+                .toList();
+    }
+
+    /**
+     * Asserts that exactly one command named {@code commandName} was sent, and that it carries every field of
+     * {@code expected}. A subset check rather than equality, because the driver adds session and cluster metadata
+     * ({@code lsid}, {@code $db}, {@code txnNumber}, and the like) that {@code expected} does not name.
+     */
+    private static void assertOneCommandNamed(List<BsonDocument> commands, String commandName, String expected) {
+        var matching = commandsNamed(commands, commandName);
+        assertThat(matching).hasSize(1);
+        assertThat(matching.get(0))
+                .asInstanceOf(InstanceOfAssertFactories.MAP)
+                .containsAllEntriesOf(BsonDocument.parse(expected));
+    }
+
+    @Entity(name = "Book")
+    @Table(name = "books")
+    static class Book {
+        @Id
+        @GeneratedValue
+        Long id;
+
+        String title;
+    }
+
+    /** A primitive identifier, to pin which class {@code getReturnedClass()} reports for one. */
+    @Entity(name = "Pamphlet")
+    @Table(name = "pamphlets")
+    static class Pamphlet {
+        @Id
+        @GeneratedValue
+        long id;
+
+        String title;
+    }
+
+    @Entity(name = "Ledger")
+    @Table(name = "ledgers")
+    @SequenceGenerator(name = "ledgerSeq", allocationSize = 1)
+    static class Ledger {
+        @Id
+        @GeneratedValue(generator = "ledgerSeq")
+        Long id;
+    }
+
+    @Entity(name = "Invoice")
+    @Table(name = "invoices")
+    @SequenceGenerator(
+            name = "invoice_numbers",
+            sequenceName = "invoice_numbers",
+            initialValue = 1000,
+            allocationSize = 10)
+    static class Invoice {
+        @Id
+        @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "invoice_numbers")
+        Long id;
+    }
+
+    @Entity(name = "Receipt")
+    @Table(name = "receipts")
+    @SequenceGenerator(name = "receiptSeq", schema = "billing", sequenceName = "receipt_numbers", allocationSize = 1)
+    static class Receipt {
+        @Id
+        @GeneratedValue(generator = "receiptSeq")
+        Long id;
+    }
+
+    /**
+     * Declares a generator that {@link SharedSequenceConsumer} references without declaring it itself. Both end up on
+     * the default allocation size, which they must, since the consumer has no way to state one.
+     */
+    @Entity(name = "SharedSequenceDeclarer")
+    @Table(name = "sharedSequenceDeclarers")
+    @SequenceGenerator(name = "shared_seq", sequenceName = "shared_seq")
+    static class SharedSequenceDeclarer {
+        @Id
+        @GeneratedValue(generator = "shared_seq")
+        Long id;
+    }
+
+    @Entity(name = "SharedSequenceConsumer")
+    @Table(name = "sharedSequenceConsumers")
+    static class SharedSequenceConsumer {
+        @Id
+        @GeneratedValue(generator = "shared_seq")
+        Long id;
+    }
+
+    @Entity(name = "Note")
+    @Table(name = "notes")
+    @SequenceGenerator(name = "noteSeq", allocationSize = 1)
+    static class Note {
+        @Id
+        @GeneratedValue(generator = "noteSeq")
+        Integer id;
+    }
+
+    @Test
+    void persistsAndReloadsWithAGeneratedIdentifier() {
+        var run = inRegistry(
+                session -> {
+                    session.getTransaction().begin();
+                    var book = new Book();
+                    book.title = "War and Peace";
+                    session.persist(book);
+                    session.getTransaction().commit();
+                    session.clear();
+                    var reloaded = session.find(Book.class, book.id);
+                    assertThat(reloaded.title).isEqualTo("War and Peace");
+                    // Read while the SessionFactory is still open: create-drop deletes this document when it closes.
+                    var sequenceDocument = sequences
+                            .find(BsonDocument.parse("{\"_id\": \"books_SEQ\"}"))
+                            .first();
+                    return new PersistedBook(book.id, reloaded.id, sequenceDocument);
+                },
+                Book.class);
+
+        assertThat(run.observed().id()).isEqualTo(1L);
+        assertThat(run.observed().reloadedId()).isEqualTo(1L);
+        assertThat(run.observed().sequenceDocument())
+                .isEqualTo(
+                        BsonDocument.parse(
+                                """
+                                {
+                                  "_id": "books_SEQ",
+                                  "next_value": {"$numberLong": "51"},
+                                  "increment": {"$numberLong": "50"}
+                                }"""));
+
+        assertOneCommandNamed(
+                run.commands(),
+                "update",
+                """
+                {
+                  "update": "hibernate_sequences",
+                  "updates": [
+                    {
+                      "q": {"_id": "books_SEQ"},
+                      "u": {
+                        "$setOnInsert": {
+                          "next_value": {"$numberLong": "1"},
+                          "increment": {"$numberLong": "50"}
+                        }
+                      },
+                      "upsert": true
+                    }
+                  ]
+                }""");
+        assertOneCommandNamed(
+                run.commands(),
+                "findAndModify",
+                """
+                {
+                  "findAndModify": "hibernate_sequences",
+                  "query": {
+                    "_id": "books_SEQ",
+                    "next_value": {"$type": "long"},
+                    "increment": {"$type": "long"}
+                  },
+                  "update": [
+                    {"$set": {"next_value": {"$add": ["$next_value", "$increment"]}}}
+                  ],
+                  "new": false,
+                  "fields": {"_id": 0, "next_value": 1}
+                }""");
+        assertThat(commandsNamed(run.commands(), "findAndModify").get(0)).doesNotContainKey("nonTransactional");
+
+        // Two, not one: the schema tool's "create" action does a defensive drop before creating, and "create-drop"
+        // drops again at teardown, so the sequence's drop command is sent twice with identical content.
+        var deleteCommands = commandsNamed(run.commands(), "delete");
+        assertThat(deleteCommands).hasSize(2);
+        var expectedDelete = BsonDocument.parse(
+                """
+                {
+                  "delete": "hibernate_sequences",
+                  "deletes": [
+                    {"q": {"_id": "books_SEQ"}, "limit": 1}
+                  ]
+                }""");
+        assertThat(deleteCommands).allSatisfy(command -> assertThat(command)
+                .asInstanceOf(InstanceOfAssertFactories.MAP)
+                .containsAllEntriesOf(expectedDelete));
+    }
+
+    @Test
+    void persistsWithAPrimitiveGeneratedIdentifier() {
+        var run = inRegistry(
+                session -> {
+                    session.getTransaction().begin();
+                    var pamphlet = new Pamphlet();
+                    pamphlet.title = "On Liberty";
+                    session.persist(pamphlet);
+                    session.getTransaction().commit();
+                    return pamphlet.id;
+                },
+                Pamphlet.class);
+
+        assertThat(run.observed()).isEqualTo(1L);
+    }
+
+    @Test
+    void persistsWithAnIntegerGeneratedIdentifier() {
+        var run = inRegistry(
+                session -> {
+                    session.getTransaction().begin();
+                    var note = new Note();
+                    session.persist(note);
+                    session.getTransaction().commit();
+                    return note.id;
+                },
+                Note.class);
+
+        assertThat(run.observed()).isEqualTo(1);
+    }
+
+    @Test
+    void allocationSizeOneAllocatesPerRow() {
+        var run = inRegistry(
+                session -> {
+                    session.getTransaction().begin();
+                    var ids = new ArrayList<Long>();
+                    for (var i = 0; i < 3; i++) {
+                        var ledger = new Ledger();
+                        session.persist(ledger);
+                        ids.add(ledger.id);
+                    }
+                    session.getTransaction().commit();
+                    return ids;
+                },
+                Ledger.class);
+
+        assertThat(run.observed()).containsExactly(1L, 2L, 3L);
+        assertThat(commandsNamed(run.commands(), "findAndModify")).hasSize(3);
+    }
+
+    @Test
+    void pooledAllocationAmortizesTheRoundTrip() {
+        var run = inRegistry(
+                session -> {
+                    session.getTransaction().begin();
+                    var ids = new ArrayList<Long>();
+                    for (var i = 0; i < 51; i++) {
+                        var book = new Book();
+                        book.title = "Volume " + i;
+                        session.persist(book);
+                        ids.add(book.id);
+                    }
+                    session.getTransaction().commit();
+                    return ids;
+                },
+                Book.class);
+
+        assertThat(run.observed())
+                .isEqualTo(LongStream.rangeClosed(1, 51).boxed().toList());
+        assertThat(commandsNamed(run.commands(), "findAndModify")).hasSize(2);
+    }
+
+    /**
+     * {@link #allocationSizeOneAllocatesPerRow()} and {@link #pooledAllocationAmortizesTheRoundTrip()} assert exact
+     * identifiers for {@code none} and {@code pooled}. These three produce different numbers: {@code hilo} multiplies
+     * the stored value by the increment. This test checks only that identifiers are distinct and increasing.
+     */
+    @ParameterizedTest
+    @ValueSource(strings = {"pooled-lo", "hilo", "legacy-hilo"})
+    void optimizersYieldDistinctIncreasingIdentifiers(String optimizer) {
+        var run = inRegistry(
+                Map.of("hibernate.id.optimizer.pooled.preferred", optimizer),
+                session -> {
+                    session.getTransaction().begin();
+                    var ids = new ArrayList<Long>();
+                    for (var i = 0; i < 51; i++) {
+                        var book = new Book();
+                        book.title = "Volume " + i;
+                        session.persist(book);
+                        ids.add(book.id);
+                    }
+                    session.getTransaction().commit();
+                    return ids;
+                },
+                Book.class);
+
+        assertThat(run.observed()).doesNotHaveDuplicates().isSorted();
+    }
+
+    /**
+     * JPA generator names are global, so an entity may reference a {@link SequenceGenerator} declared on a different
+     * entity. {@code forbidUnintrospectableGenerator} rejects a {@code generator()} name it cannot resolve, and this is
+     * the only shape that reaches its global-registration lookup rather than the member or class lookup.
+     */
+    @Test
+    void aGeneratorNamedOnAnotherEntityIsAccepted() {
+        var run = inRegistry(
+                session -> {
+                    session.getTransaction().begin();
+                    var consumer = new SharedSequenceConsumer();
+                    session.persist(consumer);
+                    session.getTransaction().commit();
+                    return consumer.id;
+                },
+                SharedSequenceDeclarer.class,
+                SharedSequenceConsumer.class);
+
+        assertThat(run.observed()).isEqualTo(1L);
+    }
+
+    @Test
+    void namedSequenceSeedsAtItsInitialValue() {
+        record Result(long id, BsonDocument sequenceDocument) {}
+
+        var run = inRegistry(
+                session -> {
+                    session.getTransaction().begin();
+                    var invoice = new Invoice();
+                    session.persist(invoice);
+                    session.getTransaction().commit();
+                    // Read while the SessionFactory is still open: create-drop deletes this document when it closes.
+                    var sequenceDocument = sequences
+                            .find(BsonDocument.parse("{\"_id\": \"invoice_numbers\"}"))
+                            .first();
+                    return new Result(invoice.id, sequenceDocument);
+                },
+                Invoice.class);
+
+        assertThat(run.observed().id()).isEqualTo(1000L);
+        assertThat(run.observed().sequenceDocument())
+                .isEqualTo(
+                        BsonDocument.parse(
+                                """
+                                {
+                                  "_id": "invoice_numbers",
+                                  "next_value": {"$numberLong": "1010"},
+                                  "increment": {"$numberLong": "10"}
+                                }"""));
+    }
+
+    @Test
+    void schemaQualifiedSequenceNameFoldsIntoTheCounterId() {
+        var run = inRegistry(
+                session -> {
+                    session.getTransaction().begin();
+                    var receipt = new Receipt();
+                    session.persist(receipt);
+                    session.getTransaction().commit();
+                    // Read while the SessionFactory is still open: create-drop deletes this document when it closes.
+                    return sequences
+                            .find(BsonDocument.parse("{\"_id\": \"billing.receipt_numbers\"}"))
+                            .first();
+                },
+                Receipt.class);
+
+        assertThat(run.observed()).isNotNull();
+    }
+
+    @Test
+    void reExportDoesNotResetALiveSequence() {
+        sequences.insertOne(
+                BsonDocument.parse(
+                        """
+                        {
+                          "_id": "books_SEQ",
+                          "next_value": {"$numberLong": "501"},
+                          "increment": {"$numberLong": "50"}
+                        }"""));
+
+        // The JPA action "create" (unlike "create-drop") does not drop before creating, so re-export is the only
+        // thing under test here: no teardown-drop to muddy whether the counter merely survived being untouched.
+        var run = inRegistry(
+                Map.of("jakarta.persistence.schema-generation.database.action", "create"),
+                session -> {
+                    session.getTransaction().begin();
+                    var book = new Book();
+                    book.title = "After re-export";
+                    session.persist(book);
+                    session.getTransaction().commit();
+                    return book.id;
+                },
+                Book.class);
+
+        // The pooled optimizer reads the returned value as the upper bound of the block it just reserved, the same
+        // as a native sequence would: the fresh optimizer's first identifier is next_value - increment + 1 = 452,
+        // not 501.
+        assertThat(run.observed()).isEqualTo(452L);
+    }
+
+    @Test
+    void allocationSurvivesARolledBackTransaction() {
+        record Result(long id, long bookCount, long nextValue) {}
+
+        // Read while the SessionFactory is still open: create-drop drops the "books" collection and deletes the
+        // sequence document when it closes, so the row count would then read zero whatever rollback did.
+        var run = inRegistry(
+                session -> {
+                    session.getTransaction().begin();
+                    var book = new Book();
+                    book.title = "Never committed";
+                    session.persist(book);
+                    session.getTransaction().rollback();
+                    var nextValue = sequences
+                            .find(BsonDocument.parse("{\"_id\": \"books_SEQ\"}"))
+                            .first()
+                            .getInt64("next_value")
+                            .getValue();
+                    return new Result(book.id, books.countDocuments(), nextValue);
+                },
+                Book.class);
+
+        assertThat(run.observed().id()).isEqualTo(1L);
+        assertThat(run.observed().bookCount()).isZero();
+        assertThat(run.observed().nextValue()).isEqualTo(51L);
+    }
+
+    @Test
+    void concurrentAllocationYieldsDistinctIdentifiers() throws Exception {
+        var threads = 8;
+        var perThread = 20;
+        var run = inRegistry(
+                session -> {
+                    var sessionFactory = session.getSessionFactory();
+                    var ids = Collections.synchronizedList(new ArrayList<Long>());
+                    var executor = Executors.newFixedThreadPool(threads);
+                    try {
+                        var futures = new ArrayList<Future<?>>();
+                        for (var t = 0; t < threads; t++) {
+                            futures.add(executor.submit(() -> {
+                                try (var threadSession = sessionFactory.openSession()) {
+                                    for (var i = 0; i < perThread; i++) {
+                                        threadSession.getTransaction().begin();
+                                        var ledger = new Ledger();
+                                        threadSession.persist(ledger);
+                                        threadSession.getTransaction().commit();
+                                        ids.add(ledger.id);
+                                    }
+                                }
+                            }));
+                        }
+                        for (var future : futures) {
+                            try {
+                                future.get();
+                            } catch (Exception e) {
+                                throw new AssertionError("concurrent allocation failed", e);
+                            }
+                        }
+                    } finally {
+                        executor.shutdown();
+                    }
+                    return ids;
+                },
+                Ledger.class);
+
+        assertThat(run.observed()).hasSize(threads * perThread).doesNotHaveDuplicates();
+    }
+
+    /**
+     * A counter document created by hand, which a deployment with schema management turned off has to do, is rejected
+     * unless it carries both 64-bit fields. Left unguarded, a missing {@code increment} makes {@code $add} evaluate to
+     * null, so the sequence writes null over its own value and hands out the same identifier forever.
+     *
+     * <p>Each shape is caught in a different place, which is why each asserts its own message. A missing
+     * {@code increment} reads back as {@code 0} during Hibernate ORM's boot-time increment-mismatch check and fails
+     * there. A wrong BSON type fails in the same check, while reading the value. A missing {@code next_value} leaves
+     * {@code increment} matching {@code allocationSize}, so boot succeeds and the allocation's own shape guard catches
+     * it instead.
+     */
+    @ParameterizedTest
+    @MethodSource("malformedCounterDocuments")
+    void allocationFromAMalformedCounterFails(String counterDocument, String expectedMessage) {
+        sequences.insertOne(BsonDocument.parse(counterDocument));
+
+        assertThatThrownBy(() -> inRegistry(
+                        Map.of("jakarta.persistence.schema-generation.database.action", "none"),
+                        session -> {
+                            session.getTransaction().begin();
+                            var book = new Book();
+                            book.title = "Malformed counter";
+                            session.persist(book);
+                            session.getTransaction().commit();
+                            return null;
+                        },
+                        Book.class))
+                .hasStackTraceContaining(expectedMessage);
+
+        assertThat(sequences
+                        .find(BsonDocument.parse("{\"_id\": \"books_SEQ\"}"))
+                        .first())
+                .isEqualTo(BsonDocument.parse(counterDocument));
+    }
+
+    private static Stream<Arguments> malformedCounterDocuments() {
+        return Stream.of(
+                arguments(
+                        """
+                        {"_id": "books_SEQ", "next_value": {"$numberLong": "1"}}""",
+                        "database sequence increment size is [0]"),
+                arguments(
+                        """
+                        {"_id": "books_SEQ", "increment": {"$numberLong": "50"}}""",
+                        "matched no document"),
+                arguments(
+                        """
+                        {"_id": "books_SEQ", "next_value": 1, "increment": 50}""",
+                        "Value expected to be of type INT64 is of unexpected type INT32"));
+    }
+
+    /**
+     * A counter document created by hand, the way a deployment with schema management turned off has to, may declare an
+     * {@code increment} that does not match the generator's {@code allocationSize}. Hibernate ORM's own
+     * increment-mismatch check catches this at boot, provided the dialect supplies sequence metadata; left unguarded,
+     * the pooled optimizer would otherwise hand out negative identifiers once its first block is exhausted.
+     */
+    @Test
+    void mismatchedIncrementFailsAtBoot() {
+        sequences.insertOne(
+                BsonDocument.parse(
+                        """
+                        {"_id": "books_SEQ", "next_value": {"$numberLong": "1"}, "increment": {"$numberLong": "1"}}"""));
+
+        assertThatThrownBy(() -> inRegistry(
+                        Map.of("jakarta.persistence.schema-generation.database.action", "none"),
+                        session -> null,
+                        Book.class))
+                .isInstanceOf(MappingException.class)
+                .hasMessage(
+                        "The increment size of the [books_SEQ] sequence is set to [50] in the entity mapping but the"
+                                + " mapped database sequence increment size is [1]");
+    }
+
+    @Test
+    void allocationWithoutASeededCounterFails() {
+        assertThatThrownBy(() -> inRegistry(
+                        Map.of("jakarta.persistence.schema-generation.database.action", "none"),
+                        session -> {
+                            session.getTransaction().begin();
+                            var book = new Book();
+                            book.title = "No counter";
+                            session.persist(book);
+                            session.getTransaction().commit();
+                            return null;
+                        },
+                        Book.class))
+                .rootCause()
+                .hasMessageContaining("findAndModify")
+                .hasMessageContaining("books_SEQ");
+    }
+
+    @Nested
+    class Unsupported {
+
+        @Entity(name = "IdentityItem")
+        @Table(name = "identityItems")
+        static class IdentityItem {
+            @Id
+            @GeneratedValue(strategy = GenerationType.IDENTITY)
+            Long id;
+        }
+
+        @Entity(name = "TableItem")
+        @Table(name = "tableItems")
+        static class TableItem {
+            @Id
+            @GeneratedValue(strategy = GenerationType.TABLE)
+            Long id;
+        }
+
+        @Entity(name = "UuidItem")
+        @Table(name = "uuidItems")
+        static class UuidItem {
+            @Id
+            @GeneratedValue(strategy = GenerationType.UUID)
+            String id;
+        }
+
+        @Entity(name = "BigIntegerItem")
+        @Table(name = "bigIntegerItems")
+        static class BigIntegerItem {
+            @Id
+            @GeneratedValue
+            BigInteger id;
+        }
+
+        /**
+         * Hibernate ORM reads a three-part sequence name as catalog, schema, sequence. This dialect reports only
+         * SCHEMA, so the catalog would be dropped and the counter key would collide with a plain {@code schema = "b"},
+         * {@code sequenceName = "c"}.
+         */
+        @Entity(name = "CatalogQualifiedItem")
+        @Table(name = "catalogQualifiedItems")
+        @SequenceGenerator(name = "catalogQualifiedSeq", sequenceName = "a.b.c", allocationSize = 1)
+        static class CatalogQualifiedItem {
+            @Id
+            @GeneratedValue(generator = "catalogQualifiedSeq")
+            Long id;
+        }
+
+        @Entity(name = "CatalogAttributeItem")
+        @Table(name = "catalogAttributeItems")
+        @SequenceGenerator(name = "catalogAttributeSeq", catalog = "cat", sequenceName = "s", allocationSize = 1)
+        static class CatalogAttributeItem {
+            @Id
+            @GeneratedValue(generator = "catalogAttributeSeq")
+            Long id;
+        }
+
+        /**
+         * A '.' in the schema survives as a quoted identifier, so the counter key {@code a.b.c} would be
+         * indistinguishable from a schema {@code a.b} plus sequence {@code c} written any other way.
+         */
+        @Entity(name = "DottedSequenceSchemaItem")
+        @Table(name = "dottedSequenceSchemaItems")
+        @SequenceGenerator(name = "dottedSchemaSeq", schema = "a.b", sequenceName = "c", allocationSize = 1)
+        static class DottedSequenceSchemaItem {
+            @Id
+            @GeneratedValue(generator = "dottedSchemaSeq")
+            Long id;
+        }
+
+        /**
+         * Backtick-quoting stops Hibernate ORM from splitting the name on the '.', so the counter key {@code b.c} would
+         * be indistinguishable from schema {@code b} plus sequence {@code c}.
+         */
+        @Entity(name = "QuotedDottedSequenceNameItem")
+        @Table(name = "quotedDottedSequenceNameItems")
+        @SequenceGenerator(name = "quotedDottedSeq", sequenceName = "`b.c`", allocationSize = 1)
+        static class QuotedDottedSequenceNameItem {
+            @Id
+            @GeneratedValue(generator = "quotedDottedSeq")
+            Long id;
+        }
+
+        @Entity(name = "OptionsItem")
+        @Table(name = "optionsItems")
+        @SequenceGenerator(name = "optionsSeq", options = "cache 20")
+        static class OptionsItem {
+            @Id
+            @GeneratedValue(generator = "optionsSeq")
+            Long id;
+        }
+
+        @Entity(name = "SequenceCollectionItem")
+        @Table(name = "hibernate_sequences")
+        static class SequenceCollectionItem {
+            @Id
+            Long id;
+        }
+
+        /**
+         * {@code hiloOptimizersYieldDistinctMonotonicallyIncreasingIdentifiers} covers the working way to select
+         * {@code hilo}: the {@code hibernate.id.optimizer.pooled.preferred} setting, which needs no generator
+         * annotation at all. This entity instead selects it per-generator, the only way to do that being an explicit
+         * {@code optimizer} parameter carried by {@code @GenericGenerator}, which
+         * {@code forbidUnintrospectableGenerator} rejects outright alongside {@code @GeneratedValue}.
+         */
+        @SuppressWarnings("removal")
+        @GenericGenerator(
+                name = "hiloItemSeq",
+                strategy = "org.hibernate.id.enhanced.SequenceStyleGenerator",
+                parameters = {
+                    @Parameter(name = "optimizer", value = "hilo"),
+                    @Parameter(name = "increment_size", value = "20")
+                })
+        @Entity(name = "HiloItem")
+        @Table(name = "hiloItems")
+        static class HiloItem {
+            @Id
+            @GeneratedValue(generator = "hiloItemSeq")
+            Long id;
+        }
+
+        @Entity(name = "TableGeneratorItem")
+        @Table(name = "tableGeneratorItems")
+        static class TableGeneratorItem {
+            @Id
+            @GeneratedValue
+            @TableGenerator(name = "tableGeneratorItemSeq", table = "table_generator_item_seq")
+            Long id;
+        }
+
+        @Entity(name = "IdentityNamedGeneratorItem")
+        @Table(name = "identityNamedGeneratorItems")
+        static class IdentityNamedGeneratorItem {
+            @Id
+            @GeneratedValue(generator = "identity")
+            Long id;
+        }
+
+        @Entity(name = "IncrementNamedGeneratorItem")
+        @Table(name = "incrementNamedGeneratorItems")
+        static class IncrementNamedGeneratorItem {
+            @Id
+            @GeneratedValue(generator = "increment")
+            Long id;
+        }
+
+        @Test
+        void identityStrategyIsRejected() {
+            assertThatThrownBy(() -> inRegistry(session -> null, IdentityItem.class))
+                    .isInstanceOf(FeatureNotSupportedException.class)
+                    .hasMessageContaining("IDENTITY")
+                    .hasMessageContaining("SEQUENCE");
+        }
+
+        @Test
+        void tableStrategyIsRejected() {
+            assertThatThrownBy(() -> inRegistry(session -> null, TableItem.class))
+                    .isInstanceOf(FeatureNotSupportedException.class)
+                    .hasMessageContaining("TODO-HIBERNATE-252");
+        }
+
+        @Test
+        void uuidStrategyIsRejected() {
+            assertThatThrownBy(() -> inRegistry(session -> null, UuidItem.class))
+                    .isInstanceOf(FeatureNotSupportedException.class)
+                    .hasMessageContaining("TODO-HIBERNATE-121");
+        }
+
+        @Test
+        void bigIntegerIdentifierIsRejected() {
+            assertThatThrownBy(() -> inRegistry(session -> null, BigIntegerItem.class))
+                    .isInstanceOf(FeatureNotSupportedException.class)
+                    .hasMessageContaining("TODO-HIBERNATE-253");
+        }
+
+        @Test
+        void catalogQualifiedSequenceIsRejected() {
+            assertThatThrownBy(() -> inRegistry(session -> null, CatalogQualifiedItem.class))
+                    .hasStackTraceContaining("qualified by the catalog [a]");
+        }
+
+        @Test
+        void catalogAttributeOnSequenceIsRejected() {
+            assertThatThrownBy(() -> inRegistry(session -> null, CatalogAttributeItem.class))
+                    .hasStackTraceContaining("qualified by the catalog [cat]");
+        }
+
+        @Test
+        void dottedSequenceSchemaIsRejected() {
+            assertThatThrownBy(() -> inRegistry(session -> null, DottedSequenceSchemaItem.class))
+                    .hasStackTraceContaining("The character [.] in a sequence schema name is not supported");
+        }
+
+        @Test
+        void dottedSequenceNameIsRejected() {
+            assertThatThrownBy(() -> inRegistry(session -> null, QuotedDottedSequenceNameItem.class))
+                    .hasStackTraceContaining("The character [.] in a sequence name is not supported");
+        }
+
+        @Test
+        void sequenceOptionsAreRejected() {
+            assertThatThrownBy(() -> inRegistry(session -> null, OptionsItem.class))
+                    .isInstanceOf(FeatureNotSupportedException.class)
+                    .hasMessageContaining("cache 20");
+        }
+
+        @Test
+        void entityMappedToTheSequenceCollectionIsRejected() {
+            assertThatThrownBy(() -> inRegistry(session -> null, SequenceCollectionItem.class))
+                    .isInstanceOf(FeatureNotSupportedException.class)
+                    .hasMessageContaining("hibernate_sequences");
+        }
+
+        @Test
+        void hiloViaGenericGeneratorAnnotationIsRejected() {
+            assertThatThrownBy(() -> inRegistry(session -> null, HiloItem.class))
+                    .isInstanceOf(FeatureNotSupportedException.class)
+                    .hasMessageContaining("GenericGenerator");
+        }
+
+        @Test
+        void localizedTableGeneratorIsRejected() {
+            assertThatThrownBy(() -> inRegistry(session -> null, TableGeneratorItem.class))
+                    .isInstanceOf(FeatureNotSupportedException.class)
+                    .hasMessageContaining("TODO-HIBERNATE-252");
+        }
+
+        @Test
+        void namedIdentityGeneratorIsRejected() {
+            assertThatThrownBy(() -> inRegistry(session -> null, IdentityNamedGeneratorItem.class))
+                    .isInstanceOf(FeatureNotSupportedException.class)
+                    .hasMessageContaining("IDENTITY")
+                    .hasMessageContaining("SEQUENCE");
+        }
+
+        @Test
+        void namedIncrementGeneratorIsRejected() {
+            assertThatThrownBy(() -> inRegistry(session -> null, IncrementNamedGeneratorItem.class))
+                    .isInstanceOf(FeatureNotSupportedException.class)
+                    .hasMessageContaining("increment");
+        }
+
+        @Test
+        void bulkInsertSelectIsRejected() {
+            assertThatThrownBy(() -> inRegistry(
+                            session -> {
+                                session.getTransaction().begin();
+                                try {
+                                    return session.createMutationQuery(
+                                                    "insert into Book (id, title) select b.id, b.title from Book b")
+                                            .executeUpdate();
+                                } finally {
+                                    session.getTransaction().rollback();
+                                }
+                            },
+                            Book.class))
+                    .isInstanceOf(FeatureNotSupportedException.class)
+                    .hasMessageContaining("Insertion statement with source selection is not supported");
+        }
+    }
+}

--- a/src/integrationTest/java/com/mongodb/hibernate/query/select/NativeQueryIntegrationTests.java
+++ b/src/integrationTest/java/com/mongodb/hibernate/query/select/NativeQueryIntegrationTests.java
@@ -50,6 +50,7 @@ import jakarta.persistence.Table;
 import jakarta.persistence.Tuple;
 import java.math.BigDecimal;
 import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
 import java.time.Instant;
 import java.util.HashSet;
 import java.util.List;
@@ -782,6 +783,28 @@ class NativeQueryIntegrationTests extends AbstractQueryIntegrationTests {
 
     @Nested
     class Unsupported implements MongoServiceRegistryProducer {
+        /**
+         * {@code findAndModify} reaches the JDBC adapter from a native query, but the adapter accepts only the fields
+         * it generates for sequence allocation.
+         */
+        @Test
+        void testFindAndModifyWithUnsupportedField() {
+            getSessionFactoryScope().inSession(session -> {
+                var mql =
+                        """
+                        {
+                          "findAndModify": "hibernate_sequences",
+                          "query": {},
+                          "update": [],
+                          "sort": {"_id": 1}
+                        }""";
+                assertThatThrownBy(() ->
+                                session.createNativeQuery(mql, Object.class).getResultList())
+                        .hasRootCauseInstanceOf(SQLFeatureNotSupportedException.class)
+                        .hasMessageContaining("sort");
+            });
+        }
+
         /**
          * We do not support this due to what seem to be a Hibernate ORM bug: <a
          * href="https://hibernate.atlassian.net/browse/HHH-19866">Entity native query incorrectly handles

--- a/src/main/java/com/mongodb/hibernate/internal/MongoConstants.java
+++ b/src/main/java/com/mongodb/hibernate/internal/MongoConstants.java
@@ -41,6 +41,18 @@ public final class MongoConstants {
     public static final String MONGO_JDBC_DRIVER_NAME = MONGO_DBMS_NAME + " Java Driver JDBC Adapter";
     public static final String ID_FIELD_NAME = "_id";
 
+    /**
+     * A JDBC-adapter field, not a MongoDB command field. When {@code true}, {@code MongoStatement} runs the command
+     * without a {@code ClientSession} and without starting a transaction. {@code findAndModify} is the only command
+     * that reads this field, and {@code MongoStatement} requires it there: a {@code findAndModify} that omits it is
+     * refused. No other command consults it. Stated in the command so that it is visible in generated MQL rather than
+     * being an implicit rule about one command name.
+     */
+    public static final String NON_TRANSACTIONAL_COMMAND_FIELD_NAME = "nonTransactional";
+
+    /** The fixed, non-configurable collection backing every Hibernate sequence counter. */
+    public static final String SEQUENCE_COLLECTION_NAME = "hibernate_sequences";
+
     public static final String MONGO_DIALECT_SHORT_NAME = "MongoDB";
 
     /**

--- a/src/main/java/com/mongodb/hibernate/internal/boot/MongoAdditionalMappingContributor.java
+++ b/src/main/java/com/mongodb/hibernate/internal/boot/MongoAdditionalMappingContributor.java
@@ -21,15 +21,25 @@ import static com.mongodb.hibernate.internal.MongoAssertions.assertInstanceOf;
 import static com.mongodb.hibernate.internal.MongoAssertions.assertNotNull;
 import static com.mongodb.hibernate.internal.MongoAssertions.assertTrue;
 import static com.mongodb.hibernate.internal.MongoConstants.ID_FIELD_NAME;
+import static com.mongodb.hibernate.internal.MongoConstants.MONGO_DBMS_NAME;
+import static com.mongodb.hibernate.internal.MongoConstants.SEQUENCE_COLLECTION_NAME;
+import static com.mongodb.hibernate.internal.boot.NameChecks.forbidDot;
 import static java.lang.String.format;
 import static java.util.stream.Collectors.toSet;
 
+import com.mongodb.hibernate.annotations.ObjectIdGenerator;
 import com.mongodb.hibernate.internal.EmbeddedIdColumnName;
 import com.mongodb.hibernate.internal.FeatureNotSupportedException;
+import com.mongodb.hibernate.internal.MongoConstants;
 import com.mongodb.hibernate.internal.dialect.MongoDialect;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.TableGenerator;
+import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.sql.Time;
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
@@ -57,6 +67,8 @@ import org.bson.types.MinKey;
 import org.bson.types.Symbol;
 import org.hibernate.annotations.Generated;
 import org.hibernate.annotations.GeneratedColumn;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.IdGeneratorType;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.annotations.Struct;
 import org.hibernate.boot.Metadata;
@@ -72,11 +84,13 @@ import org.hibernate.engine.config.spi.ConfigurationService;
 import org.hibernate.mapping.AggregateColumn;
 import org.hibernate.mapping.Collection;
 import org.hibernate.mapping.Component;
+import org.hibernate.mapping.KeyValue;
 import org.hibernate.mapping.PersistentClass;
 import org.hibernate.mapping.Property;
 import org.hibernate.mapping.SimpleValue;
 import org.hibernate.mapping.ToOne;
 import org.hibernate.mapping.UniqueKey;
+import org.hibernate.models.spi.MemberDetails;
 import org.hibernate.type.BasicPluralType;
 import org.hibernate.type.ComponentType;
 
@@ -152,11 +166,13 @@ public final class MongoAdditionalMappingContributor implements AdditionalMappin
             forbidDerivedIdentity(persistentClass);
             forbidJdbcTypeCodeAnnotation(persistentClass);
             forbidColumnFragmentAnnotations(persistentClass);
+            forbidUnsupportedIdentifierGeneration(persistentClass, metadata);
             setIdentifierColumnName(persistentClass);
             materializeUniqueColumns(persistentClass);
         });
         forbidCatalog(metadata, buildingContext);
         forbidDottedTableQualifiers(metadata);
+        forbidReservedCollectionName(metadata);
     }
 
     /**
@@ -210,12 +226,7 @@ public final class MongoAdditionalMappingContributor implements AdditionalMappin
                 catalog));
     }
 
-    /**
-     * A schema folds into the collection name as {@code schema.name}, so the '.' is the extension's own separator. A
-     * '.' written by the user makes the resolved name ambiguous: {@code @Table(schema = "a", name = "b")} and
-     * {@code @Table(name = "a.b")} would resolve to the same collection, and nothing downstream could tell the two
-     * qualifiers apart.
-     */
+    /** @see NameChecks#forbidDot(String, String) */
     private static void forbidDottedTableQualifiers(InFlightMetadataCollector metadata) {
         for (var namespace : metadata.getDatabase().getNamespaces()) {
             var schema = namespace.getName().schema();
@@ -228,13 +239,22 @@ public final class MongoAdditionalMappingContributor implements AdditionalMappin
         }
     }
 
-    private static void forbidDot(String name, String kind) {
-        if (name.contains(".")) {
-            throw new FeatureNotSupportedException(format(
-                    "The character [.] in a %s name is not supported, but is present in [%s]. A schema folds into the"
-                            + " collection name as [schema.name], so a '.' written by the user would make the resolved"
-                            + " collection name ambiguous.",
-                    kind, name));
+    /**
+     * {@value MongoConstants#SEQUENCE_COLLECTION_NAME} is fixed and not configurable, so mapping an entity onto it is
+     * the user's only way to collide with the sequence counters it holds.
+     */
+    private static void forbidReservedCollectionName(InFlightMetadataCollector metadata) {
+        for (var namespace : metadata.getDatabase().getNamespaces()) {
+            var schema = namespace.getName().schema();
+            for (var table : namespace.getTables()) {
+                var resolved = schema == null ? table.getName() : schema.getText() + "." + table.getName();
+                if (resolved.equals(SEQUENCE_COLLECTION_NAME)) {
+                    throw new FeatureNotSupportedException(format(
+                            "An entity is mapped to the collection [%s], which is reserved for Hibernate sequence"
+                                    + " counters.",
+                            SEQUENCE_COLLECTION_NAME));
+                }
+            }
         }
     }
 
@@ -363,8 +383,191 @@ public final class MongoAdditionalMappingContributor implements AdditionalMappin
                 false,
                 ClassElementChecker.forbid(Generated.class),
                 ClassElementChecker.forbid(GeneratedColumn.class),
-                ClassElementChecker.forbid(GeneratedValue.class),
                 ClassElementChecker.CURRENT_TIMESTAMP_WITH_DB_SOURCE);
+    }
+
+    private static final Set<String> IDENTITY_FLAVORED_LEGACY_GENERATOR_NAMES = Set.of("identity");
+    private static final Set<String> TABLE_FLAVORED_LEGACY_GENERATOR_NAMES = Set.of("table", "enhanced-table");
+    private static final Set<String> UUID_FLAVORED_LEGACY_GENERATOR_NAMES = Set.of("uuid", "uuid.hex", "uuid2", "guid");
+
+    /**
+     * The names {@code GeneratorStrategies.mapLegacyNamedGenerator} maps to something other than a sequence.
+     * {@code sequence} and {@code enhanced-sequence} are absent because they are supported, and so is {@code native},
+     * which resolves through {@code Dialect#getNativeIdentifierGeneratorStrategy} to {@code sequence} for a dialect
+     * without identity columns.
+     */
+    private static final Set<String> NON_SEQUENCE_LEGACY_GENERATOR_NAMES = Set.of(
+            "assigned",
+            "foreign",
+            "select",
+            "increment",
+            "identity",
+            "table",
+            "enhanced-table",
+            "uuid",
+            "uuid.hex",
+            "uuid2",
+            "guid");
+
+    /**
+     * Only sequence-backed generation is supported, and only for the identifier types Hibernate ORM reads with
+     * {@code ResultSet#getLong}.
+     *
+     * <p>{@code generatedValue.strategy()} is not what determines the generator Hibernate actually resolves: an unnamed
+     * {@code AUTO} generator can be captured by a localized {@link TableGenerator}, and a named generator can map
+     * through {@code GeneratorStrategies.mapLegacyNamedGenerator} to identity, table, increment or UUID generation
+     * regardless of what {@code strategy()} says. Since the resolved generator is not introspectable
+     * ({@link SimpleValue#getCustomIdGeneratorCreator()} is an opaque lambda), the annotation shapes that could produce
+     * one of those generators are forbidden directly rather than relying on {@code strategy()}.
+     */
+    private static void forbidUnsupportedIdentifierGeneration(
+            PersistentClass persistentClass, InFlightMetadataCollector metadata) {
+        var identifier = persistentClass.getIdentifier();
+        if (!(identifier instanceof SimpleValue simpleValue)) {
+            return;
+        }
+        var memberDetails = simpleValue.getMemberDetails();
+        if (memberDetails == null) {
+            return;
+        }
+        // getDirectAnnotationUsage returns null when the annotation is absent, though it is declared without
+        // @Nullable, so an IDE reports this check as always false. Removing it would run the switch below on every
+        // entity, including the ones with no @GeneratedValue at all.
+        var generatedValue = memberDetails.getDirectAnnotationUsage(GeneratedValue.class);
+        if (generatedValue == null) {
+            return;
+        }
+        forbidUnintrospectableGenerator(persistentClass, memberDetails, generatedValue, metadata);
+        switch (generatedValue.strategy()) {
+            case AUTO, SEQUENCE -> forbidUnsupportedGeneratedIdentifierType(persistentClass, identifier);
+            case IDENTITY -> throw identityGenerationNotSupported(persistentClass);
+            case TABLE -> throw tableGenerationNotSupported(persistentClass);
+            case UUID -> throw uuidGenerationNotSupported(persistentClass);
+        }
+    }
+
+    /**
+     * Rejects the annotation combinations that resolve, via Hibernate's own generator lookup, to a generator other than
+     * a MongoDB-backed sequence: a {@link TableGenerator} or {@link GenericGenerator} localized on the identifier
+     * member or its entity class, a meta-annotation annotated with {@link IdGeneratorType}, and a non-blank
+     * {@code generator()} that names none of {@code @SequenceGenerator} localized on the member/class or declared
+     * globally in the metadata.
+     */
+    @SuppressWarnings("removal") // org.hibernate.annotations.GenericGenerator is deprecated but still resolvable
+    private static void forbidUnintrospectableGenerator(
+            PersistentClass persistentClass,
+            MemberDetails idMember,
+            GeneratedValue generatedValue,
+            InFlightMetadataCollector metadata) {
+        var classDetails = metadata.getClassDetailsRegistry().getClassDetails(persistentClass.getClassName());
+        var modelsContext = metadata.getBootstrapContext().getModelsContext();
+
+        if (idMember.hasDirectAnnotationUsage(TableGenerator.class)
+                || classDetails.hasDirectAnnotationUsage(TableGenerator.class)) {
+            throw tableGenerationNotSupported(persistentClass);
+        }
+        if (idMember.hasDirectAnnotationUsage(GenericGenerator.class)
+                || classDetails.hasDirectAnnotationUsage(GenericGenerator.class)) {
+            throw unsupportedGenerator(
+                    persistentClass, format("a [@%s] identifier generator", GenericGenerator.class.getSimpleName()));
+        }
+        if (!idMember.getMetaAnnotated(IdGeneratorType.class, modelsContext).isEmpty()
+                || !classDetails
+                        .getMetaAnnotated(IdGeneratorType.class, modelsContext)
+                        .isEmpty()) {
+            throw unsupportedGenerator(
+                    persistentClass,
+                    format(
+                            "a custom identifier generator (meta-annotated with [@%s])",
+                            IdGeneratorType.class.getSimpleName()));
+        }
+
+        var generatorName = generatedValue.generator();
+        if (!generatorName.isBlank() && namesANonSequenceGenerator(generatorName, metadata)) {
+            throw nonSequenceGenerator(persistentClass, generatorName);
+        }
+    }
+
+    /**
+     * Any name that is neither a legacy non-sequence name nor a globally registered {@link GenericGenerator} either
+     * matches a declared {@link SequenceGenerator} or becomes an implicit sequence, and both are supported. A declared
+     * {@link SequenceGenerator} is not looked up here because generator names are global: an entity may name one
+     * declared on a different entity.
+     */
+    private static boolean namesANonSequenceGenerator(String generatorName, InFlightMetadataCollector metadata) {
+        return NON_SEQUENCE_LEGACY_GENERATOR_NAMES.contains(generatorName)
+                || metadata.getGlobalRegistrations()
+                        .getGenericGeneratorRegistrations()
+                        .containsKey(generatorName);
+    }
+
+    private static FeatureNotSupportedException nonSequenceGenerator(
+            PersistentClass persistentClass, String generatorName) {
+        if (IDENTITY_FLAVORED_LEGACY_GENERATOR_NAMES.contains(generatorName)) {
+            return identityGenerationNotSupported(persistentClass);
+        }
+        if (TABLE_FLAVORED_LEGACY_GENERATOR_NAMES.contains(generatorName)) {
+            return tableGenerationNotSupported(persistentClass);
+        }
+        if (UUID_FLAVORED_LEGACY_GENERATOR_NAMES.contains(generatorName)) {
+            return uuidGenerationNotSupported(persistentClass);
+        }
+        return unsupportedGenerator(persistentClass, format("the identifier generator named [%s]", generatorName));
+    }
+
+    private static FeatureNotSupportedException unsupportedGenerator(PersistentClass persistentClass, String what) {
+        return new FeatureNotSupportedException(format(
+                "%s: %s is not supported; the only supported identifier generation is sequence-backed"
+                        + " (@GeneratedValue with strategy AUTO or SEQUENCE, naming a @SequenceGenerator or no"
+                        + " generator name at all)",
+                persistentClass, what));
+    }
+
+    private static FeatureNotSupportedException identityGenerationNotSupported(PersistentClass persistentClass) {
+        return new FeatureNotSupportedException(format(
+                "%s: identifier generation strategy [%s] is not supported: %s has no auto-increment field and"
+                        + " no way to return a generated key from an insert. Use [%s], or [@%s] for a"
+                        + " database-chosen ObjectId identifier.",
+                persistentClass,
+                GenerationType.IDENTITY,
+                MONGO_DBMS_NAME,
+                GenerationType.SEQUENCE,
+                ObjectIdGenerator.class.getSimpleName()));
+    }
+
+    private static FeatureNotSupportedException tableGenerationNotSupported(PersistentClass persistentClass) {
+        return new FeatureNotSupportedException(format(
+                "%s: identifier generation strategy [%s] is not supported; use [%s]."
+                        + " TODO-HIBERNATE-252 https://jira.mongodb.org/browse/HIBERNATE-252",
+                persistentClass, GenerationType.TABLE, GenerationType.SEQUENCE));
+    }
+
+    private static FeatureNotSupportedException uuidGenerationNotSupported(PersistentClass persistentClass) {
+        return new FeatureNotSupportedException(format(
+                "%s: identifier generation strategy [%s] is not supported."
+                        + " TODO-HIBERNATE-121 https://jira.mongodb.org/browse/HIBERNATE-121",
+                persistentClass, GenerationType.UUID));
+    }
+
+    private static void forbidUnsupportedGeneratedIdentifierType(PersistentClass persistentClass, KeyValue identifier) {
+        var identifierType = identifier.getType().getReturnedClass();
+        if (isSupportedGeneratedIdentifierType(identifierType)) {
+            return;
+        }
+        if (identifierType == BigInteger.class || identifierType == BigDecimal.class) {
+            throw new FeatureNotSupportedException(format(
+                    "%s: a generated identifier of type [%s] is not supported."
+                            + " TODO-HIBERNATE-253 https://jira.mongodb.org/browse/HIBERNATE-253",
+                    persistentClass, identifierType.getTypeName()));
+        }
+        throw new FeatureNotSupportedException(format(
+                "%s: a generated identifier of type [%s] is not supported;"
+                        + " supported types are [short], [int] and [long] and their boxed forms",
+                persistentClass, identifierType.getTypeName()));
+    }
+
+    private static boolean isSupportedGeneratedIdentifierType(Class<?> identifierType) {
+        return identifierType == Short.class || identifierType == Integer.class || identifierType == Long.class;
     }
 
     private static void checkPropertyType(

--- a/src/main/java/com/mongodb/hibernate/internal/boot/MongoSequenceIntegrator.java
+++ b/src/main/java/com/mongodb/hibernate/internal/boot/MongoSequenceIntegrator.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2026-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.hibernate.internal.boot;
+
+import static com.mongodb.hibernate.internal.boot.NameChecks.forbidDot;
+import static java.lang.String.format;
+
+import com.mongodb.hibernate.internal.FeatureNotSupportedException;
+import com.mongodb.hibernate.internal.dialect.MongoDialect;
+import org.hibernate.boot.Metadata;
+import org.hibernate.boot.model.relational.QualifiedSequenceName;
+import org.hibernate.boot.spi.BootstrapContext;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.integrator.spi.Integrator;
+
+/**
+ * Applies to sequences the qualifier rules {@link MongoAdditionalMappingContributor} applies to tables. Sequences are
+ * registered after that contributor runs, which is why this lives here rather than beside it.
+ *
+ * <p>Every sequence becomes one document in
+ * {@value com.mongodb.hibernate.internal.MongoConstants#SEQUENCE_COLLECTION_NAME} keyed by {@code schema.name}, so a
+ * '.' written by the user would let two sequences Hibernate ORM keeps apart by qualifier land on one counter document
+ * and hand out interleaved identifiers.
+ *
+ * @hidden
+ */
+@SuppressWarnings("MissingSummary")
+public final class MongoSequenceIntegrator implements Integrator {
+
+    public MongoSequenceIntegrator() {}
+
+    @Override
+    public void integrate(
+            Metadata metadata, BootstrapContext bootstrapContext, SessionFactoryImplementor sessionFactory) {
+        if (!(metadata.getDatabase().getDialect() instanceof MongoDialect)) {
+            // avoid interfering with bootstrapping unrelated to the MongoDB Extension for Hibernate ORM
+            return;
+        }
+        for (var namespace : metadata.getDatabase().getNamespaces()) {
+            for (var sequence : namespace.getSequences()) {
+                var name = sequence.getName();
+                forbidCatalog(name);
+                var schema = name.getSchemaName();
+                if (schema != null) {
+                    forbidDot(schema.getText(), "sequence schema");
+                }
+                forbidDot(name.getSequenceName().getText(), "sequence");
+            }
+        }
+    }
+
+    /**
+     * A catalog reaches a sequence through {@code @SequenceGenerator(catalog)} or through a three-part
+     * {@code sequenceName}, neither of which surfaces on a table namespace, so this fires where
+     * {@link MongoAdditionalMappingContributor}'s equivalent check for tables cannot.
+     */
+    private static void forbidCatalog(QualifiedSequenceName name) {
+        var catalog = name.getCatalogName();
+        if (catalog != null) {
+            throw new FeatureNotSupportedException(format(
+                    "The sequence [%s] is qualified by the catalog [%s], which is not supported: a MongoDB database is"
+                            + " the analog of a SQL catalog. Note that a sequence name of the form [a.b.c] is read as"
+                            + " catalog [a], schema [b], sequence [c].",
+                    name, catalog.getText()));
+        }
+    }
+}

--- a/src/main/java/com/mongodb/hibernate/internal/boot/NameChecks.java
+++ b/src/main/java/com/mongodb/hibernate/internal/boot/NameChecks.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.hibernate.internal.boot;
+
+import static java.lang.String.format;
+
+import com.mongodb.hibernate.internal.FeatureNotSupportedException;
+
+final class NameChecks {
+
+    /**
+     * A schema folds into the name a collection or a sequence counter is stored under, as {@code schema.name}, so the
+     * '.' is the extension's own separator. A '.' written by the user makes the folded name ambiguous:
+     * {@code @Table(schema = "a", name = "b")} and {@code @Table(name = "a.b")} would resolve to the same collection,
+     * and nothing downstream could tell the two qualifiers apart.
+     */
+    static void forbidDot(String name, String kind) {
+        if (name.contains(".")) {
+            throw new FeatureNotSupportedException(format(
+                    "The character [.] in a %s name is not supported, but is present in [%s]. A schema folds into the"
+                            + " name as [schema.name], so a '.' written by the user would make the folded name"
+                            + " ambiguous.",
+                    kind, name));
+        }
+    }
+
+    private NameChecks() {}
+}

--- a/src/main/java/com/mongodb/hibernate/internal/dialect/MongoDialect.java
+++ b/src/main/java/com/mongodb/hibernate/internal/dialect/MongoDialect.java
@@ -16,7 +16,9 @@
 
 package com.mongodb.hibernate.internal.dialect;
 
+import static com.mongodb.hibernate.internal.MongoConstants.ID_FIELD_NAME;
 import static com.mongodb.hibernate.internal.MongoConstants.MONGO_DBMS_NAME;
+import static com.mongodb.hibernate.internal.MongoConstants.SEQUENCE_COLLECTION_NAME;
 import static com.mongodb.hibernate.internal.dialect.function.FunctionParameterDefinition.orMissing;
 import static com.mongodb.hibernate.internal.dialect.function.FunctionParameterDefinition.required;
 import static com.mongodb.hibernate.internal.dialect.function.MongoExpressionPositionalFunction.swap;
@@ -53,10 +55,13 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.util.Calendar;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Stream;
+import org.bson.BsonArray;
 import org.bson.BsonDocument;
+import org.bson.BsonInt32;
 import org.bson.BsonString;
 import org.hibernate.JDBCException;
 import org.hibernate.boot.Metadata;
@@ -67,6 +72,7 @@ import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.dialect.DatabaseVersion;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.dialect.aggregate.AggregateSupport;
+import org.hibernate.dialect.sequence.SequenceSupport;
 import org.hibernate.engine.jdbc.dialect.spi.DialectResolutionInfo;
 import org.hibernate.engine.jdbc.env.spi.NameQualifierSupport;
 import org.hibernate.engine.jdbc.mutation.JdbcValueBindings;
@@ -86,6 +92,7 @@ import org.hibernate.sql.model.MutationOperation;
 import org.hibernate.sql.model.ValuesAnalysis;
 import org.hibernate.sql.model.internal.OptionalTableUpdate;
 import org.hibernate.sql.model.jdbc.OptionalTableUpdateOperation;
+import org.hibernate.tool.schema.extract.spi.SequenceInformationExtractor;
 import org.hibernate.tool.schema.spi.Exporter;
 import org.hibernate.type.SqlTypes;
 import org.hibernate.type.StandardBasicTypes;
@@ -198,6 +205,29 @@ public sealed class MongoDialect extends Dialect permits TestMongoDialect {
     @Override
     public AggregateSupport getAggregateSupport() {
         return MongoAggregateSupport.INSTANCE;
+    }
+
+    @Override
+    public SequenceSupport getSequenceSupport() {
+        return MongoSequenceSupport.INSTANCE;
+    }
+
+    /**
+     * Projects only the two fields {@link MongoSequenceInformationExtractor} reads, out of every document in
+     * {@value MongoConstants#SEQUENCE_COLLECTION_NAME}.
+     */
+    @Override
+    public String getQuerySequencesString() {
+        var projectStage = new BsonDocument(ID_FIELD_NAME, new BsonInt32(1))
+                .append(MongoSequenceSupport.INCREMENT_FIELD_NAME, new BsonInt32(1));
+        return new BsonDocument("aggregate", new BsonString(SEQUENCE_COLLECTION_NAME))
+                .append("pipeline", new BsonArray(List.of(new BsonDocument("$project", projectStage))))
+                .toJson(MongoConstants.EXTENDED_JSON_WRITER_SETTINGS);
+    }
+
+    @Override
+    public SequenceInformationExtractor getSequenceInformationExtractor() {
+        return MongoSequenceInformationExtractor.INSTANCE;
     }
 
     @Override

--- a/src/main/java/com/mongodb/hibernate/internal/dialect/MongoSequenceInformationExtractor.java
+++ b/src/main/java/com/mongodb/hibernate/internal/dialect/MongoSequenceInformationExtractor.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2026-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.hibernate.internal.dialect;
+
+import static com.mongodb.hibernate.internal.MongoAssertions.assertNotNull;
+import static com.mongodb.hibernate.internal.MongoConstants.ID_FIELD_NAME;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import org.hibernate.boot.model.naming.Identifier;
+import org.hibernate.boot.model.relational.QualifiedSequenceName;
+import org.hibernate.tool.schema.extract.spi.ExtractionContext;
+import org.hibernate.tool.schema.extract.spi.SequenceInformation;
+import org.hibernate.tool.schema.extract.spi.SequenceInformationExtractor;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Reports the increment stored in each counter document, which is what lets Hibernate ORM's own check reject a mapping
+ * whose {@code allocationSize} disagrees with the counter it will allocate from. Without it that check has nothing to
+ * compare against and is skipped, and a disagreement corrupts identifiers instead of failing.
+ *
+ * <p>Only the sequence name and the increment are reported. The start, minimum and maximum values have no counterpart
+ * in a counter document, and nothing reads them.
+ *
+ * <p>A sequence declared with a schema qualifier is not covered, here or on any other dialect: the check requires the
+ * extracted schema to be the default one, and a qualified sequence's is not.
+ *
+ * @hidden
+ */
+@SuppressWarnings("MissingSummary")
+final class MongoSequenceInformationExtractor implements SequenceInformationExtractor {
+
+    static final MongoSequenceInformationExtractor INSTANCE = new MongoSequenceInformationExtractor();
+
+    private MongoSequenceInformationExtractor() {}
+
+    @Override
+    public Iterable<SequenceInformation> extractMetadata(ExtractionContext extractionContext) throws SQLException {
+        var query = assertNotNull(
+                extractionContext.getJdbcEnvironment().getDialect().getQuerySequencesString());
+        return extractionContext.getQueryResults(query, null, resultSet -> {
+            var nameColumn = resultSet.findColumn(ID_FIELD_NAME);
+            var incrementColumn = resultSet.findColumn(MongoSequenceSupport.INCREMENT_FIELD_NAME);
+            var sequences = new ArrayList<SequenceInformation>();
+            while (resultSet.next()) {
+                var name = assertNotNull(resultSet.getString(nameColumn));
+                sequences.add(new MongoSequenceInformation(
+                        new QualifiedSequenceName(null, null, Identifier.toIdentifier(name)),
+                        resultSet.getLong(incrementColumn)));
+            }
+            return sequences;
+        });
+    }
+
+    /** A counter document missing its increment reports zero, which disagrees with any allocation size. */
+    private record MongoSequenceInformation(QualifiedSequenceName name, long increment) implements SequenceInformation {
+
+        @Override
+        public QualifiedSequenceName getSequenceName() {
+            return name;
+        }
+
+        @Override
+        public @Nullable Number getStartValue() {
+            return null;
+        }
+
+        @Override
+        public @Nullable Number getMinValue() {
+            return null;
+        }
+
+        @Override
+        public @Nullable Number getMaxValue() {
+            return null;
+        }
+
+        @Override
+        public Number getIncrementValue() {
+            return increment;
+        }
+    }
+}

--- a/src/main/java/com/mongodb/hibernate/internal/dialect/MongoSequenceSupport.java
+++ b/src/main/java/com/mongodb/hibernate/internal/dialect/MongoSequenceSupport.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2026-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.hibernate.internal.dialect;
+
+import static com.mongodb.hibernate.internal.MongoConstants.EXTENDED_JSON_WRITER_SETTINGS;
+import static com.mongodb.hibernate.internal.MongoConstants.ID_FIELD_NAME;
+import static com.mongodb.hibernate.internal.MongoConstants.NON_TRANSACTIONAL_COMMAND_FIELD_NAME;
+import static com.mongodb.hibernate.internal.MongoConstants.SEQUENCE_COLLECTION_NAME;
+import static java.lang.String.format;
+
+import com.mongodb.hibernate.internal.FeatureNotSupportedException;
+import java.util.List;
+import org.bson.BsonArray;
+import org.bson.BsonBoolean;
+import org.bson.BsonDocument;
+import org.bson.BsonInt32;
+import org.bson.BsonInt64;
+import org.bson.BsonString;
+import org.hibernate.dialect.sequence.SequenceSupport;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Backs Hibernate ORM sequences with one document per sequence in the
+ * {@value com.mongodb.hibernate.internal.MongoConstants#SEQUENCE_COLLECTION_NAME} collection, keyed by sequence name.
+ *
+ * <p>The document holds the value the next allocation will hand out, so the seed and a restart store their target
+ * verbatim and only the allocation does arithmetic.
+ *
+ * <p>The increment is stored in the document because {@code SequenceStructure} only ever calls
+ * {@link #getSequenceNextValString(String)}, which has no increment parameter.
+ *
+ * @hidden
+ */
+@SuppressWarnings("MissingSummary")
+public final class MongoSequenceSupport implements SequenceSupport {
+
+    public static final MongoSequenceSupport INSTANCE = new MongoSequenceSupport();
+
+    private static final String NEXT_VALUE_FIELD_NAME = "next_value";
+
+    /** Package-private so {@link MongoSequenceInformationExtractor} can read the same column by name. */
+    static final String INCREMENT_FIELD_NAME = "increment";
+
+    private MongoSequenceSupport() {}
+
+    /**
+     * Returns the pre-image, which is the value being handed out, and narrows the reply to one field because
+     * {@code SequenceStructure} reads column 1 positionally.
+     *
+     * <p>Carries {@link com.mongodb.hibernate.internal.MongoConstants#NON_TRANSACTIONAL_COMMAND_FIELD_NAME} because a
+     * native SQL sequence advances outside the caller's transaction and {@code SequenceStructure} relies on that:
+     * joining the transaction would make concurrent allocations conflict and let a rollback rewind the counter.
+     */
+    @Override
+    public String getSequenceNextValString(String sequenceName) {
+        var addStoredIncrement = new BsonDocument(
+                "$add",
+                new BsonArray(List.of(
+                        new BsonString("$" + NEXT_VALUE_FIELD_NAME), new BsonString("$" + INCREMENT_FIELD_NAME))));
+        return new BsonDocument("findAndModify", new BsonString(SEQUENCE_COLLECTION_NAME))
+                .append("query", allocatableSequenceFilter(sequenceName))
+                .append(
+                        "update",
+                        new BsonArray(List.of(
+                                new BsonDocument("$set", new BsonDocument(NEXT_VALUE_FIELD_NAME, addStoredIncrement)))))
+                .append("new", BsonBoolean.FALSE)
+                .append(
+                        "fields",
+                        new BsonDocument(ID_FIELD_NAME, new BsonInt32(0))
+                                .append(NEXT_VALUE_FIELD_NAME, new BsonInt32(1)))
+                .append(NON_TRANSACTIONAL_COMMAND_FIELD_NAME, BsonBoolean.TRUE)
+                .toJson(EXTENDED_JSON_WRITER_SETTINGS);
+    }
+
+    @Override
+    public String[] getCreateSequenceStrings(
+            String sequenceName, int initialValue, int incrementSize, @Nullable String options) {
+        if (options != null && !options.isBlank()) {
+            throw new FeatureNotSupportedException(format(
+                    "Sequence [%s] declares options [%s], which are not supported: options are a SQL fragment and have"
+                            + " no MQL form.",
+                    sequenceName, options));
+        }
+        return new String[] {getCreateSequenceString(sequenceName, initialValue, incrementSize)};
+    }
+
+    @Override
+    public String getCreateSequenceString(String sequenceName, int initialValue, int incrementSize) {
+        return updateCommand(
+                sequenceName,
+                new BsonDocument(
+                        "$setOnInsert",
+                        new BsonDocument(NEXT_VALUE_FIELD_NAME, new BsonInt64(initialValue))
+                                .append(INCREMENT_FIELD_NAME, new BsonInt64(incrementSize))),
+                true);
+    }
+
+    @Override
+    public String getRestartSequenceString(String sequenceName, long startWith) {
+        return updateCommand(
+                sequenceName,
+                new BsonDocument("$set", new BsonDocument(NEXT_VALUE_FIELD_NAME, new BsonInt64(startWith))),
+                false);
+    }
+
+    @Override
+    public String getDropSequenceString(String sequenceName) {
+        return new BsonDocument("delete", new BsonString(SEQUENCE_COLLECTION_NAME))
+                .append(
+                        "deletes",
+                        new BsonArray(List.of(
+                                new BsonDocument("q", sequenceFilter(sequenceName)).append("limit", new BsonInt32(1)))))
+                .toJson(EXTENDED_JSON_WRITER_SETTINGS);
+    }
+
+    /** Its only caller is bulk insertion, {@code insert into ... select}. */
+    @Override
+    public String getSelectSequenceNextValString(String sequenceName) {
+        throw new FeatureNotSupportedException(format(
+                "Inline allocation from sequence [%s] is not supported: MQL cannot embed an allocation inside another"
+                        + " statement.",
+                sequenceName));
+    }
+
+    private static String updateCommand(String sequenceName, BsonDocument modification, boolean upsert) {
+        var statement = new BsonDocument("q", sequenceFilter(sequenceName)).append("u", modification);
+        if (upsert) {
+            statement.append("upsert", BsonBoolean.TRUE);
+        }
+        return new BsonDocument("update", new BsonString(SEQUENCE_COLLECTION_NAME))
+                .append("updates", new BsonArray(List.of(statement)))
+                .toJson(EXTENDED_JSON_WRITER_SETTINGS);
+    }
+
+    /**
+     * Matches the sequence document only when it carries both 64-bit fields the allocation needs, so a document that is
+     * missing one, or that stores it as a 32-bit integer, produces the same "matched no document" error a missing
+     * document does. Without this an absent {@value #INCREMENT_FIELD_NAME} would make {@code $add} evaluate to null,
+     * writing null into {@value #NEXT_VALUE_FIELD_NAME} and leaving the sequence handing out the same value forever.
+     *
+     * <p>Only the allocation filters on shape. The create and restart commands are upserts keyed on {@code _id}, and a
+     * shape predicate there would make a malformed document miss and be inserted again under the same {@code _id}.
+     */
+    private static BsonDocument allocatableSequenceFilter(String sequenceName) {
+        var int64 = new BsonDocument("$type", new BsonString("long"));
+        return sequenceFilter(sequenceName).append(NEXT_VALUE_FIELD_NAME, int64).append(INCREMENT_FIELD_NAME, int64);
+    }
+
+    private static BsonDocument sequenceFilter(String sequenceName) {
+        return new BsonDocument(ID_FIELD_NAME, new BsonString(sequenceName));
+    }
+}

--- a/src/main/java/com/mongodb/hibernate/internal/jdbc/MongoResultSet.java
+++ b/src/main/java/com/mongodb/hibernate/internal/jdbc/MongoResultSet.java
@@ -45,6 +45,7 @@ import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
 import java.time.Instant;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
 import org.bson.BsonDocument;
@@ -54,7 +55,9 @@ import org.jspecify.annotations.Nullable;
 
 final class MongoResultSet implements ResultSetAdapter {
 
-    private final MongoCursor<BsonDocument> mongoCursor;
+    private final Iterator<BsonDocument> documents;
+
+    private final Runnable closer;
 
     private final List<String> fieldNames;
 
@@ -64,17 +67,26 @@ final class MongoResultSet implements ResultSetAdapter {
 
     private boolean closed;
 
-    MongoResultSet(MongoCursor<BsonDocument> mongoCursor, List<String> fieldNames) {
+    static MongoResultSet forCursor(MongoCursor<BsonDocument> cursor, List<String> fieldNames) {
+        return new MongoResultSet(cursor, cursor::close, fieldNames);
+    }
+
+    static MongoResultSet forDocument(BsonDocument document, List<String> fieldNames) {
+        return new MongoResultSet(List.of(document).iterator(), () -> {}, fieldNames);
+    }
+
+    private MongoResultSet(Iterator<BsonDocument> documents, Runnable closer, List<String> fieldNames) {
         assertFalse(fieldNames.isEmpty());
-        this.mongoCursor = mongoCursor;
+        this.documents = documents;
+        this.closer = closer;
         this.fieldNames = fieldNames;
     }
 
     @Override
     public boolean next() throws SQLException {
         checkClosed();
-        if (mongoCursor.hasNext()) {
-            currentDocument = mongoCursor.next();
+        if (documents.hasNext()) {
+            currentDocument = documents.next();
             return true;
         } else {
             return false;
@@ -86,10 +98,9 @@ final class MongoResultSet implements ResultSetAdapter {
         if (!closed) {
             closed = true;
             try {
-                mongoCursor.close();
+                closer.run();
             } catch (RuntimeException e) {
-                throw new SQLException(
-                        format("Failed to close %s", mongoCursor.getClass().getSimpleName()), e);
+                throw new SQLException("Failed to close the result set", e);
             }
         }
     }

--- a/src/main/java/com/mongodb/hibernate/internal/jdbc/MongoStatement.java
+++ b/src/main/java/com/mongodb/hibernate/internal/jdbc/MongoStatement.java
@@ -22,7 +22,9 @@ import static com.mongodb.hibernate.internal.MongoAssertions.assertTrue;
 import static com.mongodb.hibernate.internal.MongoAssertions.fail;
 import static com.mongodb.hibernate.internal.MongoConstants.EXTENDED_JSON_WRITER_SETTINGS;
 import static com.mongodb.hibernate.internal.MongoConstants.ID_FIELD_NAME;
+import static com.mongodb.hibernate.internal.MongoConstants.NON_TRANSACTIONAL_COMMAND_FIELD_NAME;
 import static com.mongodb.hibernate.internal.VisibleForTesting.AccessModifier.PRIVATE;
+import static com.mongodb.hibernate.internal.jdbc.MongoStatement.CommandDescription.FIND_AND_MODIFY;
 import static java.lang.String.format;
 import static java.util.stream.Collectors.toCollection;
 import static org.bson.BsonBoolean.FALSE;
@@ -39,7 +41,9 @@ import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
 import com.mongodb.client.model.DeleteManyModel;
 import com.mongodb.client.model.DeleteOneModel;
+import com.mongodb.client.model.FindOneAndUpdateOptions;
 import com.mongodb.client.model.InsertOneModel;
+import com.mongodb.client.model.ReturnDocument;
 import com.mongodb.client.model.UpdateManyModel;
 import com.mongodb.client.model.UpdateOneModel;
 import com.mongodb.client.model.UpdateOptions;
@@ -76,8 +80,14 @@ class MongoStatement implements StatementAdapter {
     private static final String EXCEPTION_MESSAGE_OPERATION_FAILED = "Failed to execute operation";
     private static final String EXCEPTION_MESSAGE_OPERATION_TIMED_OUT =
             "Timeout while waiting for operation to complete";
+    private static final String UNSUPPORTED_MESSAGE_TEMPLATE_STATEMENT_FIELD =
+            "Unsupported field in [%s] statement: [%s]";
+    private static final String UNSUPPORTED_MESSAGE_TEMPLATE_COMMAND_FIELD = "Unsupported field in [%s] command: [%s]";
     static final int NO_ERROR_CODE = 0;
     static final int[] EMPTY_UPDATE_COUNTS = new int[0];
+
+    private static final Set<String> SUPPORTED_FIND_AND_MODIFY_COMMAND_FIELDS =
+            Set.of("query", "update", "new", "fields", NON_TRANSACTIONAL_COMMAND_FIELD_NAME);
 
     static final @Nullable String NULL_SQL_STATE = null;
 
@@ -110,8 +120,17 @@ class MongoStatement implements StatementAdapter {
     }
 
     ResultSet executeQuery(BsonDocument command) throws SQLException {
+        var commandDescription = getCommandDescription(command);
+        return switch (commandDescription) {
+            case AGGREGATE -> executeAggregate(command, commandDescription);
+            case FIND_AND_MODIFY -> executeFindAndModify(command);
+            default -> throw fail(commandDescription.toString());
+        };
+    }
+
+    private ResultSet executeAggregate(BsonDocument command, CommandDescription commandDescription)
+            throws SQLException {
         try {
-            var commandDescription = getCommandDescription(command);
             var collection = getCollection(commandDescription, command);
             var pipeline = command.getArray("pipeline").stream()
                     .map(BsonValue::asDocument)
@@ -129,8 +148,42 @@ class MongoStatement implements StatementAdapter {
             }
             var fieldNames = getFieldNamesFromProjectStage(projectStage);
             startTransactionIfNeeded();
-            return resultSet = new MongoResultSet(
+            return resultSet = MongoResultSet.forCursor(
                     collection.aggregate(clientSession, pipeline).cursor(), fieldNames);
+        } catch (BSONException bsonException) {
+            throw createSyntaxErrorException("%s: [%s]", command, bsonException);
+        } catch (RuntimeException exception) {
+            throw handleExecuteQueryOrUpdateException(exception);
+        }
+    }
+
+    private ResultSet executeFindAndModify(BsonDocument command) throws SQLException {
+        try {
+            checkCommandFields(command, FIND_AND_MODIFY, SUPPORTED_FIND_AND_MODIFY_COMMAND_FIELDS);
+            if (!command.getBoolean(NON_TRANSACTIONAL_COMMAND_FIELD_NAME, FALSE).getValue()) {
+                throw new SQLFeatureNotSupportedException(format(
+                        "[%s] is supported only with [%s: true]: it exists to allocate sequence values, which must not"
+                                + " join the caller's transaction",
+                        FIND_AND_MODIFY.getCommandName(), NON_TRANSACTIONAL_COMMAND_FIELD_NAME));
+            }
+            var collection = getCollection(FIND_AND_MODIFY, command);
+            var filter = command.getDocument("query");
+            var projection = command.getDocument("fields");
+            var update = command.getArray("update").stream()
+                    .map(BsonValue::asDocument)
+                    .toList();
+            var options = new FindOneAndUpdateOptions()
+                    .projection(projection)
+                    .returnDocument(
+                            command.getBoolean("new", FALSE).getValue() ? ReturnDocument.AFTER : ReturnDocument.BEFORE);
+            var fieldNames = getFieldNamesFromProjectStage(projection);
+            var document = collection.findOneAndUpdate(filter, update, options);
+            if (document == null) {
+                throw new SQLException(format(
+                        "[%s] matched no document: [%s]",
+                        FIND_AND_MODIFY.getCommandName(), command.toJson(EXTENDED_JSON_WRITER_SETTINGS)));
+            }
+            return resultSet = MongoResultSet.forDocument(document, fieldNames);
         } catch (BSONException bsonException) {
             throw createSyntaxErrorException("%s: [%s]", command, bsonException);
         } catch (RuntimeException exception) {
@@ -249,13 +302,19 @@ class MongoStatement implements StatementAdapter {
     public boolean execute(String mql) throws SQLException {
         checkClosed();
         closeLastOpenResultSet();
-        var command = AdminCommand.toAdminCommand(mql);
-        try {
-            command.execute(mongoDatabase);
-            return false;
-        } catch (RuntimeException exception) {
-            throw handleExecuteQueryOrUpdateException(exception);
+        var parsedCommand = parse(mql);
+        var commandDescription = CommandDescription.find(getCommandName(parsedCommand));
+        if (commandDescription != null && commandDescription.isUpdate()) {
+            executeUpdate(parsedCommand);
+        } else {
+            var command = AdminCommand.toAdminCommand(mql);
+            try {
+                command.execute(mongoDatabase);
+            } catch (RuntimeException exception) {
+                throw handleExecuteQueryOrUpdateException(exception);
+            }
         }
+        return false;
     }
 
     @Override
@@ -317,6 +376,39 @@ class MongoStatement implements StatementAdapter {
         }
     }
 
+    private static void checkStatementFields(
+            BsonDocument statement, CommandDescription commandDescription, Set<String> supportedStatementFields)
+            throws SQLFeatureNotSupportedException {
+        checkFields(
+                commandDescription,
+                UNSUPPORTED_MESSAGE_TEMPLATE_STATEMENT_FIELD,
+                supportedStatementFields,
+                statement.keySet().iterator());
+    }
+
+    private static void checkCommandFields(
+            BsonDocument command, CommandDescription commandDescription, Set<String> supportedCommandFields)
+            throws SQLFeatureNotSupportedException {
+        var iterator = command.keySet().iterator();
+        iterator.next(); // skip the command name
+        checkFields(commandDescription, UNSUPPORTED_MESSAGE_TEMPLATE_COMMAND_FIELD, supportedCommandFields, iterator);
+    }
+
+    private static void checkFields(
+            CommandDescription commandDescription,
+            String exceptionMessageTemplate,
+            Set<String> supportedCommandFields,
+            Iterator<String> fieldNameIterator)
+            throws SQLFeatureNotSupportedException {
+        while (fieldNameIterator.hasNext()) {
+            var field = fieldNameIterator.next();
+            if (!supportedCommandFields.contains(field)) {
+                throw new SQLFeatureNotSupportedException(
+                        exceptionMessageTemplate.formatted(commandDescription.getCommandName(), field));
+            }
+        }
+    }
+
     static BsonDocument parse(String mql) throws SQLSyntaxErrorException {
         try {
             return BsonDocument.parse(mql);
@@ -335,16 +427,18 @@ class MongoStatement implements StatementAdapter {
         }
     }
 
-    /** The first key is always the command name, e.g. "insert", "update", "delete". */
-    static CommandDescription getCommandDescription(BsonDocument command)
-            throws SQLFeatureNotSupportedException, SQLSyntaxErrorException {
-        String commandName;
+    private static String getCommandName(BsonDocument command) throws SQLSyntaxErrorException {
         try {
-            commandName = command.getFirstKey();
+            return command.getFirstKey();
         } catch (NoSuchElementException exception) {
             throw createSyntaxErrorException("%s. Command name is missing: [%s]", command, exception);
         }
-        return CommandDescription.of(commandName);
+    }
+
+    /** The first key is always the command name, e.g. "insert", "update", "delete". */
+    static CommandDescription getCommandDescription(BsonDocument command)
+            throws SQLFeatureNotSupportedException, SQLSyntaxErrorException {
+        return CommandDescription.of(getCommandName(command));
     }
 
     private MongoCollection<BsonDocument> getCollection(CommandDescription commandDescription, BsonDocument command)
@@ -477,7 +571,14 @@ class MongoStatement implements StatementAdapter {
         /** See <a href="https://www.mongodb.com/docs/manual/reference/command/delete/">{@code delete}</a>. */
         DELETE("delete", false, true),
         /** See <a href="https://www.mongodb.com/docs/manual/reference/command/aggregate/">{@code aggregate}</a>. */
-        AGGREGATE("aggregate", true, false);
+        AGGREGATE("aggregate", true, false),
+        /**
+         * See <a href="https://www.mongodb.com/docs/manual/reference/command/findAndModify/">{@code findAndModify}</a>.
+         *
+         * <p>A write that Hibernate ORM submits through {@code executeQuery}, because that is how it reads an allocated
+         * sequence value. The flags below say which JDBC method may carry a command, not whether it mutates.
+         */
+        FIND_AND_MODIFY("findAndModify", true, false);
 
         private final String commandName;
         private final boolean isQuery;
@@ -512,22 +613,26 @@ class MongoStatement implements StatementAdapter {
         }
 
         static CommandDescription of(String commandName) throws SQLFeatureNotSupportedException {
+            var commandDescription = find(commandName);
+            if (commandDescription == null) {
+                throw new SQLFeatureNotSupportedException("Unsupported command: %s".formatted(commandName));
+            }
+            return commandDescription;
+        }
+
+        static @Nullable CommandDescription find(String commandName) {
             return switch (commandName) {
                 case "insert" -> INSERT;
                 case "update" -> UPDATE;
                 case "delete" -> DELETE;
                 case "aggregate" -> AGGREGATE;
-                default -> throw new SQLFeatureNotSupportedException("Unsupported command: %s".formatted(commandName));
+                case "findAndModify" -> FIND_AND_MODIFY;
+                default -> null;
             };
         }
     }
 
     private static class WriteModelConverter {
-        private static final String UNSUPPORTED_MESSAGE_TEMPLATE_STATEMENT_FIELD =
-                "Unsupported field in [%s] statement: [%s]";
-        private static final String UNSUPPORTED_MESSAGE_TEMPLATE_COMMAND_FIELD =
-                "Unsupported field in [%s] command: [%s]";
-
         private static final Set<String> SUPPORTED_INSERT_COMMAND_FIELDS = Set.of("documents");
 
         private static final Set<String> SUPPORTED_UPDATE_COMMAND_FIELDS = Set.of("updates");
@@ -617,40 +722,6 @@ class MongoStatement implements StatementAdapter {
                 return new DeleteOneModel<>(filter);
             }
             return new DeleteManyModel<>(filter);
-        }
-
-        private static void checkStatementFields(
-                BsonDocument statement, CommandDescription commandDescription, Set<String> supportedStatementFields)
-                throws SQLFeatureNotSupportedException {
-            checkFields(
-                    commandDescription,
-                    UNSUPPORTED_MESSAGE_TEMPLATE_STATEMENT_FIELD,
-                    supportedStatementFields,
-                    statement.keySet().iterator());
-        }
-
-        private static void checkCommandFields(
-                BsonDocument command, CommandDescription commandDescription, Set<String> supportedCommandFields)
-                throws SQLFeatureNotSupportedException {
-            var iterator = command.keySet().iterator();
-            iterator.next(); // skip the command name
-            checkFields(
-                    commandDescription, UNSUPPORTED_MESSAGE_TEMPLATE_COMMAND_FIELD, supportedCommandFields, iterator);
-        }
-
-        private static void checkFields(
-                CommandDescription commandDescription,
-                String exceptionMessageTemplate,
-                Set<String> supportedCommandFields,
-                Iterator<String> fieldNameIterator)
-                throws SQLFeatureNotSupportedException {
-            while (fieldNameIterator.hasNext()) {
-                var field = fieldNameIterator.next();
-                if (!supportedCommandFields.contains(field)) {
-                    throw new SQLFeatureNotSupportedException(
-                            exceptionMessageTemplate.formatted(commandDescription.getCommandName(), field));
-                }
-            }
         }
     }
 

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -15,10 +15,12 @@
  */
 
 import com.mongodb.hibernate.internal.boot.MongoAdditionalMappingContributor;
+import com.mongodb.hibernate.internal.boot.MongoSequenceIntegrator;
 import com.mongodb.hibernate.internal.service.MongoNamedStrategyContributor;
 import com.mongodb.hibernate.internal.service.StandardServiceRegistryScopedState;
 import org.hibernate.boot.registry.selector.spi.NamedStrategyContributor;
 import org.hibernate.boot.spi.AdditionalMappingContributor;
+import org.hibernate.integrator.spi.Integrator;
 import org.hibernate.service.spi.ServiceContributor;
 
 /**
@@ -136,6 +138,8 @@ module com.mongodb.hibernate {
             MongoNamedStrategyContributor;
     provides AdditionalMappingContributor with
             MongoAdditionalMappingContributor;
+    provides Integrator with
+            MongoSequenceIntegrator;
 
     opens com.mongodb.hibernate.internal.dialect to
             org.hibernate.orm.core;

--- a/src/main/resources/META-INF/services/org.hibernate.integrator.spi.Integrator
+++ b/src/main/resources/META-INF/services/org.hibernate.integrator.spi.Integrator
@@ -1,0 +1,4 @@
+# Hibernate ORM runs integrators for any `org.hibernate.SessionFactory`/`jakarta.persistence.EntityManagerFactory`
+# that is being bootstrapped. Consequently, this integrator must check that the involved dialect is an instance of
+# `MongoDialect`, to avoid interfering with bootstrapping unrelated to the MongoDB Extension for Hibernate ORM.
+com.mongodb.hibernate.internal.boot.MongoSequenceIntegrator

--- a/src/test/java/com/mongodb/hibernate/internal/dialect/MongoSequenceSupportTests.java
+++ b/src/test/java/com/mongodb/hibernate/internal/dialect/MongoSequenceSupportTests.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2026-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.hibernate.internal.dialect;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.mongodb.hibernate.internal.FeatureNotSupportedException;
+import org.bson.BsonDocument;
+import org.junit.jupiter.api.Test;
+
+class MongoSequenceSupportTests {
+
+    private final MongoSequenceSupport sequenceSupport = MongoSequenceSupport.INSTANCE;
+
+    @Test
+    void supportsPooledSequences() {
+        assertAll(
+                () -> assertThat(sequenceSupport.supportsSequences()).isTrue(),
+                () -> assertThat(sequenceSupport.supportsPooledSequences()).isTrue());
+    }
+
+    @Test
+    void nextValueAddsStoredIncrementAndReturnsPreImage() {
+        assertThat(BsonDocument.parse(sequenceSupport.getSequenceNextValString("books_SEQ")))
+                .isEqualTo(
+                        BsonDocument.parse(
+                                """
+                                {
+                                  "findAndModify": "hibernate_sequences",
+                                  "query": {
+                                    "_id": "books_SEQ",
+                                    "next_value": {"$type": "long"},
+                                    "increment": {"$type": "long"}
+                                  },
+                                  "update": [
+                                    {"$set": {"next_value": {"$add": ["$next_value", "$increment"]}}}
+                                  ],
+                                  "new": false,
+                                  "fields": {"_id": {"$numberInt": "0"}, "next_value": {"$numberInt": "1"}},
+                                  "nonTransactional": true
+                                }"""));
+    }
+
+    @Test
+    void createSeedsIdempotentlyWithInitialValueAndIncrement() {
+        assertThat(onlyCommand(sequenceSupport.getCreateSequenceStrings("books_SEQ", 1, 50, null)))
+                .isEqualTo(
+                        BsonDocument.parse(
+                                """
+                                {
+                                  "update": "hibernate_sequences",
+                                  "updates": [
+                                    {
+                                      "q": {"_id": "books_SEQ"},
+                                      "u": {
+                                        "$setOnInsert": {
+                                          "next_value": {"$numberLong": "1"},
+                                          "increment": {"$numberLong": "50"}
+                                        }
+                                      },
+                                      "upsert": true
+                                    }
+                                  ]
+                                }"""));
+    }
+
+    @Test
+    void restartSetsNextValueDirectly() {
+        assertThat(BsonDocument.parse(sequenceSupport.getRestartSequenceString("books_SEQ", 500)))
+                .isEqualTo(
+                        BsonDocument.parse(
+                                """
+                                {
+                                  "update": "hibernate_sequences",
+                                  "updates": [
+                                    {
+                                      "q": {"_id": "books_SEQ"},
+                                      "u": {"$set": {"next_value": {"$numberLong": "500"}}}
+                                    }
+                                  ]
+                                }"""));
+    }
+
+    @Test
+    void dropRemovesOnlyTheSequenceDocument() {
+        assertThat(onlyCommand(sequenceSupport.getDropSequenceStrings("books_SEQ")))
+                .isEqualTo(
+                        BsonDocument.parse(
+                                """
+                                {
+                                  "delete": "hibernate_sequences",
+                                  "deletes": [
+                                    {"q": {"_id": "books_SEQ"}, "limit": {"$numberInt": "1"}}
+                                  ]
+                                }"""));
+    }
+
+    @Test
+    void negativeIncrementIsStoredAsGiven() {
+        assertThat(onlyCommand(sequenceSupport.getCreateSequenceStrings("countdown_SEQ", 100, -5, null)))
+                .isEqualTo(
+                        BsonDocument.parse(
+                                """
+                                {
+                                  "update": "hibernate_sequences",
+                                  "updates": [
+                                    {
+                                      "q": {"_id": "countdown_SEQ"},
+                                      "u": {
+                                        "$setOnInsert": {
+                                          "next_value": {"$numberLong": "100"},
+                                          "increment": {"$numberLong": "-5"}
+                                        }
+                                      },
+                                      "upsert": true
+                                    }
+                                  ]
+                                }"""));
+    }
+
+    @Test
+    void inlineAllocationIsRejected() {
+        assertThatThrownBy(() -> sequenceSupport.getSelectSequenceNextValString("books_SEQ"))
+                .isInstanceOf(FeatureNotSupportedException.class)
+                .hasMessageContaining("books_SEQ")
+                .hasMessageContaining("cannot embed an allocation");
+    }
+
+    @Test
+    void sequenceOptionsAreRejected() {
+        assertThatThrownBy(() -> sequenceSupport.getCreateSequenceStrings("books_SEQ", 1, 50, "cache 20"))
+                .isInstanceOf(FeatureNotSupportedException.class)
+                .hasMessageContaining("cache 20");
+    }
+
+    @Test
+    void blankSequenceOptionsAreIgnored() {
+        assertThat(sequenceSupport.getCreateSequenceStrings("books_SEQ", 1, 50, "  "))
+                .isEqualTo(sequenceSupport.getCreateSequenceStrings("books_SEQ", 1, 50, null));
+    }
+
+    /** Hibernate ORM's multi-command forms; this dialect never needs more than one command for either. */
+    private static BsonDocument onlyCommand(String[] commands) {
+        assertThat(commands).hasSize(1);
+        return BsonDocument.parse(commands[0]);
+    }
+}

--- a/src/test/java/com/mongodb/hibernate/internal/jdbc/MongoResultSetTests.java
+++ b/src/test/java/com/mongodb/hibernate/internal/jdbc/MongoResultSetTests.java
@@ -67,7 +67,7 @@ class MongoResultSetTests {
 
     @BeforeEach
     void beforeEach() {
-        mongoResultSet = new MongoResultSet(mongoCursor, FIELDS);
+        mongoResultSet = MongoResultSet.forCursor(mongoCursor, FIELDS);
     }
 
     @Test
@@ -94,7 +94,7 @@ class MongoResultSetTests {
 
             doReturn(true).when(mongoCursor).hasNext();
             doReturn(bsonDocument).when(mongoCursor).next();
-            mongoResultSet = new MongoResultSet(mongoCursor, singletonList("field"));
+            mongoResultSet = MongoResultSet.forCursor(mongoCursor, singletonList("field"));
             assertTrue(mongoResultSet.next());
         }
 

--- a/src/test/java/com/mongodb/hibernate/internal/jdbc/MongoStatementTests.java
+++ b/src/test/java/com/mongodb/hibernate/internal/jdbc/MongoStatementTests.java
@@ -18,6 +18,8 @@ package com.mongodb.hibernate.internal.jdbc;
 
 import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -185,8 +187,13 @@ class MongoStatementTests {
 
         @Test
         void testExecute() throws SQLException {
-            assertThrows(SQLFeatureNotSupportedException.class, () -> mongoStatement.execute(EXAMPLE_UPDATE_MQL));
+            doReturn(BulkWriteResult.acknowledged(0, 1, 0, 0, emptyList(), emptyList()))
+                    .when(mongoCollection)
+                    .bulkWrite(eq(clientSession), anyList());
+
+            mongoStatement.execute(EXAMPLE_UPDATE_MQL);
             assertTrue(lastOpenResultSet.isClosed());
+            verify(mongoCollection).bulkWrite(eq(clientSession), anyList());
         }
     }
 
@@ -218,6 +225,75 @@ class MongoStatementTests {
                 () -> failureAsserter.accept(
                         "{title: ['array literal']}", "Unsupported value in '$project' specification"),
                 () -> successAsserter.accept("{title: {fieldName: 'document literal'}}", List.of("title")));
+    }
+
+    @Test
+    void findAndModifyIsRejectedByExecuteUpdate() {
+        var command = BsonDocument.parse(
+                """
+                {
+                  "findAndModify": "hibernate_sequences",
+                  "query": {"_id": "books_SEQ"}
+                }""");
+        assertThatThrownBy(() -> MongoStatement.checkSupportedUpdateCommand(command))
+                .isInstanceOf(SQLFeatureNotSupportedException.class)
+                .hasMessage("Unsupported command for executeUpdate: findAndModify");
+    }
+
+    /**
+     * {@code findAndModify} exists in the adapter to allocate sequence values, which must not join the caller's
+     * transaction, so a command that does not opt out is refused rather than run transactionally. The refusal precedes
+     * any collection access, which is why this needs no stubbing.
+     */
+    @Test
+    void findAndModifyWithoutOptingOutOfTheTransactionIsRejected() {
+        var command = BsonDocument.parse(
+                """
+                {
+                  "findAndModify": "hibernate_sequences",
+                  "query": {"_id": "books_SEQ"},
+                  "update": [{"$set": {"next_value": {"$add": ["$next_value", 1]}}}],
+                  "new": false,
+                  "fields": {"_id": 0, "next_value": 1}
+                }""");
+        assertThatThrownBy(() -> mongoStatement.executeQuery(command))
+                .isInstanceOf(SQLFeatureNotSupportedException.class)
+                .hasMessageContaining("nonTransactional");
+    }
+
+    @Test
+    void findAndModifyIsAcceptedByExecuteQuery() {
+        var command = BsonDocument.parse(
+                """
+                {
+                  "findAndModify": "hibernate_sequences",
+                  "query": {"_id": "books_SEQ"}
+                }""");
+        assertThatCode(() -> MongoStatement.checkSupportedQueryCommand(command)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void executeRoutesWriteCommandsAwayFromAdminCommands() throws SQLException {
+        var seed =
+                """
+                {
+                  "update": "hibernate_sequences",
+                  "updates": [
+                    {
+                      "q": {"_id": "books_SEQ"},
+                      "u": {"$setOnInsert": {"next_value": {"$numberLong": "1"}}},
+                      "upsert": true
+                    }
+                  ]
+                }""";
+        doReturn(mongoCollection).when(mongoDatabase).getCollection(anyString(), eq(BsonDocument.class));
+        doReturn(BulkWriteResult.acknowledged(0, 0, 0, 0, emptyList(), emptyList()))
+                .when(mongoCollection)
+                .bulkWrite(eq(clientSession), anyList());
+
+        mongoStatement.execute(seed);
+
+        verify(mongoCollection).bulkWrite(eq(clientSession), anyList());
     }
 
     @Nested


### PR DESCRIPTION
Back @GeneratedValue with a MongoDB counter collection. MongoSequenceSupport generates the four commands Hibernate ORM's SequenceStyleGenerator asks a dialect for, and MongoStatement runs the allocation as a findAndModify whose $setOnInsert seeds the counter and whose pipeline update advances it by the increment.

Counters live in one document per sequence in hibernate_sequences, keyed by the sequence's formatted name:

  {"_id": "<schema.>name", "next_value": <int64>, "increment": <int64>}

Allocation deliberately does not join the caller's transaction. Sharing the session would make two concurrent allocations conflict, and a rollback would rewind the counter and hand the same identifier out twice.

Because a counter document is ordinary data that a deployment running without schema management may create by hand, the shape above is enforced rather than assumed. An allocation filter requires next_value and increment to be int64, so a malformed or partial document fails loudly instead of silently returning the same identifier forever. MongoSequenceInformationExtractor reports each counter's increment, which is what lets Hibernate ORM reject a mapping whose allocationSize disagrees with the counter it would allocate from.

Sequence qualifiers follow the rules tables already follow. A catalog is rejected, reaching a sequence either through @SequenceGenerator(catalog) or through a three-part sequenceName that Hibernate ORM reads as catalog, schema, sequence. A '.' in a sequence schema or name is rejected, which makes the counter key unambiguous: two sequences can no longer format alike and share one counter. These checks live in an Integrator because sequences are registered after AdditionalMappingContributor runs.

Rejected at boot, each with a message naming the alternative: IDENTITY, TABLE and UUID generation, BigInteger identifiers, generators that cannot be introspected, sequence options, and an entity mapped onto hibernate_sequences.