### PR TITLE
HIBERNATE-239

### DIFF
--- a/src/integrationTest/java/com/mongodb/hibernate/query/select/ExpressionIntegrationTests.java
+++ b/src/integrationTest/java/com/mongodb/hibernate/query/select/ExpressionIntegrationTests.java
@@ -1017,15 +1017,6 @@ class ExpressionIntegrationTests extends AbstractQueryIntegrationTests {
         }
 
         @Test
-        void testCaseInGroupByIsUnsupported() {
-            assertSelectQueryFailure(
-                    "select count(id) from Item group by case when y > 5 then 1 else 0 end",
-                    Long.class,
-                    FeatureNotSupportedException.class,
-                    "TODO-HIBERNATE-196");
-        }
-
-        @Test
         void testCaseAsInListTestExpressionIsUnsupported() {
             assertSelectQueryFailure(
                     "from Item where (case when y > 5 then 1 else 0 end) in (1, 2)",

--- a/src/integrationTest/java/com/mongodb/hibernate/query/select/GroupByHavingIntegrationTests.java
+++ b/src/integrationTest/java/com/mongodb/hibernate/query/select/GroupByHavingIntegrationTests.java
@@ -1541,6 +1541,108 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
         }
 
         @Test
+        void orderByAggregateAlias() {
+            assertSelectionQuery(
+                    "select b.string, sum(b.primitiveInt) as total from Item as b GROUP BY b.string"
+                            + " ORDER BY total DESC, b.string",
+                    Object[].class,
+                    """
+                    {
+                      "aggregate": "Item",
+                      "pipeline": [
+                        {
+                          "$group": {
+                            "_id": {"string": "$string"},
+                            "#acc_0": {"$sum": {"$toLong": "$primitiveInt"}}
+                          }
+                        },
+                        {"$sort": {"#acc_0": -1, "_id.string": 1}},
+                        {"$project": {"_id#string": "$_id.string", "total": "$#acc_0", "_id": 0}}
+                      ]
+                    }
+                    """,
+                    results -> assertThat((Iterable<Object[]>) results)
+                            .containsExactly(new Object[] {"c", 7L}, new Object[] {"a", 4L}, new Object[] {"b", 4L}),
+                    Set.of(COLLECTION_NAME));
+        }
+
+        @Test
+        void orderByAggregateOrdinal() {
+            assertSelectionQuery(
+                    "select b.string, sum(b.primitiveInt) from Item as b GROUP BY b.string ORDER BY 2 DESC, 1",
+                    Object[].class,
+                    """
+                    {
+                      "aggregate": "Item",
+                      "pipeline": [
+                        {
+                          "$group": {
+                            "_id": {"string": "$string"},
+                            "#acc_0": {"$sum": {"$toLong": "$primitiveInt"}}
+                          }
+                        },
+                        {"$sort": {"#acc_0": -1, "_id.string": 1}},
+                        {"$project": {"_id#string": "$_id.string", "#c_2": "$#acc_0", "_id": 0}}
+                      ]
+                    }
+                    """,
+                    results -> assertThat((Iterable<Object[]>) results)
+                            .containsExactly(new Object[] {"c", 7L}, new Object[] {"a", 4L}, new Object[] {"b", 4L}),
+                    Set.of(COLLECTION_NAME));
+        }
+
+        /**
+         * An alias naming an aggregate that is already in SELECT must resolve to the accumulator SELECT registered, not
+         * add a second one.
+         */
+        @Test
+        void orderByAggregateAliasSharesTheSelectAccumulator() {
+            assertSelectionQuery(
+                    "select b.string, sum(b.primitiveInt) as total from Item as b GROUP BY b.string"
+                            + " HAVING sum(b.primitiveInt) > 4 ORDER BY total",
+                    Object[].class,
+                    """
+                    {
+                      "aggregate": "Item",
+                      "pipeline": [
+                        {
+                          "$group": {
+                            "_id": {"string": "$string"},
+                            "#acc_0": {"$sum": {"$toLong": "$primitiveInt"}}
+                          }
+                        },
+                        {"$match": {"#acc_0": {"$gt": 4}}},
+                        {"$sort": {"#acc_0": 1}},
+                        {"$project": {"_id#string": "$_id.string", "total": "$#acc_0", "_id": 0}}
+                      ]
+                    }
+                    """,
+                    results -> assertThat((Iterable<Object[]>) results).containsExactly(new Object[] {"c", 7L}),
+                    Set.of(COLLECTION_NAME));
+        }
+
+        /**
+         * Ordering by an expression is unsupported however it is named, but it must now fail with a ticket rather than
+         * with the message-less exception an unresolved alias used to produce.
+         */
+        @ParameterizedTest(name = "[{index}] {0}")
+        @MethodSource("orderByExpressionQueries")
+        void orderByExpressionIsRejected(String hql) {
+            assertSelectQueryFailure(hql, Object[].class, FeatureNotSupportedException.class, "TODO-HIBERNATE-251");
+        }
+
+        static Stream<String> orderByExpressionQueries() {
+            return Stream.of(
+                    // written out
+                    "select b.string, avg(b.primitiveInt) from Item as b GROUP BY b.string"
+                            + " ORDER BY avg(b.primitiveInt) + 1",
+                    // by alias
+                    "select b.string, avg(b.primitiveInt) + 1 as a from Item as b GROUP BY b.string ORDER BY a",
+                    // by ordinal
+                    "select b.string, avg(b.primitiveInt) + 1 from Item as b GROUP BY b.string ORDER BY 2");
+        }
+
+        @Test
         void aggregateWithoutGroupByIsRejected() {
             assertThatThrownBy(() -> getSessionFactoryScope().inTransaction(session -> session.createSelectionQuery(
                                     "select sum(b.primitiveInt) from Item as b", Object.class)
@@ -1576,6 +1678,109 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                                     Object[].class)
                             .getResultList()))
                     .isInstanceOf(FeatureNotSupportedException.class);
+        }
+    }
+
+    /**
+     * SQL's {@code COUNT(x)} counts only the rows where {@code x} is not null, which is the whole reason the translator
+     * emits a {@code $switch} rather than a bare {@code $sum: 1}. The shared dataset has no nulls, so this nest brings
+     * its own.
+     */
+    @Nested
+    @DomainModel(annotatedClasses = {Item.class})
+    class CountNullSemantics extends AbstractQueryIntegrationTests {
+
+        @BeforeEach
+        void beforeEach() {
+            getSessionFactoryScope().inTransaction(session -> {
+                session.createMutationQuery("delete from Item").executeUpdate();
+                List.of(
+                                // primitiveInt 1: two non-null strings and one null
+                                new Item(1, 1, "x", true, new ItemStruct(1)),
+                                new Item(2, 1, null, true, new ItemStruct(1)),
+                                new Item(3, 1, "y", true, new ItemStruct(1)),
+                                // primitiveInt 2: every string null, so count(string) must be 0 while count(*) is 2
+                                new Item(4, 2, null, false, new ItemStruct(2)),
+                                new Item(5, 2, null, false, new ItemStruct(2)))
+                        .forEach(session::persist);
+            });
+        }
+
+        @Test
+        void countOfNullableColumnExcludesNulls() {
+            assertSelectionQuery(
+                    "select b.primitiveInt, count(*), count(b.string) from Item as b"
+                            + " GROUP BY b.primitiveInt ORDER BY b.primitiveInt",
+                    Object[].class,
+                    """
+                    {
+                      "aggregate": "Item",
+                      "pipeline": [
+                        {
+                          "$group": {
+                            "_id": {"primitiveInt": "$primitiveInt"},
+                            "#acc_0": {"$sum": {"$toLong": 1}},
+                            "#acc_1": {
+                              "$sum": {
+                                "$toLong": {
+                                  "$switch": {
+                                    "branches": [{"case": {"$eq": ["$string", null]}, "then": 0}],
+                                    "default": 1
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        {"$sort": {"_id.primitiveInt": 1}},
+                        {
+                          "$project": {
+                            "_id#primitiveInt": "$_id.primitiveInt",
+                            "#c_2": "$#acc_0",
+                            "#c_3": "$#acc_1",
+                            "_id": 0
+                          }
+                        }
+                      ]
+                    }
+                    """,
+                    results -> assertThat((Iterable<Object[]>) results)
+                            .containsExactly(new Object[] {1, 3L, 2L}, new Object[] {2, 2L, 0L}),
+                    Set.of(COLLECTION_NAME));
+        }
+
+        /** A HAVING on a non-null count filters on the counted rows, not on the group size. */
+        @Test
+        void havingOnCountOfNullableColumn() {
+            assertSelectionQuery(
+                    "select b.primitiveInt from Item as b GROUP BY b.primitiveInt HAVING count(b.string) > 0",
+                    Object.class,
+                    """
+                    {
+                      "aggregate": "Item",
+                      "pipeline": [
+                        {
+                          "$group": {
+                            "_id": {"primitiveInt": "$primitiveInt"},
+                            "#acc_0": {
+                              "$sum": {
+                                "$toLong": {
+                                  "$switch": {
+                                    "branches": [{"case": {"$eq": ["$string", null]}, "then": 0}],
+                                    "default": 1
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        {"$match": {"#acc_0": {"$gt": 0}}},
+                        {"$project": {"_id#primitiveInt": "$_id.primitiveInt", "_id": 0}}
+                      ]
+                    }
+                    """,
+                    List.of(1),
+                    Set.of(COLLECTION_NAME));
         }
     }
 

--- a/src/integrationTest/java/com/mongodb/hibernate/query/select/GroupByHavingIntegrationTests.java
+++ b/src/integrationTest/java/com/mongodb/hibernate/query/select/GroupByHavingIntegrationTests.java
@@ -25,6 +25,7 @@ import com.mongodb.hibernate.internal.FeatureNotSupportedException;
 import com.mongodb.hibernate.junit.InjectMongoCollection;
 import com.mongodb.hibernate.junit.MongoExtension;
 import com.mongodb.hibernate.query.AbstractQueryIntegrationTests;
+import com.mongodb.hibernate.query.Book;
 import jakarta.persistence.Embeddable;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
@@ -32,6 +33,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
@@ -647,15 +649,8 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                     {
                       "aggregate": "Item",
                       "pipeline": [
-                        {
-                          "$group": {
-                            "_id": {
-                              "k0": {"$switch": {"branches": [{"case": {"$gt": ["$primitiveInt", 2]}, "then": 1}], "default": 0}}
-                            },
-                            "#acc_0": {"$sum": {"$toLong": 1}}
-                          }
-                        },
-                        {"$project": {"#c_1": "$_id.k0", "#c_2": "$#acc_0", "_id": 0}}
+                        {"$group": {"_id": {"k0": {"$switch": {"branches": [{"case": {"$gt": ["$primitiveInt", 2]}, "then": 1}], "default": 0}}}, "#acc_0": {"$sum": 1}}},
+                        {"$project": {"#c_1": "$_id.k0", "#c_2": {"$toLong": "$#acc_0"}, "_id": 0}}
                       ]
                     }
                     """,
@@ -1241,9 +1236,9 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                     {
                       "aggregate": "Item",
                       "pipeline": [
-                        {"$group": {"_id": {"string": "$string"}, "#acc_0": {"$sum": {"$toLong": 1}}}},
+                        {"$group": {"_id": {"string": "$string"}, "#acc_0": {"$sum": 1}}},
                         {"$sort": {"_id.string": 1}},
-                        {"$project": {"_id#string": "$_id.string", "#c_2": "$#acc_0", "_id": 0}}
+                        {"$project": {"_id#string": "$_id.string", "#c_2": {"$toLong": "$#acc_0"}, "_id": 0}}
                       ]
                     }
                     """,
@@ -1261,9 +1256,9 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                     {
                       "aggregate": "Item",
                       "pipeline": [
-                        {"$group": {"_id": {"string": "$string"}, "#acc_0": {"$sum": {"$toLong": {"$switch": {"branches": [{"case": {"$eq": ["$primitiveInt", null]}, "then": 0}], "default": 1}}}}}},
+                        {"$group": {"_id": {"string": "$string"}, "#acc_0": {"$sum": {"$switch": {"branches": [{"case": {"$eq": ["$primitiveInt", null]}, "then": 0}], "default": 1}}}}},
                         {"$sort": {"_id.string": 1}},
-                        {"$project": {"_id#string": "$_id.string", "#c_2": "$#acc_0", "_id": 0}}
+                        {"$project": {"_id#string": "$_id.string", "#c_2": {"$toLong": "$#acc_0"}, "_id": 0}}
                       ]
                     }
                     """,
@@ -1281,9 +1276,9 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                     {
                       "aggregate": "Item",
                       "pipeline": [
-                        {"$group": {"_id": {"string": "$string"}, "#acc_0": {"$sum": {"$toLong": "$primitiveInt"}}}},
+                        {"$group": {"_id": {"string": "$string"}, "#acc_0": {"$sum": "$primitiveInt"}}},
                         {"$sort": {"_id.string": 1}},
-                        {"$project": {"_id#string": "$_id.string", "#c_2": "$#acc_0", "_id": 0}}
+                        {"$project": {"_id#string": "$_id.string", "#c_2": {"$toLong": "$#acc_0"}, "_id": 0}}
                       ]
                     }
                     """,
@@ -1301,9 +1296,9 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                     {
                       "aggregate": "Item",
                       "pipeline": [
-                        {"$group": {"_id": {"string": "$string"}, "#acc_0": {"$avg": {"$toDouble": "$primitiveInt"}}}},
+                        {"$group": {"_id": {"string": "$string"}, "#acc_0": {"$avg": "$primitiveInt"}}},
                         {"$sort": {"_id.string": 1}},
-                        {"$project": {"_id#string": "$_id.string", "#c_2": "$#acc_0", "_id": 0}}
+                        {"$project": {"_id#string": "$_id.string", "#c_2": {"$toDouble": "$#acc_0"}, "_id": 0}}
                       ]
                     }
                     """,
@@ -1321,9 +1316,9 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                     {
                       "aggregate": "Item",
                       "pipeline": [
-                        {"$group": {"_id": {"string": "$string"}, "#acc_0": {"$min": {"$toInt": "$primitiveInt"}}}},
+                        {"$group": {"_id": {"string": "$string"}, "#acc_0": {"$min": "$primitiveInt"}}},
                         {"$sort": {"_id.string": 1}},
-                        {"$project": {"_id#string": "$_id.string", "#c_2": "$#acc_0", "_id": 0}}
+                        {"$project": {"_id#string": "$_id.string", "#c_2": {"$toInt": "$#acc_0"}, "_id": 0}}
                       ]
                     }
                     """,
@@ -1341,9 +1336,9 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                     {
                       "aggregate": "Item",
                       "pipeline": [
-                        {"$group": {"_id": {"string": "$string"}, "#acc_0": {"$max": {"$toInt": "$primitiveInt"}}}},
+                        {"$group": {"_id": {"string": "$string"}, "#acc_0": {"$max": "$primitiveInt"}}},
                         {"$sort": {"_id.string": 1}},
-                        {"$project": {"_id#string": "$_id.string", "#c_2": "$#acc_0", "_id": 0}}
+                        {"$project": {"_id#string": "$_id.string", "#c_2": {"$toInt": "$#acc_0"}, "_id": 0}}
                       ]
                     }
                     """,
@@ -1362,9 +1357,9 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                     {
                       "aggregate": "Item",
                       "pipeline": [
-                        {"$group": {"_id": {"string": "$string"}, "#acc_0": {"$sum": {"$toLong": 1}}, "#acc_1": {"$sum": {"$toLong": "$primitiveInt"}}, "#acc_2": {"$avg": {"$toDouble": "$primitiveInt"}}, "#acc_3": {"$min": {"$toInt": "$primitiveInt"}}, "#acc_4": {"$max": {"$toInt": "$primitiveInt"}}}},
+                        {"$group": {"_id": {"string": "$string"}, "#acc_0": {"$sum": 1}, "#acc_1": {"$sum": "$primitiveInt"}, "#acc_2": {"$avg": "$primitiveInt"}, "#acc_3": {"$min": "$primitiveInt"}, "#acc_4": {"$max": "$primitiveInt"}}},
                         {"$sort": {"_id.string": 1}},
-                        {"$project": {"_id#string": "$_id.string", "#c_2": "$#acc_0", "#c_3": "$#acc_1", "#c_4": "$#acc_2", "#c_5": "$#acc_3", "#c_6": "$#acc_4", "_id": 0}}
+                        {"$project": {"_id#string": "$_id.string", "#c_2": {"$toLong": "$#acc_0"}, "#c_3": {"$toLong": "$#acc_1"}, "#c_4": {"$toDouble": "$#acc_2"}, "#c_5": {"$toInt": "$#acc_3"}, "#c_6": {"$toInt": "$#acc_4"}, "_id": 0}}
                       ]
                     }
                     """,
@@ -1385,9 +1380,9 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                     {
                       "aggregate": "Item",
                       "pipeline": [
-                        {"$group": {"_id": {"string": "$string"}, "#acc_0": {"$sum": {"$toLong": {"$add": ["$primitiveInt", 1]}}}}},
+                        {"$group": {"_id": {"string": "$string"}, "#acc_0": {"$sum": {"$add": ["$primitiveInt", 1]}}}},
                         {"$sort": {"_id.string": 1}},
-                        {"$project": {"_id#string": "$_id.string", "#c_2": "$#acc_0", "_id": 0}}
+                        {"$project": {"_id#string": "$_id.string", "#c_2": {"$toLong": "$#acc_0"}, "_id": 0}}
                       ]
                     }
                     """,
@@ -1405,9 +1400,9 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                     {
                       "aggregate": "Item",
                       "pipeline": [
-                        {"$group": {"_id": {"string": "$string"}, "#acc_0": {"$avg": {"$toDouble": "$primitiveInt"}}}},
+                        {"$group": {"_id": {"string": "$string"}, "#acc_0": {"$avg": "$primitiveInt"}}},
                         {"$sort": {"_id.string": 1}},
-                        {"$project": {"_id#string": "$_id.string", "#c_2": {"$add": ["$#acc_0", 1]}, "_id": 0}}
+                        {"$project": {"_id#string": "$_id.string", "#c_2": {"$add": [{"$toDouble": "$#acc_0"}, 1]}, "_id": 0}}
                       ]
                     }
                     """,
@@ -1426,7 +1421,7 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                     {
                       "aggregate": "Item",
                       "pipeline": [
-                        {"$group": {"_id": {"string": "$string"}, "#acc_0": {"$sum": {"$toLong": "$primitiveInt"}}}},
+                        {"$group": {"_id": {"string": "$string"}, "#acc_0": {"$sum": "$primitiveInt"}}},
                         {"$match": {"#acc_0": {"$gt": 4}}},
                         {"$sort": {"_id.string": 1}},
                         {"$project": {"_id#string": "$_id.string", "_id": 0}}
@@ -1447,10 +1442,10 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                     {
                       "aggregate": "Item",
                       "pipeline": [
-                        {"$group": {"_id": {"string": "$string"}, "#acc_0": {"$sum": {"$toLong": "$primitiveInt"}}}},
+                        {"$group": {"_id": {"string": "$string"}, "#acc_0": {"$sum": "$primitiveInt"}}},
                         {"$match": {"#acc_0": {"$gt": 4}}},
                         {"$sort": {"_id.string": 1}},
-                        {"$project": {"_id#string": "$_id.string", "#c_2": "$#acc_0", "_id": 0}}
+                        {"$project": {"_id#string": "$_id.string", "#c_2": {"$toLong": "$#acc_0"}, "_id": 0}}
                       ]
                     }
                     """,
@@ -1468,10 +1463,10 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                     {
                       "aggregate": "Item",
                       "pipeline": [
-                        {"$group": {"_id": {"string": "$string"}, "#acc_0": {"$sum": {"$toLong": "$primitiveInt"}}, "#acc_1": {"$sum": {"$toLong": 1}}}},
+                        {"$group": {"_id": {"string": "$string"}, "#acc_0": {"$sum": "$primitiveInt"}, "#acc_1": {"$sum": 1}}},
                         {"$match": {"#acc_1": {"$gt": 2}}},
                         {"$sort": {"_id.string": 1}},
-                        {"$project": {"_id#string": "$_id.string", "#c_2": "$#acc_0", "_id": 0}}
+                        {"$project": {"_id#string": "$_id.string", "#c_2": {"$toLong": "$#acc_0"}, "_id": 0}}
                       ]
                     }
                     """,
@@ -1489,7 +1484,7 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                     {
                       "aggregate": "Item",
                       "pipeline": [
-                        {"$group": {"_id": {"string": "$string"}, "#acc_0": {"$avg": {"$toDouble": "$primitiveInt"}}}},
+                        {"$group": {"_id": {"string": "$string"}, "#acc_0": {"$avg": "$primitiveInt"}}},
                         {"$match": {"$expr": {"$gt": [{"$add": ["$#acc_0", 1]}, 3]}}},
                         {"$sort": {"_id.string": 1}},
                         {"$project": {"_id#string": "$_id.string", "_id": 0}}
@@ -1510,9 +1505,9 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                     {
                       "aggregate": "Item",
                       "pipeline": [
-                        {"$group": {"_id": {"string": "$string"}, "#acc_0": {"$sum": {"$toLong": "$primitiveInt"}}}},
+                        {"$group": {"_id": {"string": "$string"}, "#acc_0": {"$sum": "$primitiveInt"}}},
                         {"$sort": {"#acc_0": -1, "_id.string": 1}},
-                        {"$project": {"_id#string": "$_id.string", "#c_2": "$#acc_0", "_id": 0}}
+                        {"$project": {"_id#string": "$_id.string", "#c_2": {"$toLong": "$#acc_0"}, "_id": 0}}
                       ]
                     }
                     """,
@@ -1530,7 +1525,7 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                     {
                       "aggregate": "Item",
                       "pipeline": [
-                        {"$group": {"_id": {"string": "$string"}, "#acc_0": {"$sum": {"$toLong": "$primitiveInt"}}}},
+                        {"$group": {"_id": {"string": "$string"}, "#acc_0": {"$sum": "$primitiveInt"}}},
                         {"$sort": {"#acc_0": -1, "_id.string": 1}},
                         {"$project": {"_id#string": "$_id.string", "_id": 0}}
                       ]
@@ -1550,14 +1545,9 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                     {
                       "aggregate": "Item",
                       "pipeline": [
-                        {
-                          "$group": {
-                            "_id": {"string": "$string"},
-                            "#acc_0": {"$sum": {"$toLong": "$primitiveInt"}}
-                          }
-                        },
+                        {"$group": {"_id": {"string": "$string"}, "#acc_0": {"$sum": "$primitiveInt"}}},
                         {"$sort": {"#acc_0": -1, "_id.string": 1}},
-                        {"$project": {"_id#string": "$_id.string", "total": "$#acc_0", "_id": 0}}
+                        {"$project": {"_id#string": "$_id.string", "total": {"$toLong": "$#acc_0"}, "_id": 0}}
                       ]
                     }
                     """,
@@ -1575,14 +1565,9 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                     {
                       "aggregate": "Item",
                       "pipeline": [
-                        {
-                          "$group": {
-                            "_id": {"string": "$string"},
-                            "#acc_0": {"$sum": {"$toLong": "$primitiveInt"}}
-                          }
-                        },
+                        {"$group": {"_id": {"string": "$string"}, "#acc_0": {"$sum": "$primitiveInt"}}},
                         {"$sort": {"#acc_0": -1, "_id.string": 1}},
-                        {"$project": {"_id#string": "$_id.string", "#c_2": "$#acc_0", "_id": 0}}
+                        {"$project": {"_id#string": "$_id.string", "#c_2": {"$toLong": "$#acc_0"}, "_id": 0}}
                       ]
                     }
                     """,
@@ -1605,15 +1590,10 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                     {
                       "aggregate": "Item",
                       "pipeline": [
-                        {
-                          "$group": {
-                            "_id": {"string": "$string"},
-                            "#acc_0": {"$sum": {"$toLong": "$primitiveInt"}}
-                          }
-                        },
+                        {"$group": {"_id": {"string": "$string"}, "#acc_0": {"$sum": "$primitiveInt"}}},
                         {"$match": {"#acc_0": {"$gt": 4}}},
                         {"$sort": {"#acc_0": 1}},
-                        {"$project": {"_id#string": "$_id.string", "total": "$#acc_0", "_id": 0}}
+                        {"$project": {"_id#string": "$_id.string", "total": {"$toLong": "$#acc_0"}, "_id": 0}}
                       ]
                     }
                     """,
@@ -1640,6 +1620,26 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                     "select b.string, avg(b.primitiveInt) + 1 as a from Item as b GROUP BY b.string ORDER BY a",
                     // by ordinal
                     "select b.string, avg(b.primitiveInt) + 1 from Item as b GROUP BY b.string ORDER BY 2");
+        }
+
+        static Stream<String> aggregateInGroupByQueries() {
+            return Stream.of(
+                    "select sum(b.primitiveInt) from Item as b GROUP BY sum(b.primitiveInt)",
+                    "select b.string, count(*) from Item as b GROUP BY b.string, count(*)",
+                    "select b.string from Item as b GROUP BY sum(b.primitiveInt)");
+        }
+
+        /**
+         * SQL does not allow an aggregate function in GROUP BY, but Hibernate ORM passes one through. Translating it
+         * would make the {@code _id} sub-key reference the accumulator's own {@code $group} output field, which does
+         * not exist among the stage's input documents, so every document would land in one group under a null key with
+         * no error.
+         */
+        @ParameterizedTest(name = "[{index}] {0}")
+        @MethodSource("aggregateInGroupByQueries")
+        void aggregateInGroupByIsRejected(String hql) {
+            assertSelectQueryFailure(
+                    hql, Object[].class, FeatureNotSupportedException.class, "not allowed in GROUP BY");
         }
 
         @Test
@@ -1669,6 +1669,30 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
         @MethodSource("statisticalAggregateQueries")
         void statisticalAggregateIsRejected(String function, String hql) {
             assertSelectQueryFailure(hql, Object[].class, FeatureNotSupportedException.class, "TODO-HIBERNATE-257");
+        }
+
+        static Stream<String> aggregateWithFilterQueries() {
+            return Stream.of(
+                    "select b.string, sum(b.primitiveInt) filter (where b.primitiveInt > 1) from Item as b"
+                            + " GROUP BY b.string",
+                    "select b.string, count(*) filter (where b.primitiveInt > 1) from Item as b GROUP BY b.string",
+                    "select b.string, avg(b.primitiveInt) filter (where b.primitiveInt > 1) from Item as b"
+                            + " GROUP BY b.string");
+        }
+
+        /**
+         * HQL's {@code FILTER (WHERE ...)} restricts which rows an aggregate sees, which no {@code $group} accumulator
+         * expresses directly, so it is refused. Only the exception type is asserted: the message currently comes from
+         * the generic unsupported-function path, which names a ticket about a different shape, and should be given one
+         * of its own.
+         */
+        @ParameterizedTest(name = "[{index}] {0}")
+        @MethodSource("aggregateWithFilterQueries")
+        void aggregateWithFilterIsRejected(String hql) {
+            assertThatThrownBy(() -> getSessionFactoryScope()
+                            .inTransaction(session -> session.createSelectionQuery(hql, Object[].class)
+                                    .getResultList()))
+                    .isInstanceOf(FeatureNotSupportedException.class);
         }
 
         @Test
@@ -1716,31 +1740,9 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                     {
                       "aggregate": "Item",
                       "pipeline": [
-                        {
-                          "$group": {
-                            "_id": {"primitiveInt": "$primitiveInt"},
-                            "#acc_0": {"$sum": {"$toLong": 1}},
-                            "#acc_1": {
-                              "$sum": {
-                                "$toLong": {
-                                  "$switch": {
-                                    "branches": [{"case": {"$eq": ["$string", null]}, "then": 0}],
-                                    "default": 1
-                                  }
-                                }
-                              }
-                            }
-                          }
-                        },
+                        {"$group": {"_id": {"primitiveInt": "$primitiveInt"}, "#acc_0": {"$sum": 1}, "#acc_1": {"$sum": {"$switch": {"branches": [{"case": {"$eq": ["$string", null]}, "then": 0}], "default": 1}}}}},
                         {"$sort": {"_id.primitiveInt": 1}},
-                        {
-                          "$project": {
-                            "_id#primitiveInt": "$_id.primitiveInt",
-                            "#c_2": "$#acc_0",
-                            "#c_3": "$#acc_1",
-                            "_id": 0
-                          }
-                        }
+                        {"$project": {"_id#primitiveInt": "$_id.primitiveInt", "#c_2": {"$toLong": "$#acc_0"}, "#c_3": {"$toLong": "$#acc_1"}, "_id": 0}}
                       ]
                     }
                     """,
@@ -1759,21 +1761,7 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                     {
                       "aggregate": "Item",
                       "pipeline": [
-                        {
-                          "$group": {
-                            "_id": {"primitiveInt": "$primitiveInt"},
-                            "#acc_0": {
-                              "$sum": {
-                                "$toLong": {
-                                  "$switch": {
-                                    "branches": [{"case": {"$eq": ["$string", null]}, "then": 0}],
-                                    "default": 1
-                                  }
-                                }
-                              }
-                            }
-                          }
-                        },
+                        {"$group": {"_id": {"primitiveInt": "$primitiveInt"}, "#acc_0": {"$sum": {"$switch": {"branches": [{"case": {"$eq": ["$string", null]}, "then": 0}], "default": 1}}}}},
                         {"$match": {"#acc_0": {"$gt": 0}}},
                         {"$project": {"_id#primitiveInt": "$_id.primitiveInt", "_id": 0}}
                       ]
@@ -1781,6 +1769,63 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                     """,
                     List.of(1),
                     Set.of(COLLECTION_NAME));
+        }
+    }
+
+    /**
+     * {@code $sum} yields {@code int32 0} for a group it finds nothing to add, without evaluating its argument. A
+     * conversion applied to that argument therefore never runs, and reading the {@code int32} back as the type
+     * Hibernate ORM inferred throws. {@code Item} has no nullable numeric column, so this uses {@code Book}.
+     *
+     * <p>The value returned for such a group is {@code 0} rather than SQL's {@code NULL}, because that is what
+     * {@code $sum} produces; the conversion only fixes its width.
+     */
+    @Nested
+    @DomainModel(annotatedClasses = {Item.class, Book.class})
+    class SumOverGroupWithNoValues extends AbstractQueryIntegrationTests {
+
+        @BeforeEach
+        void beforeEach() {
+            getSessionFactoryScope().inTransaction(session -> {
+                session.createMutationQuery("delete from Item").executeUpdate();
+                session.createMutationQuery("delete from Book").executeUpdate();
+                var withValues = new Book(1, "hasValues", 2001, false);
+                withValues.isbn13 = 10L;
+                withValues.discount = 1.5;
+                withValues.price = new BigDecimal("1.50");
+                session.persist(withValues);
+                // Every aggregated column null, in both rows of the group.
+                for (var id : List.of(2, 3)) {
+                    var allNull = new Book(id, "allNull", null, false);
+                    allNull.isbn13 = null;
+                    allNull.discount = null;
+                    allNull.price = null;
+                    session.persist(allNull);
+                }
+            });
+        }
+
+        @Test
+        void sumOverAGroupWithNoValues() {
+            assertSelectionQuery(
+                    "select b.title, sum(b.isbn13), sum(b.publishYear), sum(b.discount), sum(b.price) from Book as b"
+                            + " GROUP BY b.title ORDER BY b.title",
+                    Object[].class,
+                    """
+                    {
+                      "aggregate": "books",
+                      "pipeline": [
+                        {"$group": {"_id": {"title": "$title"}, "#acc_0": {"$sum": "$isbn13"}, "#acc_1": {"$sum": "$publishYear"}, "#acc_2": {"$sum": "$discount"}, "#acc_3": {"$sum": "$price"}}},
+                        {"$sort": {"_id.title": 1}},
+                        {"$project": {"_id#title": "$_id.title", "#c_2": {"$toLong": "$#acc_0"}, "#c_3": {"$toLong": "$#acc_1"}, "#c_4": {"$toDouble": "$#acc_2"}, "#c_5": {"$toDecimal": "$#acc_3"}, "_id": 0}}
+                      ]
+                    }
+                    """,
+                    results -> assertThat((Iterable<Object[]>) results)
+                            .containsExactly(
+                                    new Object[] {"allNull", 0L, 0L, 0.0d, new BigDecimal("0")},
+                                    new Object[] {"hasValues", 10L, 2001L, 1.5d, new BigDecimal("1.50")}),
+                    Set.of("books"));
         }
     }
 

--- a/src/integrationTest/java/com/mongodb/hibernate/query/select/GroupByHavingIntegrationTests.java
+++ b/src/integrationTest/java/com/mongodb/hibernate/query/select/GroupByHavingIntegrationTests.java
@@ -1548,6 +1548,27 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                     .isInstanceOf(FeatureNotSupportedException.class);
         }
 
+        static Stream<Arguments> statisticalAggregateQueries() {
+            return Stream.of("stddev_pop", "stddev_samp", "var_pop", "var_samp", "stddev", "variance")
+                    .flatMap(function -> Stream.of(
+                            Arguments.of(
+                                    function,
+                                    "select b.string, " + function
+                                            + "(b.primitiveInt) from Item as b GROUP BY b.string"),
+                            Arguments.of(function, "select " + function + "(b.primitiveInt) from Item as b")));
+        }
+
+        /**
+         * HQL's statistical aggregates are not translated yet. They are rejected by name rather than by falling through
+         * the generic unsupported-function path, so the message names the ticket that tracks them; see <a
+         * href="https://jira.mongodb.org/browse/HIBERNATE-257">HIBERNATE-257</a>.
+         */
+        @ParameterizedTest(name = "[{index}] {0}: {1}")
+        @MethodSource("statisticalAggregateQueries")
+        void statisticalAggregateIsRejected(String function, String hql) {
+            assertSelectQueryFailure(hql, Object[].class, FeatureNotSupportedException.class, "TODO-HIBERNATE-257");
+        }
+
         @Test
         void distinctWithinAggregateIsRejected() {
             assertThatThrownBy(() -> getSessionFactoryScope().inTransaction(session -> session.createSelectionQuery(

--- a/src/integrationTest/java/com/mongodb/hibernate/query/select/GroupByHavingIntegrationTests.java
+++ b/src/integrationTest/java/com/mongodb/hibernate/query/select/GroupByHavingIntegrationTests.java
@@ -46,6 +46,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 @ExtendWith(MongoExtension.class)
 @DomainModel(
@@ -152,8 +153,19 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                 {
                   "aggregate": "Item",
                   "pipeline": [
-                    {"$group": {"_id": {"itemStruct#primitiveInt": "$itemStruct.primitiveInt"}}},
-                    {"$project": {"_id#itemStruct#primitiveInt": "$_id.itemStruct#primitiveInt", "_id": 0}}
+                    {
+                      "$group": {
+                        "_id": {
+                          "itemStruct#primitiveInt": "$itemStruct.primitiveInt"
+                        }
+                      }
+                    },
+                    {
+                      "$project": {
+                        "_id#itemStruct#primitiveInt": "$_id.itemStruct#primitiveInt",
+                        "_id": 0
+                      }
+                    }
                   ]
                 }
                 """,
@@ -204,9 +216,24 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                 {
                   "aggregate": "Item",
                   "pipeline": [
-                    {"$group": {"_id": {"itemStruct#primitiveInt": "$itemStruct.primitiveInt"}}},
-                    {"$sort": {"_id.itemStruct#primitiveInt": 1}},
-                    {"$project": {"_id#itemStruct#primitiveInt": "$_id.itemStruct#primitiveInt", "_id": 0}}
+                    {
+                      "$group": {
+                        "_id": {
+                          "itemStruct#primitiveInt": "$itemStruct.primitiveInt"
+                        }
+                      }
+                    },
+                    {
+                      "$sort": {
+                        "_id.itemStruct#primitiveInt": 1
+                      }
+                    },
+                    {
+                      "$project": {
+                        "_id#itemStruct#primitiveInt": "$_id.itemStruct#primitiveInt",
+                        "_id": 0
+                      }
+                    }
                   ]
                 }
                 """,
@@ -640,22 +667,42 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
         }
 
         @Test
-        void groupByCaseKeyWithAccumulator() {
+        void groupByCaseKey() {
             assertSelectionQuery(
-                    "select case when b.primitiveInt > 2 then 1 else 0 end, count(*) from Item as b"
+                    "select case when b.primitiveInt > 2 then 1 else 0 end from Item as b"
                             + " GROUP BY case when b.primitiveInt > 2 then 1 else 0 end",
-                    Object[].class,
+                    Object.class,
                     """
                     {
                       "aggregate": "Item",
                       "pipeline": [
-                        {"$group": {"_id": {"k0": {"$switch": {"branches": [{"case": {"$gt": ["$primitiveInt", 2]}, "then": 1}], "default": 0}}}, "#acc_0": {"$sum": 1}}},
-                        {"$project": {"#c_1": "$_id.k0", "#c_2": {"$toLong": "$#acc_0"}, "_id": 0}}
+                        {
+                          "$group": {
+                            "_id": {
+                              "k0": {
+                                "$switch": {
+                                  "branches": [
+                                    {
+                                      "case": {"$gt": ["$primitiveInt", 2]},
+                                      "then": 1
+                                    }
+                                  ],
+                                  "default": 0
+                                }
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "$project": {
+                            "#c_1": "$_id.k0",
+                            "_id": 0
+                          }
+                        }
                       ]
                     }
                     """,
-                    results -> assertThat((Iterable<Object[]>) results)
-                            .containsExactlyInAnyOrder(new Object[] {0, 2L}, new Object[] {1, 2L}),
+                    results -> assertThat((Iterable<Integer>) results).containsExactlyInAnyOrder(0, 1),
                     Set.of(COLLECTION_NAME));
         }
 
@@ -668,8 +715,24 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                     {
                       "aggregate": "Item",
                       "pipeline": [
-                        {"$group": {"_id": {"k0": {"$add": ["$primitiveInt", 1]}}}},
-                        {"$project": {"#c_1": "$_id.k0", "_id": 0}}
+                        {
+                          "$group": {
+                            "_id": {
+                              "k0": {
+                                "$add": [
+                                  "$primitiveInt",
+                                  1
+                                ]
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "$project": {
+                            "#c_1": "$_id.k0",
+                            "_id": 0
+                          }
+                        }
                       ]
                     }
                     """,
@@ -686,8 +749,24 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                     {
                       "aggregate": "Item",
                       "pipeline": [
-                        {"$group": {"_id": {"primitiveInt": "$primitiveInt"}}},
-                        {"$project": {"#c_1": {"$add": ["$_id.primitiveInt", 1]}, "_id": 0}}
+                        {
+                          "$group": {
+                            "_id": {
+                              "primitiveInt": "$primitiveInt"
+                            }
+                          }
+                        },
+                        {
+                          "$project": {
+                            "#c_1": {
+                              "$add": [
+                                "$_id.primitiveInt",
+                                1
+                              ]
+                            },
+                            "_id": 0
+                          }
+                        }
                       ]
                     }
                     """,
@@ -704,8 +783,29 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                     {
                       "aggregate": "Item",
                       "pipeline": [
-                        {"$group": {"_id": {"k0": {"$add": ["$primitiveInt", 1]}}}},
-                        {"$project": {"#c_1": {"$multiply": ["$_id.k0", 2]}, "_id": 0}}
+                        {
+                          "$group": {
+                            "_id": {
+                              "k0": {
+                                "$add": [
+                                  "$primitiveInt",
+                                  1
+                                ]
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "$project": {
+                            "#c_1": {
+                              "$multiply": [
+                                "$_id.k0",
+                                2
+                              ]
+                            },
+                            "_id": 0
+                          }
+                        }
                       ]
                     }
                     """,
@@ -722,11 +822,25 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                     {
                       "aggregate": "Item",
                       "pipeline": [
-                        {"$group": {"_id": {
-                          "primitiveInt": "$primitiveInt",
-                          "k1": {"$add": ["$primitiveInt", 1]}
-                        }}},
-                        {"$project": {"#c_1": "$_id.k1", "_id": 0}}
+                        {
+                          "$group": {
+                            "_id": {
+                              "primitiveInt": "$primitiveInt",
+                              "k1": {
+                                "$add": [
+                                  "$primitiveInt",
+                                  1
+                                ]
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "$project": {
+                            "#c_1": "$_id.k1",
+                            "_id": 0
+                          }
+                        }
                       ]
                     }
                     """,
@@ -743,8 +857,24 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                     {
                       "aggregate": "Item",
                       "pipeline": [
-                        {"$group": {"_id": {"k0": {"$multiply": [-1, "$primitiveInt"]}}}},
-                        {"$project": {"#c_1": "$_id.k0", "_id": 0}}
+                        {
+                          "$group": {
+                            "_id": {
+                              "k0": {
+                                "$multiply": [
+                                  -1,
+                                  "$primitiveInt"
+                                ]
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "$project": {
+                            "#c_1": "$_id.k0",
+                            "_id": 0
+                          }
+                        }
                       ]
                     }
                     """,
@@ -761,11 +891,26 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                     {
                       "aggregate": "Item",
                       "pipeline": [
-                        {"$group": {"_id": {
-                          "primitiveInt": "$primitiveInt",
-                          "k1": {"$add": ["$primitiveInt", 1]}
-                        }}},
-                        {"$project": {"#c_1": "$_id.k1", "_id#primitiveInt": "$_id.primitiveInt", "_id": 0}}
+                        {
+                          "$group": {
+                            "_id": {
+                              "primitiveInt": "$primitiveInt",
+                              "k1": {
+                                "$add": [
+                                  "$primitiveInt",
+                                  1
+                                ]
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "$project": {
+                            "#c_1": "$_id.k1",
+                            "_id#primitiveInt": "$_id.primitiveInt",
+                            "_id": 0
+                          }
+                        }
                       ]
                     }
                     """,
@@ -788,8 +933,24 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                     {
                       "aggregate": "Item",
                       "pipeline": [
-                        {"$group": {"_id": {"k0": {"$add": ["$primitiveInt", 10]}}}},
-                        {"$project": {"#c_1": "$_id.k0", "_id": 0}}
+                        {
+                          "$group": {
+                            "_id": {
+                              "k0": {
+                                "$add": [
+                                  "$primitiveInt",
+                                  10
+                                ]
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "$project": {
+                            "#c_1": "$_id.k0",
+                            "_id": 0
+                          }
+                        }
                       ]
                     }
                     """,
@@ -809,9 +970,31 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                     {
                       "aggregate": "Item",
                       "pipeline": [
-                        {"$group": {"_id": {"k0": {"$add": ["$primitiveInt", 1]}}}},
-                        {"$match": {"_id.k0": {"$gt": 2}}},
-                        {"$project": {"#c_1": "$_id.k0", "_id": 0}}
+                        {
+                          "$group": {
+                            "_id": {
+                              "k0": {
+                                "$add": [
+                                  "$primitiveInt",
+                                  1
+                                ]
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "$match": {
+                            "_id.k0": {
+                              "$gt": 2
+                            }
+                          }
+                        },
+                        {
+                          "$project": {
+                            "#c_1": "$_id.k0",
+                            "_id": 0
+                          }
+                        }
                       ]
                     }
                     """,
@@ -829,12 +1012,40 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                     {
                       "aggregate": "Item",
                       "pipeline": [
-                        {"$group": {"_id": {"k0": {"$add": ["$primitiveInt", 1]}}}},
-                        {"$match": {"$and": [
-                          {"_id.k0": {"$gt": 2}},
-                          {"_id.k0": {"$lt": 5}}
-                        ]}},
-                        {"$project": {"#c_1": "$_id.k0", "_id": 0}}
+                        {
+                          "$group": {
+                            "_id": {
+                              "k0": {
+                                "$add": [
+                                  "$primitiveInt",
+                                  1
+                                ]
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "$match": {
+                            "$and": [
+                              {
+                                "_id.k0": {
+                                  "$gt": 2
+                                }
+                              },
+                              {
+                                "_id.k0": {
+                                  "$lt": 5
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "$project": {
+                            "#c_1": "$_id.k0",
+                            "_id": 0
+                          }
+                        }
                       ]
                     }
                     """,
@@ -854,11 +1065,34 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                     {
                       "aggregate": "Item",
                       "pipeline": [
-                        {"$group": {"_id": {"primitiveInt": "$primitiveInt"}}},
-                        {"$project": {"#c_1": {"$switch": {
-                          "branches": [{"case": {"$gt": ["$_id.primitiveInt", 2]}, "then": 1}],
-                          "default": 0
-                        }}, "_id": 0}}
+                        {
+                          "$group": {
+                            "_id": {
+                              "primitiveInt": "$primitiveInt"
+                            }
+                          }
+                        },
+                        {
+                          "$project": {
+                            "#c_1": {
+                              "$switch": {
+                                "branches": [
+                                  {
+                                    "case": {
+                                      "$gt": [
+                                        "$_id.primitiveInt",
+                                        2
+                                      ]
+                                    },
+                                    "then": 1
+                                  }
+                                ],
+                                "default": 0
+                              }
+                            },
+                            "_id": 0
+                          }
+                        }
                       ]
                     }
                     """,
@@ -880,14 +1114,44 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                     {
                       "aggregate": "Item",
                       "pipeline": [
-                        {"$group": {"_id": {"primitiveInt": "$primitiveInt"}}},
-                        {"$project": {"#c_1": {"$switch": {
-                          "branches": [{"case": {"$and": [
-                            {"$gt": ["$_id.primitiveInt", 1]},
-                            {"$lt": ["$_id.primitiveInt", 4]}
-                          ]}, "then": 1}],
-                          "default": 0
-                        }}, "_id": 0}}
+                        {
+                          "$group": {
+                            "_id": {
+                              "primitiveInt": "$primitiveInt"
+                            }
+                          }
+                        },
+                        {
+                          "$project": {
+                            "#c_1": {
+                              "$switch": {
+                                "branches": [
+                                  {
+                                    "case": {
+                                      "$and": [
+                                        {
+                                          "$gt": [
+                                            "$_id.primitiveInt",
+                                            1
+                                          ]
+                                        },
+                                        {
+                                          "$lt": [
+                                            "$_id.primitiveInt",
+                                            4
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    "then": 1
+                                  }
+                                ],
+                                "default": 0
+                              }
+                            },
+                            "_id": 0
+                          }
+                        }
                       ]
                     }
                     """,
@@ -907,8 +1171,21 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                     {
                       "aggregate": "Item",
                       "pipeline": [
-                        {"$group": {"_id": {"k0": {"$strLenCP": "$string"}}}},
-                        {"$project": {"#c_1": "$_id.k0", "_id": 0}}
+                        {
+                          "$group": {
+                            "_id": {
+                              "k0": {
+                                "$strLenCP": "$string"
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "$project": {
+                            "#c_1": "$_id.k0",
+                            "_id": 0
+                          }
+                        }
                       ]
                     }
                     """,
@@ -928,8 +1205,26 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                     {
                       "aggregate": "Item",
                       "pipeline": [
-                        {"$group": {"_id": {"k0": {"$strLenCP": "$string"}}}},
-                        {"$project": {"#c_1": {"$add": ["$_id.k0", 1]}, "_id": 0}}
+                        {
+                          "$group": {
+                            "_id": {
+                              "k0": {
+                                "$strLenCP": "$string"
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "$project": {
+                            "#c_1": {
+                              "$add": [
+                                "$_id.k0",
+                                1
+                              ]
+                            },
+                            "_id": 0
+                          }
+                        }
                       ]
                     }
                     """,
@@ -948,8 +1243,23 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                     {
                       "aggregate": "Item",
                       "pipeline": [
-                        {"$group": {"_id": {"k0": {"$toUpper": {"$toLower": "$string"}}}}},
-                        {"$project": {"#c_1": "$_id.k0", "_id": 0}}
+                        {
+                          "$group": {
+                            "_id": {
+                              "k0": {
+                                "$toUpper": {
+                                  "$toLower": "$string"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "$project": {
+                            "#c_1": "$_id.k0",
+                            "_id": 0
+                          }
+                        }
                       ]
                     }
                     """,
@@ -969,8 +1279,23 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                     {
                       "aggregate": "Item",
                       "pipeline": [
-                        {"$group": {"_id": {"k0": {"$toLower": "$string"}}}},
-                        {"$project": {"#c_1": {"$toUpper": "$_id.k0"}, "_id": 0}}
+                        {
+                          "$group": {
+                            "_id": {
+                              "k0": {
+                                "$toLower": "$string"
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "$project": {
+                            "#c_1": {
+                              "$toUpper": "$_id.k0"
+                            },
+                            "_id": 0
+                          }
+                        }
                       ]
                     }
                     """,
@@ -990,8 +1315,27 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                     {
                       "aggregate": "Item",
                       "pipeline": [
-                        {"$group": {"_id": {"k0": {"$strLenCP": "$string"}}}},
-                        {"$project": {"#c_1": "$_id.k0", "#c_2": {"$add": ["$_id.k0", 1]}, "_id": 0}}
+                        {
+                          "$group": {
+                            "_id": {
+                              "k0": {
+                                "$strLenCP": "$string"
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "$project": {
+                            "#c_1": "$_id.k0",
+                            "#c_2": {
+                              "$add": [
+                                "$_id.k0",
+                                1
+                              ]
+                            },
+                            "_id": 0
+                          }
+                        }
                       ]
                     }
                     """,
@@ -1014,9 +1358,28 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                     {
                       "aggregate": "Item",
                       "pipeline": [
-                        {"$group": {"_id": {"k0": {"$strLenCP": "$string"}}}},
-                        {"$match": {"_id.k0": {"$gt": 0}}},
-                        {"$project": {"#c_1": "$_id.k0", "_id": 0}}
+                        {
+                          "$group": {
+                            "_id": {
+                              "k0": {
+                                "$strLenCP": "$string"
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "$match": {
+                            "_id.k0": {
+                              "$gt": 0
+                            }
+                          }
+                        },
+                        {
+                          "$project": {
+                            "#c_1": "$_id.k0",
+                            "_id": 0
+                          }
+                        }
                       ]
                     }
                     """,
@@ -1037,11 +1400,36 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                     {
                       "aggregate": "Item",
                       "pipeline": [
-                        {"$group": {"_id": {"k0": {"$strLenCP": "$string"}}}},
-                        {"$project": {"#c_1": {"$switch": {
-                          "branches": [{"case": {"$gt": ["$_id.k0", 0]}, "then": 1}],
-                          "default": 0
-                        }}, "_id": 0}}
+                        {
+                          "$group": {
+                            "_id": {
+                              "k0": {
+                                "$strLenCP": "$string"
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "$project": {
+                            "#c_1": {
+                              "$switch": {
+                                "branches": [
+                                  {
+                                    "case": {
+                                      "$gt": [
+                                        "$_id.k0",
+                                        0
+                                      ]
+                                    },
+                                    "then": 1
+                                  }
+                                ],
+                                "default": 0
+                              }
+                            },
+                            "_id": 0
+                          }
+                        }
                       ]
                     }
                     """,
@@ -1062,11 +1450,30 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                     {
                       "aggregate": "Item",
                       "pipeline": [
-                        {"$group": {"_id": {"k0": {"$strLenCP": {"$concat": [
-                          {"$toString": "$string"},
-                          {"$toString": "$string"}
-                        ]}}}}},
-                        {"$project": {"#c_1": "$_id.k0", "_id": 0}}
+                        {
+                          "$group": {
+                            "_id": {
+                              "k0": {
+                                "$strLenCP": {
+                                  "$concat": [
+                                    {
+                                      "$toString": "$string"
+                                    },
+                                    {
+                                      "$toString": "$string"
+                                    }
+                                  ]
+                                }
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "$project": {
+                            "#c_1": "$_id.k0",
+                            "_id": 0
+                          }
+                        }
                       ]
                     }
                     """,
@@ -1087,11 +1494,23 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                     {
                       "aggregate": "Item",
                       "pipeline": [
-                        {"$group": {"_id": {
-                          "primitiveInt": "$primitiveInt",
-                          "k1": {"$toUpper": "$string"}
-                        }}},
-                        {"$project": {"_id#primitiveInt": "$_id.primitiveInt", "#c_2": "$_id.k1", "_id": 0}}
+                        {
+                          "$group": {
+                            "_id": {
+                              "primitiveInt": "$primitiveInt",
+                              "k1": {
+                                "$toUpper": "$string"
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "$project": {
+                            "_id#primitiveInt": "$_id.primitiveInt",
+                            "#c_2": "$_id.k1",
+                            "_id": 0
+                          }
+                        }
                       ]
                     }
                     """,
@@ -1153,10 +1572,31 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                 {
                   "aggregate": "Item",
                   "pipeline": [
-                    {"$group": {"_id": {"itemStruct#primitiveInt": "$itemStruct.primitiveInt"}}},
-                    {"$match": {"_id.itemStruct#primitiveInt": {"$gt": 1}}},
-                    {"$sort": {"_id.itemStruct#primitiveInt": 1}},
-                    {"$project": {"_id#itemStruct#primitiveInt": "$_id.itemStruct#primitiveInt", "_id": 0}}
+                    {
+                      "$group": {
+                        "_id": {
+                          "itemStruct#primitiveInt": "$itemStruct.primitiveInt"
+                        }
+                      }
+                    },
+                    {
+                      "$match": {
+                        "_id.itemStruct#primitiveInt": {
+                          "$gt": 1
+                        }
+                      }
+                    },
+                    {
+                      "$sort": {
+                        "_id.itemStruct#primitiveInt": 1
+                      }
+                    },
+                    {
+                      "$project": {
+                        "_id#itemStruct#primitiveInt": "$_id.itemStruct#primitiveInt",
+                        "_id": 0
+                      }
+                    }
                   ]
                 }
                 """,
@@ -1173,10 +1613,31 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                 {
                   "aggregate": "Item",
                   "pipeline": [
-                    {"$match": {"primitiveInt": {"$gt": 1}}},
-                    {"$group": {"_id": {"primitiveInt": "$primitiveInt"}}},
-                    {"$sort": {"_id.primitiveInt": 1}},
-                    {"$project": {"_id#primitiveInt": "$_id.primitiveInt", "_id": 0}}
+                    {
+                      "$match": {
+                        "primitiveInt": {
+                          "$gt": 1
+                        }
+                      }
+                    },
+                    {
+                      "$group": {
+                        "_id": {
+                          "primitiveInt": "$primitiveInt"
+                        }
+                      }
+                    },
+                    {
+                      "$sort": {
+                        "_id.primitiveInt": 1
+                      }
+                    },
+                    {
+                      "$project": {
+                        "_id#primitiveInt": "$_id.primitiveInt",
+                        "_id": 0
+                      }
+                    }
                   ]
                 }
                 """,
@@ -1193,10 +1654,31 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                 {
                   "aggregate": "Item",
                   "pipeline": [
-                    {"$match": {"itemStruct.primitiveInt": {"$gt": 1}}},
-                    {"$group": {"_id": {"itemStruct#primitiveInt": "$itemStruct.primitiveInt"}}},
-                    {"$sort": {"_id.itemStruct#primitiveInt": 1}},
-                    {"$project": {"_id#itemStruct#primitiveInt": "$_id.itemStruct#primitiveInt", "_id": 0}}
+                    {
+                      "$match": {
+                        "itemStruct.primitiveInt": {
+                          "$gt": 1
+                        }
+                      }
+                    },
+                    {
+                      "$group": {
+                        "_id": {
+                          "itemStruct#primitiveInt": "$itemStruct.primitiveInt"
+                        }
+                      }
+                    },
+                    {
+                      "$sort": {
+                        "_id.itemStruct#primitiveInt": 1
+                      }
+                    },
+                    {
+                      "$project": {
+                        "_id#itemStruct#primitiveInt": "$_id.itemStruct#primitiveInt",
+                        "_id": 0
+                      }
+                    }
                   ]
                 }
                 """,
@@ -1213,9 +1695,24 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                 {
                   "aggregate": "Item",
                   "pipeline": [
-                    {"$group": {"_id": {"_id": "$_id"}}},
-                    {"$sort": {"_id._id": 1}},
-                    {"$project": {"_id#_id": "$_id._id", "_id": 0}}
+                    {
+                      "$group": {
+                        "_id": {
+                          "_id": "$_id"
+                        }
+                      }
+                    },
+                    {
+                      "$sort": {
+                        "_id._id": 1
+                      }
+                    },
+                    {
+                      "$project": {
+                        "_id#_id": "$_id._id",
+                        "_id": 0
+                      }
+                    }
                   ]
                 }
                 """,
@@ -1236,9 +1733,30 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                     {
                       "aggregate": "Item",
                       "pipeline": [
-                        {"$group": {"_id": {"string": "$string"}, "#acc_0": {"$sum": 1}}},
-                        {"$sort": {"_id.string": 1}},
-                        {"$project": {"_id#string": "$_id.string", "#c_2": {"$toLong": "$#acc_0"}, "_id": 0}}
+                        {
+                          "$group": {
+                            "_id": {
+                              "string": "$string"
+                            },
+                            "#acc_0": {
+                              "$sum": 1
+                            }
+                          }
+                        },
+                        {
+                          "$sort": {
+                            "_id.string": 1
+                          }
+                        },
+                        {
+                          "$project": {
+                            "_id#string": "$_id.string",
+                            "#c_2": {
+                              "$toLong": "$#acc_0"
+                            },
+                            "_id": 0
+                          }
+                        }
                       ]
                     }
                     """,
@@ -1256,9 +1774,45 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                     {
                       "aggregate": "Item",
                       "pipeline": [
-                        {"$group": {"_id": {"string": "$string"}, "#acc_0": {"$sum": {"$switch": {"branches": [{"case": {"$eq": ["$primitiveInt", null]}, "then": 0}], "default": 1}}}}},
-                        {"$sort": {"_id.string": 1}},
-                        {"$project": {"_id#string": "$_id.string", "#c_2": {"$toLong": "$#acc_0"}, "_id": 0}}
+                        {
+                          "$group": {
+                            "_id": {
+                              "string": "$string"
+                            },
+                            "#acc_0": {
+                              "$sum": {
+                                "$switch": {
+                                  "branches": [
+                                    {
+                                      "case": {
+                                        "$eq": [
+                                          "$primitiveInt",
+                                          null
+                                        ]
+                                      },
+                                      "then": 0
+                                    }
+                                  ],
+                                  "default": 1
+                                }
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "$sort": {
+                            "_id.string": 1
+                          }
+                        },
+                        {
+                          "$project": {
+                            "_id#string": "$_id.string",
+                            "#c_2": {
+                              "$toLong": "$#acc_0"
+                            },
+                            "_id": 0
+                          }
+                        }
                       ]
                     }
                     """,
@@ -1276,9 +1830,30 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                     {
                       "aggregate": "Item",
                       "pipeline": [
-                        {"$group": {"_id": {"string": "$string"}, "#acc_0": {"$sum": "$primitiveInt"}}},
-                        {"$sort": {"_id.string": 1}},
-                        {"$project": {"_id#string": "$_id.string", "#c_2": {"$toLong": "$#acc_0"}, "_id": 0}}
+                        {
+                          "$group": {
+                            "_id": {
+                              "string": "$string"
+                            },
+                            "#acc_0": {
+                              "$sum": "$primitiveInt"
+                            }
+                          }
+                        },
+                        {
+                          "$sort": {
+                            "_id.string": 1
+                          }
+                        },
+                        {
+                          "$project": {
+                            "_id#string": "$_id.string",
+                            "#c_2": {
+                              "$toLong": "$#acc_0"
+                            },
+                            "_id": 0
+                          }
+                        }
                       ]
                     }
                     """,
@@ -1296,9 +1871,30 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                     {
                       "aggregate": "Item",
                       "pipeline": [
-                        {"$group": {"_id": {"string": "$string"}, "#acc_0": {"$avg": "$primitiveInt"}}},
-                        {"$sort": {"_id.string": 1}},
-                        {"$project": {"_id#string": "$_id.string", "#c_2": {"$toDouble": "$#acc_0"}, "_id": 0}}
+                        {
+                          "$group": {
+                            "_id": {
+                              "string": "$string"
+                            },
+                            "#acc_0": {
+                              "$avg": "$primitiveInt"
+                            }
+                          }
+                        },
+                        {
+                          "$sort": {
+                            "_id.string": 1
+                          }
+                        },
+                        {
+                          "$project": {
+                            "_id#string": "$_id.string",
+                            "#c_2": {
+                              "$toDouble": "$#acc_0"
+                            },
+                            "_id": 0
+                          }
+                        }
                       ]
                     }
                     """,
@@ -1316,9 +1912,30 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                     {
                       "aggregate": "Item",
                       "pipeline": [
-                        {"$group": {"_id": {"string": "$string"}, "#acc_0": {"$min": "$primitiveInt"}}},
-                        {"$sort": {"_id.string": 1}},
-                        {"$project": {"_id#string": "$_id.string", "#c_2": {"$toInt": "$#acc_0"}, "_id": 0}}
+                        {
+                          "$group": {
+                            "_id": {
+                              "string": "$string"
+                            },
+                            "#acc_0": {
+                              "$min": "$primitiveInt"
+                            }
+                          }
+                        },
+                        {
+                          "$sort": {
+                            "_id.string": 1
+                          }
+                        },
+                        {
+                          "$project": {
+                            "_id#string": "$_id.string",
+                            "#c_2": {
+                              "$toInt": "$#acc_0"
+                            },
+                            "_id": 0
+                          }
+                        }
                       ]
                     }
                     """,
@@ -1336,9 +1953,30 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                     {
                       "aggregate": "Item",
                       "pipeline": [
-                        {"$group": {"_id": {"string": "$string"}, "#acc_0": {"$max": "$primitiveInt"}}},
-                        {"$sort": {"_id.string": 1}},
-                        {"$project": {"_id#string": "$_id.string", "#c_2": {"$toInt": "$#acc_0"}, "_id": 0}}
+                        {
+                          "$group": {
+                            "_id": {
+                              "string": "$string"
+                            },
+                            "#acc_0": {
+                              "$max": "$primitiveInt"
+                            }
+                          }
+                        },
+                        {
+                          "$sort": {
+                            "_id.string": 1
+                          }
+                        },
+                        {
+                          "$project": {
+                            "_id#string": "$_id.string",
+                            "#c_2": {
+                              "$toInt": "$#acc_0"
+                            },
+                            "_id": 0
+                          }
+                        }
                       ]
                     }
                     """,
@@ -1357,9 +1995,54 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                     {
                       "aggregate": "Item",
                       "pipeline": [
-                        {"$group": {"_id": {"string": "$string"}, "#acc_0": {"$sum": 1}, "#acc_1": {"$sum": "$primitiveInt"}, "#acc_2": {"$avg": "$primitiveInt"}, "#acc_3": {"$min": "$primitiveInt"}, "#acc_4": {"$max": "$primitiveInt"}}},
-                        {"$sort": {"_id.string": 1}},
-                        {"$project": {"_id#string": "$_id.string", "#c_2": {"$toLong": "$#acc_0"}, "#c_3": {"$toLong": "$#acc_1"}, "#c_4": {"$toDouble": "$#acc_2"}, "#c_5": {"$toInt": "$#acc_3"}, "#c_6": {"$toInt": "$#acc_4"}, "_id": 0}}
+                        {
+                          "$group": {
+                            "_id": {
+                              "string": "$string"
+                            },
+                            "#acc_0": {
+                              "$sum": 1
+                            },
+                            "#acc_1": {
+                              "$sum": "$primitiveInt"
+                            },
+                            "#acc_2": {
+                              "$avg": "$primitiveInt"
+                            },
+                            "#acc_3": {
+                              "$min": "$primitiveInt"
+                            },
+                            "#acc_4": {
+                              "$max": "$primitiveInt"
+                            }
+                          }
+                        },
+                        {
+                          "$sort": {
+                            "_id.string": 1
+                          }
+                        },
+                        {
+                          "$project": {
+                            "_id#string": "$_id.string",
+                            "#c_2": {
+                              "$toLong": "$#acc_0"
+                            },
+                            "#c_3": {
+                              "$toLong": "$#acc_1"
+                            },
+                            "#c_4": {
+                              "$toDouble": "$#acc_2"
+                            },
+                            "#c_5": {
+                              "$toInt": "$#acc_3"
+                            },
+                            "#c_6": {
+                              "$toInt": "$#acc_4"
+                            },
+                            "_id": 0
+                          }
+                        }
                       ]
                     }
                     """,
@@ -1380,9 +2063,35 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                     {
                       "aggregate": "Item",
                       "pipeline": [
-                        {"$group": {"_id": {"string": "$string"}, "#acc_0": {"$sum": {"$add": ["$primitiveInt", 1]}}}},
-                        {"$sort": {"_id.string": 1}},
-                        {"$project": {"_id#string": "$_id.string", "#c_2": {"$toLong": "$#acc_0"}, "_id": 0}}
+                        {
+                          "$group": {
+                            "_id": {
+                              "string": "$string"
+                            },
+                            "#acc_0": {
+                              "$sum": {
+                                "$add": [
+                                  "$primitiveInt",
+                                  1
+                                ]
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "$sort": {
+                            "_id.string": 1
+                          }
+                        },
+                        {
+                          "$project": {
+                            "_id#string": "$_id.string",
+                            "#c_2": {
+                              "$toLong": "$#acc_0"
+                            },
+                            "_id": 0
+                          }
+                        }
                       ]
                     }
                     """,
@@ -1400,9 +2109,35 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                     {
                       "aggregate": "Item",
                       "pipeline": [
-                        {"$group": {"_id": {"string": "$string"}, "#acc_0": {"$avg": "$primitiveInt"}}},
-                        {"$sort": {"_id.string": 1}},
-                        {"$project": {"_id#string": "$_id.string", "#c_2": {"$add": [{"$toDouble": "$#acc_0"}, 1]}, "_id": 0}}
+                        {
+                          "$group": {
+                            "_id": {
+                              "string": "$string"
+                            },
+                            "#acc_0": {
+                              "$avg": "$primitiveInt"
+                            }
+                          }
+                        },
+                        {
+                          "$sort": {
+                            "_id.string": 1
+                          }
+                        },
+                        {
+                          "$project": {
+                            "_id#string": "$_id.string",
+                            "#c_2": {
+                              "$add": [
+                                {
+                                  "$toDouble": "$#acc_0"
+                                },
+                                1
+                              ]
+                            },
+                            "_id": 0
+                          }
+                        }
                       ]
                     }
                     """,
@@ -1421,10 +2156,34 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                     {
                       "aggregate": "Item",
                       "pipeline": [
-                        {"$group": {"_id": {"string": "$string"}, "#acc_0": {"$sum": "$primitiveInt"}}},
-                        {"$match": {"#acc_0": {"$gt": 4}}},
-                        {"$sort": {"_id.string": 1}},
-                        {"$project": {"_id#string": "$_id.string", "_id": 0}}
+                        {
+                          "$group": {
+                            "_id": {
+                              "string": "$string"
+                            },
+                            "#acc_0": {
+                              "$sum": "$primitiveInt"
+                            }
+                          }
+                        },
+                        {
+                          "$match": {
+                            "#acc_0": {
+                              "$gt": 4
+                            }
+                          }
+                        },
+                        {
+                          "$sort": {
+                            "_id.string": 1
+                          }
+                        },
+                        {
+                          "$project": {
+                            "_id#string": "$_id.string",
+                            "_id": 0
+                          }
+                        }
                       ]
                     }
                     """,
@@ -1442,10 +2201,37 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                     {
                       "aggregate": "Item",
                       "pipeline": [
-                        {"$group": {"_id": {"string": "$string"}, "#acc_0": {"$sum": "$primitiveInt"}}},
-                        {"$match": {"#acc_0": {"$gt": 4}}},
-                        {"$sort": {"_id.string": 1}},
-                        {"$project": {"_id#string": "$_id.string", "#c_2": {"$toLong": "$#acc_0"}, "_id": 0}}
+                        {
+                          "$group": {
+                            "_id": {
+                              "string": "$string"
+                            },
+                            "#acc_0": {
+                              "$sum": "$primitiveInt"
+                            }
+                          }
+                        },
+                        {
+                          "$match": {
+                            "#acc_0": {
+                              "$gt": 4
+                            }
+                          }
+                        },
+                        {
+                          "$sort": {
+                            "_id.string": 1
+                          }
+                        },
+                        {
+                          "$project": {
+                            "_id#string": "$_id.string",
+                            "#c_2": {
+                              "$toLong": "$#acc_0"
+                            },
+                            "_id": 0
+                          }
+                        }
                       ]
                     }
                     """,
@@ -1463,10 +2249,40 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                     {
                       "aggregate": "Item",
                       "pipeline": [
-                        {"$group": {"_id": {"string": "$string"}, "#acc_0": {"$sum": "$primitiveInt"}, "#acc_1": {"$sum": 1}}},
-                        {"$match": {"#acc_1": {"$gt": 2}}},
-                        {"$sort": {"_id.string": 1}},
-                        {"$project": {"_id#string": "$_id.string", "#c_2": {"$toLong": "$#acc_0"}, "_id": 0}}
+                        {
+                          "$group": {
+                            "_id": {
+                              "string": "$string"
+                            },
+                            "#acc_0": {
+                              "$sum": "$primitiveInt"
+                            },
+                            "#acc_1": {
+                              "$sum": 1
+                            }
+                          }
+                        },
+                        {
+                          "$match": {
+                            "#acc_1": {
+                              "$gt": 2
+                            }
+                          }
+                        },
+                        {
+                          "$sort": {
+                            "_id.string": 1
+                          }
+                        },
+                        {
+                          "$project": {
+                            "_id#string": "$_id.string",
+                            "#c_2": {
+                              "$toLong": "$#acc_0"
+                            },
+                            "_id": 0
+                          }
+                        }
                       ]
                     }
                     """,
@@ -1484,10 +2300,42 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                     {
                       "aggregate": "Item",
                       "pipeline": [
-                        {"$group": {"_id": {"string": "$string"}, "#acc_0": {"$avg": "$primitiveInt"}}},
-                        {"$match": {"$expr": {"$gt": [{"$add": ["$#acc_0", 1]}, 3]}}},
-                        {"$sort": {"_id.string": 1}},
-                        {"$project": {"_id#string": "$_id.string", "_id": 0}}
+                        {
+                          "$group": {
+                            "_id": {
+                              "string": "$string"
+                            },
+                            "#acc_0": {
+                              "$avg": "$primitiveInt"
+                            }
+                          }
+                        },
+                        {
+                          "$match": {
+                            "$expr": {
+                              "$gt": [
+                                {
+                                  "$add": [
+                                    "$#acc_0",
+                                    1
+                                  ]
+                                },
+                                3
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "$sort": {
+                            "_id.string": 1
+                          }
+                        },
+                        {
+                          "$project": {
+                            "_id#string": "$_id.string",
+                            "_id": 0
+                          }
+                        }
                       ]
                     }
                     """,
@@ -1505,9 +2353,31 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                     {
                       "aggregate": "Item",
                       "pipeline": [
-                        {"$group": {"_id": {"string": "$string"}, "#acc_0": {"$sum": "$primitiveInt"}}},
-                        {"$sort": {"#acc_0": -1, "_id.string": 1}},
-                        {"$project": {"_id#string": "$_id.string", "#c_2": {"$toLong": "$#acc_0"}, "_id": 0}}
+                        {
+                          "$group": {
+                            "_id": {
+                              "string": "$string"
+                            },
+                            "#acc_0": {
+                              "$sum": "$primitiveInt"
+                            }
+                          }
+                        },
+                        {
+                          "$sort": {
+                            "#acc_0": -1,
+                            "_id.string": 1
+                          }
+                        },
+                        {
+                          "$project": {
+                            "_id#string": "$_id.string",
+                            "#c_2": {
+                              "$toLong": "$#acc_0"
+                            },
+                            "_id": 0
+                          }
+                        }
                       ]
                     }
                     """,
@@ -1525,9 +2395,28 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                     {
                       "aggregate": "Item",
                       "pipeline": [
-                        {"$group": {"_id": {"string": "$string"}, "#acc_0": {"$sum": "$primitiveInt"}}},
-                        {"$sort": {"#acc_0": -1, "_id.string": 1}},
-                        {"$project": {"_id#string": "$_id.string", "_id": 0}}
+                        {
+                          "$group": {
+                            "_id": {
+                              "string": "$string"
+                            },
+                            "#acc_0": {
+                              "$sum": "$primitiveInt"
+                            }
+                          }
+                        },
+                        {
+                          "$sort": {
+                            "#acc_0": -1,
+                            "_id.string": 1
+                          }
+                        },
+                        {
+                          "$project": {
+                            "_id#string": "$_id.string",
+                            "_id": 0
+                          }
+                        }
                       ]
                     }
                     """,
@@ -1545,9 +2434,31 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                     {
                       "aggregate": "Item",
                       "pipeline": [
-                        {"$group": {"_id": {"string": "$string"}, "#acc_0": {"$sum": "$primitiveInt"}}},
-                        {"$sort": {"#acc_0": -1, "_id.string": 1}},
-                        {"$project": {"_id#string": "$_id.string", "total": {"$toLong": "$#acc_0"}, "_id": 0}}
+                        {
+                          "$group": {
+                            "_id": {
+                              "string": "$string"
+                            },
+                            "#acc_0": {
+                              "$sum": "$primitiveInt"
+                            }
+                          }
+                        },
+                        {
+                          "$sort": {
+                            "#acc_0": -1,
+                            "_id.string": 1
+                          }
+                        },
+                        {
+                          "$project": {
+                            "_id#string": "$_id.string",
+                            "total": {
+                              "$toLong": "$#acc_0"
+                            },
+                            "_id": 0
+                          }
+                        }
                       ]
                     }
                     """,
@@ -1565,9 +2476,31 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                     {
                       "aggregate": "Item",
                       "pipeline": [
-                        {"$group": {"_id": {"string": "$string"}, "#acc_0": {"$sum": "$primitiveInt"}}},
-                        {"$sort": {"#acc_0": -1, "_id.string": 1}},
-                        {"$project": {"_id#string": "$_id.string", "#c_2": {"$toLong": "$#acc_0"}, "_id": 0}}
+                        {
+                          "$group": {
+                            "_id": {
+                              "string": "$string"
+                            },
+                            "#acc_0": {
+                              "$sum": "$primitiveInt"
+                            }
+                          }
+                        },
+                        {
+                          "$sort": {
+                            "#acc_0": -1,
+                            "_id.string": 1
+                          }
+                        },
+                        {
+                          "$project": {
+                            "_id#string": "$_id.string",
+                            "#c_2": {
+                              "$toLong": "$#acc_0"
+                            },
+                            "_id": 0
+                          }
+                        }
                       ]
                     }
                     """,
@@ -1590,10 +2523,37 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                     {
                       "aggregate": "Item",
                       "pipeline": [
-                        {"$group": {"_id": {"string": "$string"}, "#acc_0": {"$sum": "$primitiveInt"}}},
-                        {"$match": {"#acc_0": {"$gt": 4}}},
-                        {"$sort": {"#acc_0": 1}},
-                        {"$project": {"_id#string": "$_id.string", "total": {"$toLong": "$#acc_0"}, "_id": 0}}
+                        {
+                          "$group": {
+                            "_id": {
+                              "string": "$string"
+                            },
+                            "#acc_0": {
+                              "$sum": "$primitiveInt"
+                            }
+                          }
+                        },
+                        {
+                          "$match": {
+                            "#acc_0": {
+                              "$gt": 4
+                            }
+                          }
+                        },
+                        {
+                          "$sort": {
+                            "#acc_0": 1
+                          }
+                        },
+                        {
+                          "$project": {
+                            "_id#string": "$_id.string",
+                            "total": {
+                              "$toLong": "$#acc_0"
+                            },
+                            "_id": 0
+                          }
+                        }
                       ]
                     }
                     """,
@@ -1642,12 +2602,25 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                     hql, Object[].class, FeatureNotSupportedException.class, "not allowed in GROUP BY");
         }
 
+        /** Grouping the whole collection is a `$group` with a null `_id`; not implemented yet. */
+        @ParameterizedTest(name = "[{index}] {0}")
+        @ValueSource(strings = {"count", "sum", "avg", "min", "max"})
+        void aggregateWithoutGroupByIsRejected(String function) {
+            assertSelectQueryFailure(
+                    "select " + function + "(b.primitiveInt) from Item as b",
+                    Object.class,
+                    FeatureNotSupportedException.class,
+                    "TODO-HIBERNATE-262");
+        }
+
+        /** {@code count(*)} takes the same path, through a {@code Star} argument rather than a column. */
         @Test
-        void aggregateWithoutGroupByIsRejected() {
-            assertThatThrownBy(() -> getSessionFactoryScope().inTransaction(session -> session.createSelectionQuery(
-                                    "select sum(b.primitiveInt) from Item as b", Object.class)
-                            .getResultList()))
-                    .isInstanceOf(FeatureNotSupportedException.class);
+        void countStarWithoutGroupByIsRejected() {
+            assertSelectQueryFailure(
+                    "select count(*) from Item as b",
+                    Object.class,
+                    FeatureNotSupportedException.class,
+                    "TODO-HIBERNATE-262");
         }
 
         static Stream<Arguments> statisticalAggregateQueries() {
@@ -1671,6 +2644,21 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
             assertSelectQueryFailure(hql, Object[].class, FeatureNotSupportedException.class, "TODO-HIBERNATE-257");
         }
 
+        /**
+         * {@code every} and {@code any} are aggregate functions Hibernate ORM models the same way as the five we
+         * translate, so they reach the accumulator switch rather than the generic unsupported-function path.
+         * {@code some} is a synonym of {@code any} and arrives under that name.
+         */
+        @ParameterizedTest(name = "[{index}] {0}")
+        @ValueSource(strings = {"every", "any", "some"})
+        void booleanAggregateIsRejected(String function) {
+            assertSelectQueryFailure(
+                    "select b.string, " + function + "(b.primitiveBoolean) from Item as b GROUP BY b.string",
+                    Object[].class,
+                    FeatureNotSupportedException.class,
+                    "TODO-HIBERNATE-261");
+        }
+
         static Stream<String> aggregateWithFilterQueries() {
             return Stream.of(
                     "select b.string, sum(b.primitiveInt) filter (where b.primitiveInt > 1) from Item as b"
@@ -1680,28 +2668,22 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                             + " GROUP BY b.string");
         }
 
-        /**
-         * HQL's {@code FILTER (WHERE ...)} restricts which rows an aggregate sees, which no {@code $group} accumulator
-         * expresses directly, so it is refused. Only the exception type is asserted: the message currently comes from
-         * the generic unsupported-function path, which names a ticket about a different shape, and should be given one
-         * of its own.
-         */
+        /** HQL's {@code FILTER (WHERE ...)} restricts which rows an aggregate sees; not translated yet. */
         @ParameterizedTest(name = "[{index}] {0}")
         @MethodSource("aggregateWithFilterQueries")
         void aggregateWithFilterIsRejected(String hql) {
-            assertThatThrownBy(() -> getSessionFactoryScope()
-                            .inTransaction(session -> session.createSelectionQuery(hql, Object[].class)
-                                    .getResultList()))
-                    .isInstanceOf(FeatureNotSupportedException.class);
+            assertSelectQueryFailure(hql, Object[].class, FeatureNotSupportedException.class, "TODO-HIBERNATE-260");
         }
 
-        @Test
-        void distinctWithinAggregateIsRejected() {
-            assertThatThrownBy(() -> getSessionFactoryScope().inTransaction(session -> session.createSelectionQuery(
-                                    "select b.string, count(distinct b.primitiveInt) from Item as b GROUP BY b.string",
-                                    Object[].class)
-                            .getResultList()))
-                    .isInstanceOf(FeatureNotSupportedException.class);
+        /** Hibernate ORM accepts {@code distinct} on every aggregate we translate, not only on {@code count}. */
+        @ParameterizedTest(name = "[{index}] {0}(distinct ...)")
+        @ValueSource(strings = {"count", "sum", "avg", "min", "max"})
+        void distinctWithinAggregateIsRejected(String function) {
+            assertSelectQueryFailure(
+                    "select b.string, " + function + "(distinct b.primitiveInt) from Item as b GROUP BY b.string",
+                    Object[].class,
+                    FeatureNotSupportedException.class,
+                    "TODO-HIBERNATE-259");
         }
     }
 
@@ -1740,9 +2722,51 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                     {
                       "aggregate": "Item",
                       "pipeline": [
-                        {"$group": {"_id": {"primitiveInt": "$primitiveInt"}, "#acc_0": {"$sum": 1}, "#acc_1": {"$sum": {"$switch": {"branches": [{"case": {"$eq": ["$string", null]}, "then": 0}], "default": 1}}}}},
-                        {"$sort": {"_id.primitiveInt": 1}},
-                        {"$project": {"_id#primitiveInt": "$_id.primitiveInt", "#c_2": {"$toLong": "$#acc_0"}, "#c_3": {"$toLong": "$#acc_1"}, "_id": 0}}
+                        {
+                          "$group": {
+                            "_id": {
+                              "primitiveInt": "$primitiveInt"
+                            },
+                            "#acc_0": {
+                              "$sum": 1
+                            },
+                            "#acc_1": {
+                              "$sum": {
+                                "$switch": {
+                                  "branches": [
+                                    {
+                                      "case": {
+                                        "$eq": [
+                                          "$string",
+                                          null
+                                        ]
+                                      },
+                                      "then": 0
+                                    }
+                                  ],
+                                  "default": 1
+                                }
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "$sort": {
+                            "_id.primitiveInt": 1
+                          }
+                        },
+                        {
+                          "$project": {
+                            "_id#primitiveInt": "$_id.primitiveInt",
+                            "#c_2": {
+                              "$toLong": "$#acc_0"
+                            },
+                            "#c_3": {
+                              "$toLong": "$#acc_1"
+                            },
+                            "_id": 0
+                          }
+                        }
                       ]
                     }
                     """,
@@ -1761,9 +2785,44 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                     {
                       "aggregate": "Item",
                       "pipeline": [
-                        {"$group": {"_id": {"primitiveInt": "$primitiveInt"}, "#acc_0": {"$sum": {"$switch": {"branches": [{"case": {"$eq": ["$string", null]}, "then": 0}], "default": 1}}}}},
-                        {"$match": {"#acc_0": {"$gt": 0}}},
-                        {"$project": {"_id#primitiveInt": "$_id.primitiveInt", "_id": 0}}
+                        {
+                          "$group": {
+                            "_id": {
+                              "primitiveInt": "$primitiveInt"
+                            },
+                            "#acc_0": {
+                              "$sum": {
+                                "$switch": {
+                                  "branches": [
+                                    {
+                                      "case": {
+                                        "$eq": [
+                                          "$string",
+                                          null
+                                        ]
+                                      },
+                                      "then": 0
+                                    }
+                                  ],
+                                  "default": 1
+                                }
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "$match": {
+                            "#acc_0": {
+                              "$gt": 0
+                            }
+                          }
+                        },
+                        {
+                          "$project": {
+                            "_id#primitiveInt": "$_id.primitiveInt",
+                            "_id": 0
+                          }
+                        }
                       ]
                     }
                     """,
@@ -1815,9 +2874,48 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                     {
                       "aggregate": "books",
                       "pipeline": [
-                        {"$group": {"_id": {"title": "$title"}, "#acc_0": {"$sum": "$isbn13"}, "#acc_1": {"$sum": "$publishYear"}, "#acc_2": {"$sum": "$discount"}, "#acc_3": {"$sum": "$price"}}},
-                        {"$sort": {"_id.title": 1}},
-                        {"$project": {"_id#title": "$_id.title", "#c_2": {"$toLong": "$#acc_0"}, "#c_3": {"$toLong": "$#acc_1"}, "#c_4": {"$toDouble": "$#acc_2"}, "#c_5": {"$toDecimal": "$#acc_3"}, "_id": 0}}
+                        {
+                          "$group": {
+                            "_id": {
+                              "title": "$title"
+                            },
+                            "#acc_0": {
+                              "$sum": "$isbn13"
+                            },
+                            "#acc_1": {
+                              "$sum": "$publishYear"
+                            },
+                            "#acc_2": {
+                              "$sum": "$discount"
+                            },
+                            "#acc_3": {
+                              "$sum": "$price"
+                            }
+                          }
+                        },
+                        {
+                          "$sort": {
+                            "_id.title": 1
+                          }
+                        },
+                        {
+                          "$project": {
+                            "_id#title": "$_id.title",
+                            "#c_2": {
+                              "$toLong": "$#acc_0"
+                            },
+                            "#c_3": {
+                              "$toLong": "$#acc_1"
+                            },
+                            "#c_4": {
+                              "$toDouble": "$#acc_2"
+                            },
+                            "#c_5": {
+                              "$toDecimal": "$#acc_3"
+                            },
+                            "_id": 0
+                          }
+                        }
                       ]
                     }
                     """,

--- a/src/integrationTest/java/com/mongodb/hibernate/query/select/GroupByHavingIntegrationTests.java
+++ b/src/integrationTest/java/com/mongodb/hibernate/query/select/GroupByHavingIntegrationTests.java
@@ -638,6 +638,33 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
         }
 
         @Test
+        void groupByCaseKeyWithAccumulator() {
+            assertSelectionQuery(
+                    "select case when b.primitiveInt > 2 then 1 else 0 end, count(*) from Item as b"
+                            + " GROUP BY case when b.primitiveInt > 2 then 1 else 0 end",
+                    Object[].class,
+                    """
+                    {
+                      "aggregate": "Item",
+                      "pipeline": [
+                        {
+                          "$group": {
+                            "_id": {
+                              "k0": {"$switch": {"branches": [{"case": {"$gt": ["$primitiveInt", 2]}, "then": 1}], "default": 0}}
+                            },
+                            "#acc_0": {"$sum": {"$toLong": 1}}
+                          }
+                        },
+                        {"$project": {"#c_1": "$_id.k0", "#c_2": "$#acc_0", "_id": 0}}
+                      ]
+                    }
+                    """,
+                    results -> assertThat((Iterable<Object[]>) results)
+                            .containsExactlyInAnyOrder(new Object[] {0, 2L}, new Object[] {1, 2L}),
+                    Set.of(COLLECTION_NAME));
+        }
+
+        @Test
         void groupByArithmeticWholeMatch() {
             assertSelectionQuery(
                     "select b.primitiveInt + 1 from Item as b GROUP BY b.primitiveInt + 1",
@@ -1199,6 +1226,336 @@ public class GroupByHavingIntegrationTests extends AbstractQueryIntegrationTests
                 """,
                 List.of(1, 2, 3, 4, 5, 6, 7, 8),
                 Set.of(COLLECTION_NAME));
+    }
+
+    @Nested
+    @DomainModel(annotatedClasses = {Item.class})
+    class Accumulators extends AbstractQueryIntegrationTests {
+
+        @Test
+        void countStar() {
+            assertSelectionQuery(
+                    "select b.string, count(*) from Item as b GROUP BY b.string ORDER BY b.string",
+                    Object[].class,
+                    """
+                    {
+                      "aggregate": "Item",
+                      "pipeline": [
+                        {"$group": {"_id": {"string": "$string"}, "#acc_0": {"$sum": {"$toLong": 1}}}},
+                        {"$sort": {"_id.string": 1}},
+                        {"$project": {"_id#string": "$_id.string", "#c_2": "$#acc_0", "_id": 0}}
+                      ]
+                    }
+                    """,
+                    results -> assertThat((Iterable<Object[]>) results)
+                            .containsExactly(new Object[] {"a", 4L}, new Object[] {"b", 2L}, new Object[] {"c", 2L}),
+                    Set.of(COLLECTION_NAME));
+        }
+
+        @Test
+        void countColumn() {
+            assertSelectionQuery(
+                    "select b.string, count(b.primitiveInt) from Item as b GROUP BY b.string ORDER BY b.string",
+                    Object[].class,
+                    """
+                    {
+                      "aggregate": "Item",
+                      "pipeline": [
+                        {"$group": {"_id": {"string": "$string"}, "#acc_0": {"$sum": {"$toLong": {"$switch": {"branches": [{"case": {"$eq": ["$primitiveInt", null]}, "then": 0}], "default": 1}}}}}},
+                        {"$sort": {"_id.string": 1}},
+                        {"$project": {"_id#string": "$_id.string", "#c_2": "$#acc_0", "_id": 0}}
+                      ]
+                    }
+                    """,
+                    results -> assertThat((Iterable<Object[]>) results)
+                            .containsExactly(new Object[] {"a", 4L}, new Object[] {"b", 2L}, new Object[] {"c", 2L}),
+                    Set.of(COLLECTION_NAME));
+        }
+
+        @Test
+        void sum() {
+            assertSelectionQuery(
+                    "select b.string, sum(b.primitiveInt) from Item as b GROUP BY b.string ORDER BY b.string",
+                    Object[].class,
+                    """
+                    {
+                      "aggregate": "Item",
+                      "pipeline": [
+                        {"$group": {"_id": {"string": "$string"}, "#acc_0": {"$sum": {"$toLong": "$primitiveInt"}}}},
+                        {"$sort": {"_id.string": 1}},
+                        {"$project": {"_id#string": "$_id.string", "#c_2": "$#acc_0", "_id": 0}}
+                      ]
+                    }
+                    """,
+                    results -> assertThat((Iterable<Object[]>) results)
+                            .containsExactly(new Object[] {"a", 4L}, new Object[] {"b", 4L}, new Object[] {"c", 7L}),
+                    Set.of(COLLECTION_NAME));
+        }
+
+        @Test
+        void avg() {
+            assertSelectionQuery(
+                    "select b.string, avg(b.primitiveInt) from Item as b GROUP BY b.string ORDER BY b.string",
+                    Object[].class,
+                    """
+                    {
+                      "aggregate": "Item",
+                      "pipeline": [
+                        {"$group": {"_id": {"string": "$string"}, "#acc_0": {"$avg": {"$toDouble": "$primitiveInt"}}}},
+                        {"$sort": {"_id.string": 1}},
+                        {"$project": {"_id#string": "$_id.string", "#c_2": "$#acc_0", "_id": 0}}
+                      ]
+                    }
+                    """,
+                    results -> assertThat((Iterable<Object[]>) results)
+                            .containsExactly(new Object[] {"a", 1.0}, new Object[] {"b", 2.0}, new Object[] {"c", 3.5}),
+                    Set.of(COLLECTION_NAME));
+        }
+
+        @Test
+        void min() {
+            assertSelectionQuery(
+                    "select b.string, min(b.primitiveInt) from Item as b GROUP BY b.string ORDER BY b.string",
+                    Object[].class,
+                    """
+                    {
+                      "aggregate": "Item",
+                      "pipeline": [
+                        {"$group": {"_id": {"string": "$string"}, "#acc_0": {"$min": {"$toInt": "$primitiveInt"}}}},
+                        {"$sort": {"_id.string": 1}},
+                        {"$project": {"_id#string": "$_id.string", "#c_2": "$#acc_0", "_id": 0}}
+                      ]
+                    }
+                    """,
+                    results -> assertThat((Iterable<Object[]>) results)
+                            .containsExactly(new Object[] {"a", 1}, new Object[] {"b", 2}, new Object[] {"c", 3}),
+                    Set.of(COLLECTION_NAME));
+        }
+
+        @Test
+        void max() {
+            assertSelectionQuery(
+                    "select b.string, max(b.primitiveInt) from Item as b GROUP BY b.string ORDER BY b.string",
+                    Object[].class,
+                    """
+                    {
+                      "aggregate": "Item",
+                      "pipeline": [
+                        {"$group": {"_id": {"string": "$string"}, "#acc_0": {"$max": {"$toInt": "$primitiveInt"}}}},
+                        {"$sort": {"_id.string": 1}},
+                        {"$project": {"_id#string": "$_id.string", "#c_2": "$#acc_0", "_id": 0}}
+                      ]
+                    }
+                    """,
+                    results -> assertThat((Iterable<Object[]>) results)
+                            .containsExactly(new Object[] {"a", 1}, new Object[] {"b", 2}, new Object[] {"c", 4}),
+                    Set.of(COLLECTION_NAME));
+        }
+
+        @Test
+        void allAggregateFunctionsCombined() {
+            assertSelectionQuery(
+                    "select b.string, count(*), sum(b.primitiveInt), avg(b.primitiveInt), min(b.primitiveInt),"
+                            + " max(b.primitiveInt) from Item as b GROUP BY b.string ORDER BY b.string",
+                    Object[].class,
+                    """
+                    {
+                      "aggregate": "Item",
+                      "pipeline": [
+                        {"$group": {"_id": {"string": "$string"}, "#acc_0": {"$sum": {"$toLong": 1}}, "#acc_1": {"$sum": {"$toLong": "$primitiveInt"}}, "#acc_2": {"$avg": {"$toDouble": "$primitiveInt"}}, "#acc_3": {"$min": {"$toInt": "$primitiveInt"}}, "#acc_4": {"$max": {"$toInt": "$primitiveInt"}}}},
+                        {"$sort": {"_id.string": 1}},
+                        {"$project": {"_id#string": "$_id.string", "#c_2": "$#acc_0", "#c_3": "$#acc_1", "#c_4": "$#acc_2", "#c_5": "$#acc_3", "#c_6": "$#acc_4", "_id": 0}}
+                      ]
+                    }
+                    """,
+                    results -> assertThat((Iterable<Object[]>) results)
+                            .containsExactly(
+                                    new Object[] {"a", 4L, 4L, 1.0, 1, 1},
+                                    new Object[] {"b", 2L, 4L, 2.0, 2, 2},
+                                    new Object[] {"c", 2L, 7L, 3.5, 3, 4}),
+                    Set.of(COLLECTION_NAME));
+        }
+
+        @Test
+        void aggregateOfExpression() {
+            assertSelectionQuery(
+                    "select b.string, sum(b.primitiveInt + 1) from Item as b GROUP BY b.string ORDER BY b.string",
+                    Object[].class,
+                    """
+                    {
+                      "aggregate": "Item",
+                      "pipeline": [
+                        {"$group": {"_id": {"string": "$string"}, "#acc_0": {"$sum": {"$toLong": {"$add": ["$primitiveInt", 1]}}}}},
+                        {"$sort": {"_id.string": 1}},
+                        {"$project": {"_id#string": "$_id.string", "#c_2": "$#acc_0", "_id": 0}}
+                      ]
+                    }
+                    """,
+                    results -> assertThat((Iterable<Object[]>) results)
+                            .containsExactly(new Object[] {"a", 8L}, new Object[] {"b", 6L}, new Object[] {"c", 9L}),
+                    Set.of(COLLECTION_NAME));
+        }
+
+        @Test
+        void expressionWrappingAggregate() {
+            assertSelectionQuery(
+                    "select b.string, avg(b.primitiveInt) + 1 from Item as b GROUP BY b.string ORDER BY b.string",
+                    Object[].class,
+                    """
+                    {
+                      "aggregate": "Item",
+                      "pipeline": [
+                        {"$group": {"_id": {"string": "$string"}, "#acc_0": {"$avg": {"$toDouble": "$primitiveInt"}}}},
+                        {"$sort": {"_id.string": 1}},
+                        {"$project": {"_id#string": "$_id.string", "#c_2": {"$add": ["$#acc_0", 1]}, "_id": 0}}
+                      ]
+                    }
+                    """,
+                    results -> assertThat((Iterable<Object[]>) results)
+                            .containsExactly(new Object[] {"a", 2.0}, new Object[] {"b", 3.0}, new Object[] {"c", 4.5}),
+                    Set.of(COLLECTION_NAME));
+        }
+
+        @Test
+        void aggregateOnlyInHaving() {
+            assertSelectionQuery(
+                    "select b.string from Item as b GROUP BY b.string HAVING sum(b.primitiveInt) > 4"
+                            + " ORDER BY b.string",
+                    Object.class,
+                    """
+                    {
+                      "aggregate": "Item",
+                      "pipeline": [
+                        {"$group": {"_id": {"string": "$string"}, "#acc_0": {"$sum": {"$toLong": "$primitiveInt"}}}},
+                        {"$match": {"#acc_0": {"$gt": 4}}},
+                        {"$sort": {"_id.string": 1}},
+                        {"$project": {"_id#string": "$_id.string", "_id": 0}}
+                      ]
+                    }
+                    """,
+                    List.of("c"),
+                    Set.of(COLLECTION_NAME));
+        }
+
+        @Test
+        void sameAggregateInHavingAndSelectSharesOneAccumulator() {
+            assertSelectionQuery(
+                    "select b.string, sum(b.primitiveInt) from Item as b GROUP BY b.string"
+                            + " HAVING sum(b.primitiveInt) > 4 ORDER BY b.string",
+                    Object[].class,
+                    """
+                    {
+                      "aggregate": "Item",
+                      "pipeline": [
+                        {"$group": {"_id": {"string": "$string"}, "#acc_0": {"$sum": {"$toLong": "$primitiveInt"}}}},
+                        {"$match": {"#acc_0": {"$gt": 4}}},
+                        {"$sort": {"_id.string": 1}},
+                        {"$project": {"_id#string": "$_id.string", "#c_2": "$#acc_0", "_id": 0}}
+                      ]
+                    }
+                    """,
+                    results -> assertThat((Iterable<Object[]>) results).containsExactly(new Object[] {"c", 7L}),
+                    Set.of(COLLECTION_NAME));
+        }
+
+        @Test
+        void differentAggregatesInHavingAndSelect() {
+            assertSelectionQuery(
+                    "select b.string, sum(b.primitiveInt) from Item as b GROUP BY b.string"
+                            + " HAVING count(*) > 2 ORDER BY b.string",
+                    Object[].class,
+                    """
+                    {
+                      "aggregate": "Item",
+                      "pipeline": [
+                        {"$group": {"_id": {"string": "$string"}, "#acc_0": {"$sum": {"$toLong": "$primitiveInt"}}, "#acc_1": {"$sum": {"$toLong": 1}}}},
+                        {"$match": {"#acc_1": {"$gt": 2}}},
+                        {"$sort": {"_id.string": 1}},
+                        {"$project": {"_id#string": "$_id.string", "#c_2": "$#acc_0", "_id": 0}}
+                      ]
+                    }
+                    """,
+                    results -> assertThat((Iterable<Object[]>) results).containsExactly(new Object[] {"a", 4L}),
+                    Set.of(COLLECTION_NAME));
+        }
+
+        @Test
+        void expressionWrappingAggregateInHaving() {
+            assertSelectionQuery(
+                    "select b.string from Item as b GROUP BY b.string HAVING avg(b.primitiveInt) + 1 > 3"
+                            + " ORDER BY b.string",
+                    Object.class,
+                    """
+                    {
+                      "aggregate": "Item",
+                      "pipeline": [
+                        {"$group": {"_id": {"string": "$string"}, "#acc_0": {"$avg": {"$toDouble": "$primitiveInt"}}}},
+                        {"$match": {"$expr": {"$gt": [{"$add": ["$#acc_0", 1]}, 3]}}},
+                        {"$sort": {"_id.string": 1}},
+                        {"$project": {"_id#string": "$_id.string", "_id": 0}}
+                      ]
+                    }
+                    """,
+                    List.of("c"),
+                    Set.of(COLLECTION_NAME));
+        }
+
+        @Test
+        void orderByAggregate() {
+            assertSelectionQuery(
+                    "select b.string, sum(b.primitiveInt) from Item as b GROUP BY b.string"
+                            + " ORDER BY sum(b.primitiveInt) DESC, b.string",
+                    Object[].class,
+                    """
+                    {
+                      "aggregate": "Item",
+                      "pipeline": [
+                        {"$group": {"_id": {"string": "$string"}, "#acc_0": {"$sum": {"$toLong": "$primitiveInt"}}}},
+                        {"$sort": {"#acc_0": -1, "_id.string": 1}},
+                        {"$project": {"_id#string": "$_id.string", "#c_2": "$#acc_0", "_id": 0}}
+                      ]
+                    }
+                    """,
+                    results -> assertThat((Iterable<Object[]>) results)
+                            .containsExactly(new Object[] {"c", 7L}, new Object[] {"a", 4L}, new Object[] {"b", 4L}),
+                    Set.of(COLLECTION_NAME));
+        }
+
+        @Test
+        void orderByAggregateAbsentFromSelect() {
+            assertSelectionQuery(
+                    "select b.string from Item as b GROUP BY b.string ORDER BY sum(b.primitiveInt) DESC, b.string",
+                    Object.class,
+                    """
+                    {
+                      "aggregate": "Item",
+                      "pipeline": [
+                        {"$group": {"_id": {"string": "$string"}, "#acc_0": {"$sum": {"$toLong": "$primitiveInt"}}}},
+                        {"$sort": {"#acc_0": -1, "_id.string": 1}},
+                        {"$project": {"_id#string": "$_id.string", "_id": 0}}
+                      ]
+                    }
+                    """,
+                    List.of("c", "a", "b"),
+                    Set.of(COLLECTION_NAME));
+        }
+
+        @Test
+        void aggregateWithoutGroupByIsRejected() {
+            assertThatThrownBy(() -> getSessionFactoryScope().inTransaction(session -> session.createSelectionQuery(
+                                    "select sum(b.primitiveInt) from Item as b", Object.class)
+                            .getResultList()))
+                    .isInstanceOf(FeatureNotSupportedException.class);
+        }
+
+        @Test
+        void distinctWithinAggregateIsRejected() {
+            assertThatThrownBy(() -> getSessionFactoryScope().inTransaction(session -> session.createSelectionQuery(
+                                    "select b.string, count(distinct b.primitiveInt) from Item as b GROUP BY b.string",
+                                    Object[].class)
+                            .getResultList()))
+                    .isInstanceOf(FeatureNotSupportedException.class);
+        }
     }
 
     @Nested

--- a/src/main/java/com/mongodb/hibernate/internal/translate/AbstractMqlTranslator.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/AbstractMqlTranslator.java
@@ -444,7 +444,8 @@ public abstract class AbstractMqlTranslator<T extends JdbcOperation> implements 
          * <p>Insertion-ordered on purpose: {@code $group} renders these in registration order, so the emitted pipeline
          * is deterministic and can be asserted verbatim.
          */
-        final LinkedHashMap<Integer, AstGroupStageAccumulatorSpecification> registeredAccumulatorsByVN = new LinkedHashMap<>();
+        final LinkedHashMap<Integer, AstGroupStageAccumulatorSpecification> registeredAccumulatorsByVN =
+                new LinkedHashMap<>();
 
         /** The names of the registered accumulators, for {@link GroupBySubstitutionRule}'s whitelist. */
         final Set<String> accumulatorFieldNames = new HashSet<>();

--- a/src/main/java/com/mongodb/hibernate/internal/translate/AbstractMqlTranslator.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/AbstractMqlTranslator.java
@@ -1286,10 +1286,11 @@ public abstract class AbstractMqlTranslator<T extends JdbcOperation> implements 
     }
 
     private AstSortField createAstSortField(Expression sortExpression, AstSortOrder astSortOrder) {
-        if (!isFieldPathExpression(sortExpression)) {
+        var resolved = resolveSelectedExpression(sortExpression);
+        if (!isFieldPathExpression(resolved)) {
             // An aggregate function is orderable under a GROUP BY: it resolves to the accumulator field $group
             // computes, shared with SELECT/HAVING when they name the same function, so nothing is recomputed here.
-            if (sortExpression instanceof SelfRenderingFunctionSqlAstExpression<?> function) {
+            if (resolved instanceof SelfRenderingFunctionSqlAstExpression<?> function) {
                 var accumulatorReference = tryRegisterAccumulator(function);
                 if (accumulatorReference != null) {
                     return new AstSortField(accumulatorReference.fieldPath(), astSortOrder);
@@ -1302,8 +1303,27 @@ public abstract class AbstractMqlTranslator<T extends JdbcOperation> implements 
                             ? "TODO-HIBERNATE-251 https://jira.mongodb.org/browse/HIBERNATE-251"
                             : "TODO-HIBERNATE-79 https://jira.mongodb.org/browse/HIBERNATE-79");
         }
-        var fieldPath = acceptAndYield(sortExpression, FIELD_PATH);
+        var fieldPath = acceptAndYield(resolved, FIELD_PATH);
         return new AstSortField(fieldPath, astSortOrder);
+    }
+
+    /**
+     * Unwraps an ORDER BY item that names a select item by alias or by ordinal, which Hibernate ORM models as a
+     * {@link SqlSelectionExpression} around the selected expression, to that expression.
+     *
+     * <p>This has to happen before the sort target is classified, because {@link #isFieldPathExpression} treats the
+     * wrapper itself as a field path. Left wrapped, {@code ORDER BY total} over {@code sum(x) as total} would take the
+     * field-path branch, where the aggregate is visited with {@code FIELD_PATH} expected instead of {@code EXPRESSION},
+     * so it would never be offered to {@link #tryRegisterAccumulator} and would fail without a diagnostic. Unwrapping
+     * changes nothing for an alias or ordinal that names a plain column: the wrapper's only behaviour is to delegate to
+     * the same expression.
+     */
+    private static Expression resolveSelectedExpression(Expression expression) {
+        var resolved = expression;
+        while (resolved instanceof SqlSelectionExpression selection) {
+            resolved = selection.getSelection().getExpression();
+        }
+        return resolved;
     }
 
     @Override

--- a/src/main/java/com/mongodb/hibernate/internal/translate/AbstractMqlTranslator.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/AbstractMqlTranslator.java
@@ -127,6 +127,7 @@ import com.mongodb.hibernate.internal.translate.mongoast.filter.AstListCompariso
 import com.mongodb.hibernate.internal.translate.mongoast.filter.AstLogicalFilter;
 import com.mongodb.hibernate.internal.translate.mongoast.filter.AstLogicalFilterOperator;
 import com.mongodb.hibernate.internal.translate.mongoast.filter.AstRegularExpressionFilterOperation;
+import com.mongodb.hibernate.internal.translate.rewrite.AccumulatorResultCastRule;
 import com.mongodb.hibernate.internal.translate.rewrite.AstRewriter;
 import com.mongodb.hibernate.internal.translate.rewrite.ExprToMatchDowngradeRule;
 import com.mongodb.hibernate.internal.translate.rewrite.GroupBySubstitutionRule;
@@ -430,7 +431,7 @@ public abstract class AbstractMqlTranslator<T extends JdbcOperation> implements 
     /**
      * Per-query GROUP BY state: the VN registry, the group-key-to-sub-key map, and the accumulators registered while
      * translating SELECT/HAVING/ORDER BY. Created by {@link #prepareGroupBy} when the query has a GROUP BY clause;
-     * {@code null} otherwise. When sub-queries are supported, this should be pushed/popped on a stack.
+     * {@code null} otherwise.
      */
     static final class GroupByContext {
         final VNRegistry vnRegistry = new VNRegistry();
@@ -439,13 +440,20 @@ public abstract class AbstractMqlTranslator<T extends JdbcOperation> implements 
         /**
          * Registered accumulators keyed by the value number of the {@link AstAccumulatorExpression}, which is what
          * makes the same aggregate function appearing in both SELECT and HAVING resolve to one {@code $group} field.
-         * Ordered so that {@code $group} renders them in registration order, keeping the pipeline deterministic.
+         *
+         * <p>Insertion-ordered on purpose: {@code $group} renders these in registration order, so the emitted pipeline
+         * is deterministic and can be asserted verbatim.
          */
-        final LinkedHashMap<Integer, AstGroupStageAccumulatorSpecification> registeredAccumulatorsByVN =
-                new LinkedHashMap<>();
+        final LinkedHashMap<Integer, AstGroupStageAccumulatorSpecification> registeredAccumulatorsByVN = new LinkedHashMap<>();
 
         /** The names of the registered accumulators, for {@link GroupBySubstitutionRule}'s whitelist. */
         final Set<String> accumulatorFieldNames = new HashSet<>();
+
+        /**
+         * The conversion each accumulator's value needs to read back as the type Hibernate ORM inferred for the
+         * aggregate function, for {@link AccumulatorResultCastRule}. Holds only the accumulators that need one.
+         */
+        final Map<String, AstConversionExpressionOperator> accumulatorResultCasts = new HashMap<>();
     }
 
     // Per-query counter for naming $lookup `let` variables; see nextLetVariableName.
@@ -729,6 +737,12 @@ public abstract class AbstractMqlTranslator<T extends JdbcOperation> implements 
             havingStage = havingStage.map(astRewriter::rewrite);
             sortStage = sortStage.map(astRewriter::rewrite);
             projectStage = astRewriter.rewrite(projectStage);
+            // A second pass, over `$project` alone: the accumulator references have to survive the substitution rule
+            // above as bare field paths before they can be wrapped in their result conversion.
+            if (!ctx.accumulatorResultCasts.isEmpty()) {
+                projectStage = new AstRewriter(new AccumulatorResultCastRule(ctx.accumulatorResultCasts), null)
+                        .rewrite(projectStage);
+            }
         }
 
         havingStage.ifPresent(stages::add);
@@ -773,7 +787,16 @@ public abstract class AbstractMqlTranslator<T extends JdbcOperation> implements 
                 specs.add(new AstGroupStageSpecification(groupKey, fieldPathExpr));
             } else {
                 var groupKey = "k" + i;
+                var accumulatorsBefore = ctx.registeredAccumulatorsByVN.size();
                 var expr = acceptAndYieldExpression(groupByClauseExpression);
+                // Hibernate ORM lets an aggregate function through in GROUP BY, which SQL does not allow. Translating
+                // it would register an accumulator and make the key reference that accumulator's field --- but `_id`
+                // is computed from the stage's input documents, where a field `$group` is about to produce does not
+                // exist, so the key would silently be null for every document and collapse the whole collection into
+                // one group. Refuse instead.
+                if (ctx.registeredAccumulatorsByVN.size() != accumulatorsBefore) {
+                    throw new FeatureNotSupportedException("An aggregate function is not allowed in GROUP BY");
+                }
                 ctx.registeredGroupKeyByVN.put(ctx.vnRegistry.valueNumber(expr), groupKey);
                 specs.add(new AstGroupStageSpecification(groupKey, expr));
             }
@@ -1321,11 +1344,9 @@ public abstract class AbstractMqlTranslator<T extends JdbcOperation> implements 
      * the same expression.
      */
     private static Expression resolveSelectedExpression(Expression expression) {
-        var resolved = expression;
-        while (resolved instanceof SqlSelectionExpression selection) {
-            resolved = selection.getSelection().getExpression();
-        }
-        return resolved;
+        return expression instanceof SqlSelectionExpression selection
+                ? selection.getSelection().getExpression()
+                : expression;
     }
 
     @Override
@@ -1795,13 +1816,14 @@ public abstract class AbstractMqlTranslator<T extends JdbcOperation> implements 
                 var accumulatorReference = tryRegisterAccumulator(sqlAstExpression);
                 if (accumulatorReference != null) {
                     astVisitorValueHolder.yield(EXPRESSION, accumulatorReference);
-                    return;
+                } else {
+                    // a function call as an operand within an aggregation expression is not yet supported
+                    throw new FeatureNotSupportedException(
+                            "TODO-HIBERNATE-196 https://jira.mongodb.org/browse/HIBERNATE-196");
                 }
-                // a function call as an operand within an aggregation expression is not yet supported
-                throw new FeatureNotSupportedException(
-                        "TODO-HIBERNATE-196 https://jira.mongodb.org/browse/HIBERNATE-196");
+            } else {
+                selfRenderingExpression.renderToSql(FeatureNotSupportedSqlAppender.INSTANCE, this, sessionFactory);
             }
-            selfRenderingExpression.renderToSql(FeatureNotSupportedSqlAppender.INSTANCE, this, sessionFactory);
         } else {
             throw new FeatureNotSupportedException("Only function expressions are supported");
         }
@@ -1845,39 +1867,37 @@ public abstract class AbstractMqlTranslator<T extends JdbcOperation> implements 
         if (ctx == null || !(function instanceof AggregateFunctionExpression aggregate)) {
             return null;
         }
-        // FILTER (WHERE ...) has no `$group` counterpart, and every accumulator below takes exactly one argument.
-        if (aggregate.getFilter() != null || function.getArguments().size() != 1) {
+        // HQL's FILTER (WHERE ...) restricts which rows an aggregate sees, which no `$group` accumulator can express
+        // directly. Refused rather than translated; there is no arity check alongside it because Hibernate ORM
+        // validates the argument count of these functions itself, before translation.
+        if (aggregate.getFilter() != null) {
             return null;
         }
         var argument = function.getArguments().get(0);
         if (argument instanceof Distinct) {
             throw new FeatureNotSupportedException("DISTINCT within an aggregate function is not supported");
         }
-        // The result BSON type has to be the one Hibernate infers for the function and reads the column back as,
-        // which is not always what the accumulator would produce: `$sum` over `int` fields yields an int, while
-        // `sum()` over them is a `Long` in HQL. Casting the accumulator's argument pins the width, since MongoDB
-        // requires the accumulator itself to be the outermost operator.
-        var resultCast = resultTypeCast(function);
         var accumulator =
                 switch (function.getFunctionName().toLowerCase(Locale.ROOT)) {
-                    case "count" ->
-                        new AstAccumulatorExpression(
-                                AstAccumulatorOperator.SUM, cast(countedValue(argument), resultCast));
+                    case "count" -> new AstAccumulatorExpression(AstAccumulatorOperator.SUM, countedValue(argument));
                     case "sum" ->
-                        new AstAccumulatorExpression(
-                                AstAccumulatorOperator.SUM, cast(acceptAndYieldArgument(argument), resultCast));
+                        new AstAccumulatorExpression(AstAccumulatorOperator.SUM, acceptAndYieldArgument(argument));
                     case "avg" ->
-                        new AstAccumulatorExpression(
-                                AstAccumulatorOperator.AVG, cast(acceptAndYieldArgument(argument), resultCast));
+                        new AstAccumulatorExpression(AstAccumulatorOperator.AVG, acceptAndYieldArgument(argument));
                     case "min" ->
-                        new AstAccumulatorExpression(
-                                AstAccumulatorOperator.MIN, cast(acceptAndYieldArgument(argument), resultCast));
+                        new AstAccumulatorExpression(AstAccumulatorOperator.MIN, acceptAndYieldArgument(argument));
                     case "max" ->
-                        new AstAccumulatorExpression(
-                                AstAccumulatorOperator.MAX, cast(acceptAndYieldArgument(argument), resultCast));
+                        new AstAccumulatorExpression(AstAccumulatorOperator.MAX, acceptAndYieldArgument(argument));
                     default -> null;
                 };
-        return accumulator == null ? null : new AstFieldPathExpression(registerAccumulator(ctx, accumulator));
+        if (accumulator == null) {
+            return null;
+        }
+        // The BSON type the accumulator produces is not always the one Hibernate ORM inferred for the function and
+        // will read the column back as: `$sum` over `int` fields yields an int, while HQL's `sum()` over them is a
+        // `Long`. The conversion is recorded against the accumulator's field and applied in `$project`, the only
+        // position where the type matters; see AccumulatorResultCastRule for why it cannot live inside `$group`.
+        return new AstFieldPathExpression(registerAccumulator(ctx, accumulator, resultTypeCast(function)));
     }
 
     private AstExpression acceptAndYieldArgument(SqlAstNode argument) {
@@ -1902,11 +1922,6 @@ public abstract class AbstractMqlTranslator<T extends JdbcOperation> implements 
                 List.of(new AstSwitchCase(isNull, new AstValueExpression(new AstLiteral(new BsonInt32(0))))), one);
     }
 
-    private static AstExpression cast(
-            AstExpression expression, @Nullable AstConversionExpressionOperator conversionOperator) {
-        return conversionOperator == null ? expression : new AstUnaryOperatorExpression(conversionOperator, expression);
-    }
-
     /** The conversion producing the BSON type of {@code expression}'s inferred result type, or {@code null}. */
     private static @Nullable AstConversionExpressionOperator resultTypeCast(Expression expression) {
         var expressionType = expression.getExpressionType();
@@ -1923,7 +1938,10 @@ public abstract class AbstractMqlTranslator<T extends JdbcOperation> implements 
     }
 
     /** Returns the {@code $group} output field name of {@code accumulator}, registering it if it is new. */
-    private static String registerAccumulator(GroupByContext ctx, AstAccumulatorExpression accumulator) {
+    private static String registerAccumulator(
+            GroupByContext ctx,
+            AstAccumulatorExpression accumulator,
+            @Nullable AstConversionExpressionOperator resultCast) {
         var valueNumber = ctx.vnRegistry.valueNumber(accumulator);
         var registered = ctx.registeredAccumulatorsByVN.get(valueNumber);
         if (registered != null) {
@@ -1933,6 +1951,9 @@ public abstract class AbstractMqlTranslator<T extends JdbcOperation> implements 
         ctx.registeredAccumulatorsByVN.put(
                 valueNumber, new AstGroupStageAccumulatorSpecification(fieldName, accumulator));
         ctx.accumulatorFieldNames.add(fieldName);
+        if (resultCast != null) {
+            ctx.accumulatorResultCasts.put(fieldName, resultCast);
+        }
         return fieldName;
     }
 

--- a/src/main/java/com/mongodb/hibernate/internal/translate/AbstractMqlTranslator.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/AbstractMqlTranslator.java
@@ -98,6 +98,7 @@ import com.mongodb.hibernate.internal.translate.mongoast.command.AstUpdateComman
 import com.mongodb.hibernate.internal.translate.mongoast.command.AstUpdateStatement;
 import com.mongodb.hibernate.internal.translate.mongoast.command.aggregate.AstAggregateCommand;
 import com.mongodb.hibernate.internal.translate.mongoast.command.aggregate.AstGroupStage;
+import com.mongodb.hibernate.internal.translate.mongoast.command.aggregate.AstGroupStageAccumulatorSpecification;
 import com.mongodb.hibernate.internal.translate.mongoast.command.aggregate.AstGroupStageSpecification;
 import com.mongodb.hibernate.internal.translate.mongoast.command.aggregate.AstLetVariable;
 import com.mongodb.hibernate.internal.translate.mongoast.command.aggregate.AstLimitStage;
@@ -440,7 +441,8 @@ public abstract class AbstractMqlTranslator<T extends JdbcOperation> implements 
          * makes the same aggregate function appearing in both SELECT and HAVING resolve to one {@code $group} field.
          * Ordered so that {@code $group} renders them in registration order, keeping the pipeline deterministic.
          */
-        final LinkedHashMap<Integer, AstGroupStageSpecification> registeredAccumulatorsByVN = new LinkedHashMap<>();
+        final LinkedHashMap<Integer, AstGroupStageAccumulatorSpecification> registeredAccumulatorsByVN =
+                new LinkedHashMap<>();
 
         /** The names of the registered accumulators, for {@link GroupBySubstitutionRule}'s whitelist. */
         final Set<String> accumulatorFieldNames = new HashSet<>();
@@ -1928,7 +1930,8 @@ public abstract class AbstractMqlTranslator<T extends JdbcOperation> implements 
             return registered.key();
         }
         var fieldName = ACCUMULATOR_FIELD_PREFIX + ctx.registeredAccumulatorsByVN.size();
-        ctx.registeredAccumulatorsByVN.put(valueNumber, new AstGroupStageSpecification(fieldName, accumulator));
+        ctx.registeredAccumulatorsByVN.put(
+                valueNumber, new AstGroupStageAccumulatorSpecification(fieldName, accumulator));
         ctx.accumulatorFieldNames.add(fieldName);
         return fieldName;
     }

--- a/src/main/java/com/mongodb/hibernate/internal/translate/AbstractMqlTranslator.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/AbstractMqlTranslator.java
@@ -1789,6 +1789,16 @@ public abstract class AbstractMqlTranslator<T extends JdbcOperation> implements 
     private static final String ACCUMULATOR_FIELD_PREFIX = "#acc_";
 
     /**
+     * HQL's statistical aggregate functions, which we do not translate yet.
+     *
+     * <p>Hibernate does not model these as {@link AggregateFunctionExpression}s the way it does {@code sum} and
+     * friends, so they reach {@link #tryRegisterAccumulator} as ordinary self-rendering functions and would otherwise
+     * fall through to the generic unsupported-function error.
+     */
+    private static final Set<String> STATISTICAL_AGGREGATE_FUNCTION_NAMES =
+            Set.of("stddev", "stddev_pop", "stddev_samp", "variance", "var_pop", "var_samp");
+
+    /**
      * Recognizes an aggregate function in SELECT, HAVING or ORDER BY under a GROUP BY, registers it as an accumulator
      * on the GROUP BY context, and returns a reference to the {@code $group} output field holding its value — the form
      * in which every later stage of the pipeline refers to it.
@@ -1803,6 +1813,12 @@ public abstract class AbstractMqlTranslator<T extends JdbcOperation> implements 
      * unsupported-feature error.
      */
     private @Nullable AstFieldPathExpression tryRegisterAccumulator(SelfRenderingFunctionSqlAstExpression<?> function) {
+        // Checked before anything else so that the diagnostic is the same with or without a GROUP BY clause: the
+        // function itself is the blocker either way.
+        if (STATISTICAL_AGGREGATE_FUNCTION_NAMES.contains(
+                function.getFunctionName().toLowerCase(Locale.ROOT))) {
+            throw new FeatureNotSupportedException("TODO-HIBERNATE-257 https://jira.mongodb.org/browse/HIBERNATE-257");
+        }
         var ctx = groupByContext;
         if (ctx == null || !(function instanceof AggregateFunctionExpression aggregate)) {
             return null;

--- a/src/main/java/com/mongodb/hibernate/internal/translate/AbstractMqlTranslator.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/AbstractMqlTranslator.java
@@ -1864,19 +1864,26 @@ public abstract class AbstractMqlTranslator<T extends JdbcOperation> implements 
                 function.getFunctionName().toLowerCase(Locale.ROOT))) {
             throw new FeatureNotSupportedException("TODO-HIBERNATE-257 https://jira.mongodb.org/browse/HIBERNATE-257");
         }
-        var ctx = groupByContext;
-        if (ctx == null || !(function instanceof AggregateFunctionExpression aggregate)) {
+        if (!(function instanceof AggregateFunctionExpression aggregate)) {
+            // Not an aggregate at all, so the caller's function-as-operand error is the accurate one.
             return null;
         }
-        // HQL's FILTER (WHERE ...) restricts which rows an aggregate sees, which no `$group` accumulator can express
-        // directly. Refused rather than translated; there is no arity check alongside it because Hibernate ORM
-        // validates the argument count of these functions itself, before translation.
+        var ctx = groupByContext;
+        if (ctx == null) {
+            // An aggregate with no GROUP BY groups the whole collection, which `$group` expresses with a null `_id`;
+            // not implemented yet, so it is refused here rather than reported as an unsupported function.
+            throw new FeatureNotSupportedException("TODO-HIBERNATE-262 https://jira.mongodb.org/browse/HIBERNATE-262");
+        }
+        // HQL's FILTER (WHERE ...) restricts which rows an aggregate sees. A `$group` accumulator has no filter of
+        // its own, but the same effect is reachable by making the argument yield nothing for the excluded rows, since
+        // every accumulator ignores nulls; not implemented yet. There is no arity check alongside this, because
+        // Hibernate ORM validates the argument count of these functions itself, before translation.
         if (aggregate.getFilter() != null) {
-            return null;
+            throw new FeatureNotSupportedException("TODO-HIBERNATE-260 https://jira.mongodb.org/browse/HIBERNATE-260");
         }
         var argument = function.getArguments().get(0);
         if (argument instanceof Distinct) {
-            throw new FeatureNotSupportedException("DISTINCT within an aggregate function is not supported");
+            throw new FeatureNotSupportedException("TODO-HIBERNATE-259 https://jira.mongodb.org/browse/HIBERNATE-259");
         }
         var accumulator =
                 switch (function.getFunctionName().toLowerCase(Locale.ROOT)) {
@@ -1889,11 +1896,17 @@ public abstract class AbstractMqlTranslator<T extends JdbcOperation> implements 
                         new AstAccumulatorExpression(AstAccumulatorOperator.MIN, acceptAndYieldArgument(argument));
                     case "max" ->
                         new AstAccumulatorExpression(AstAccumulatorOperator.MAX, acceptAndYieldArgument(argument));
-                    default -> null;
+                    // HQL's `some` is a synonym of `any`, and arrives under that name. Both are translatable ---
+                    // `$max`/`$min` over the predicate's boolean value would do it --- but are not implemented.
+                    case "every", "any" ->
+                        throw new FeatureNotSupportedException(
+                                "TODO-HIBERNATE-261 https://jira.mongodb.org/browse/HIBERNATE-261");
+                    // Anything else Hibernate ORM models as an aggregate function: nothing is promised for these,
+                    // so the message names the function rather than a ticket.
+                    default ->
+                        throw new FeatureNotSupportedException(
+                                "Aggregate function is not supported: " + function.getFunctionName());
                 };
-        if (accumulator == null) {
-            return null;
-        }
         // The BSON type the accumulator produces is not always the one Hibernate ORM inferred for the function and
         // will read the column back as: `$sum` over `int` fields yields an int, while HQL's `sum()` over them is a
         // `Long`. The conversion is recorded against the accumulator's field and applied in `$project`, the only

--- a/src/main/java/com/mongodb/hibernate/internal/translate/AbstractMqlTranslator.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/AbstractMqlTranslator.java
@@ -62,6 +62,8 @@ import com.mongodb.hibernate.internal.FeatureNotSupportedException;
 import com.mongodb.hibernate.internal.dialect.function.ExpressionFunction;
 import com.mongodb.hibernate.internal.dialect.function.array.MongoUnnestFunction;
 import com.mongodb.hibernate.internal.service.StandardServiceRegistryScopedState;
+import com.mongodb.hibernate.internal.translate.mongoast.AstAccumulatorExpression;
+import com.mongodb.hibernate.internal.translate.mongoast.AstAccumulatorOperator;
 import com.mongodb.hibernate.internal.translate.mongoast.AstArithmeticExpressionOperator;
 import com.mongodb.hibernate.internal.translate.mongoast.AstBinaryOperatorExpression;
 import com.mongodb.hibernate.internal.translate.mongoast.AstComparisonExpressionOperator;
@@ -138,7 +140,9 @@ import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -181,6 +185,7 @@ import org.hibernate.sql.ast.tree.Statement;
 import org.hibernate.sql.ast.tree.cte.CteContainer;
 import org.hibernate.sql.ast.tree.delete.DeleteStatement;
 import org.hibernate.sql.ast.tree.expression.AggregateColumnWriteExpression;
+import org.hibernate.sql.ast.tree.expression.AggregateFunctionExpression;
 import org.hibernate.sql.ast.tree.expression.Any;
 import org.hibernate.sql.ast.tree.expression.BinaryArithmeticExpression;
 import org.hibernate.sql.ast.tree.expression.CaseSearchedExpression;
@@ -422,13 +427,23 @@ public abstract class AbstractMqlTranslator<T extends JdbcOperation> implements 
     private @Nullable AstRewriter astRewriter;
 
     /**
-     * Per-query GROUP BY state: the VN registry and the group-key-to-sub-key map. Created by {@link #createGroupStage}
-     * when the query has a GROUP BY clause; {@code null} otherwise. When sub-queries are supported, this should be
-     * pushed/popped on a stack.
+     * Per-query GROUP BY state: the VN registry, the group-key-to-sub-key map, and the accumulators registered while
+     * translating SELECT/HAVING/ORDER BY. Created by {@link #prepareGroupBy} when the query has a GROUP BY clause;
+     * {@code null} otherwise. When sub-queries are supported, this should be pushed/popped on a stack.
      */
     static final class GroupByContext {
         final VNRegistry vnRegistry = new VNRegistry();
         final Map<Integer, String> registeredGroupKeyByVN = new HashMap<>();
+
+        /**
+         * Registered accumulators keyed by the value number of the {@link AstAccumulatorExpression}, which is what
+         * makes the same aggregate function appearing in both SELECT and HAVING resolve to one {@code $group} field.
+         * Ordered so that {@code $group} renders them in registration order, keeping the pipeline deterministic.
+         */
+        final LinkedHashMap<Integer, AstGroupStageSpecification> registeredAccumulatorsByVN = new LinkedHashMap<>();
+
+        /** The names of the registered accumulators, for {@link GroupBySubstitutionRule}'s whitelist. */
+        final Set<String> accumulatorFieldNames = new HashSet<>();
     }
 
     // Per-query counter for naming $lookup `let` variables; see nextLetVariableName.
@@ -693,30 +708,34 @@ public abstract class AbstractMqlTranslator<T extends JdbcOperation> implements 
         stages.addAll(buildJoinStages(root));
 
         createMatchStage(querySpec.getWhereClauseRestrictions()).ifPresent(stages::add);
-        var groupStage = createGroupStage(querySpec);
+        var groupIdSpecs = prepareGroupBy(querySpec);
 
-        if (groupStage.isPresent()) {
+        // SELECT, HAVING and ORDER BY are translated before `$group` is assembled, even though `$group` precedes all
+        // three in the pipeline: an aggregate function in any of them registers an accumulator on the GROUP BY
+        // context, and `$group` has to render every accumulator they introduced. Translation order is therefore not
+        // stage order here; the stages are appended below in stage order regardless.
+        AstStage projectStage = createProjectStage(querySpec.getSelectClause());
+        Optional<? extends AstStage> havingStage = createMatchStage(querySpec.getHavingClauseRestrictions());
+        Optional<? extends AstStage> sortStage = createSortStage(querySpec);
+
+        if (groupIdSpecs != null) {
             var ctx = assertNotNull(groupByContext);
+            stages.add(new AstGroupStage(groupIdSpecs, List.copyOf(ctx.registeredAccumulatorsByVN.values())));
             astRewriter = new AstRewriter(
-                    new GroupBySubstitutionRule(ctx.registeredGroupKeyByVN, ctx.vnRegistry),
+                    new GroupBySubstitutionRule(ctx.registeredGroupKeyByVN, ctx.vnRegistry, ctx.accumulatorFieldNames),
                     new ExprToMatchDowngradeRule());
+            havingStage = havingStage.map(astRewriter::rewrite);
+            sortStage = sortStage.map(astRewriter::rewrite);
+            projectStage = astRewriter.rewrite(projectStage);
         }
-        groupStage.ifPresent(stages::add);
-        createMatchStage(querySpec.getHavingClauseRestrictions())
-                .map(ms -> astRewriter != null ? astRewriter.rewrite(ms) : ms)
-                .ifPresent(stages::add);
-        createSortStage(querySpec)
-                .map(ss -> astRewriter != null ? astRewriter.rewrite(ss) : ss)
-                .ifPresent(stages::add);
+
+        havingStage.ifPresent(stages::add);
+        sortStage.ifPresent(stages::add);
 
         var skipLimitStagesAndJdbcParams =
                 assertNotNull(queryOptionsLimit).createSkipLimitStagesAndJdbcParams(querySpec);
         stages.addAll(skipLimitStagesAndJdbcParams.stages());
 
-        AstStage projectStage = createProjectStage(querySpec.getSelectClause());
-        if (astRewriter != null) {
-            projectStage = astRewriter.rewrite(projectStage);
-        }
         stages.add(projectStage);
 
         astVisitorValueHolder.yield(
@@ -728,9 +747,14 @@ public abstract class AbstractMqlTranslator<T extends JdbcOperation> implements 
                         skipLimitStagesAndJdbcParams.limit()));
     }
 
-    private Optional<AstGroupStage> createGroupStage(final QuerySpec querySpec) {
+    /**
+     * Establishes the GROUP BY context and translates the GROUP BY keys into the {@code _id} sub-key specifications,
+     * returning them for {@link #visitQuerySpec} to combine with the accumulators registered afterwards. Returns
+     * {@code null} when the query has no GROUP BY clause.
+     */
+    private @Nullable List<AstGroupStageSpecification> prepareGroupBy(final QuerySpec querySpec) {
         if (querySpec.getGroupByClauseExpressions().isEmpty()) {
-            return Optional.empty();
+            return null;
         }
         var ctx = new GroupByContext();
         groupByContext = ctx;
@@ -752,7 +776,7 @@ public abstract class AbstractMqlTranslator<T extends JdbcOperation> implements 
                 specs.add(new AstGroupStageSpecification(groupKey, expr));
             }
         }
-        return Optional.of(new AstGroupStage(specs));
+        return specs;
     }
 
     private Optional<AstMatchStage> createMatchStage(@Nullable Predicate restrictions) {
@@ -1263,6 +1287,14 @@ public abstract class AbstractMqlTranslator<T extends JdbcOperation> implements 
 
     private AstSortField createAstSortField(Expression sortExpression, AstSortOrder astSortOrder) {
         if (!isFieldPathExpression(sortExpression)) {
+            // An aggregate function is orderable under a GROUP BY: it resolves to the accumulator field $group
+            // computes, shared with SELECT/HAVING when they name the same function, so nothing is recomputed here.
+            if (sortExpression instanceof SelfRenderingFunctionSqlAstExpression<?> function) {
+                var accumulatorReference = tryRegisterAccumulator(function);
+                if (accumulatorReference != null) {
+                    return new AstSortField(accumulatorReference.fieldPath(), astSortOrder);
+                }
+            }
             // Under a GROUP BY, an expression $group has already computed is orderable in principle; with no GROUP BY
             // nothing has computed it, which is the wider problem.
             throw new FeatureNotSupportedException(
@@ -1738,6 +1770,11 @@ public abstract class AbstractMqlTranslator<T extends JdbcOperation> implements 
         if (selfRenderingExpression instanceof SelfRenderingFunctionSqlAstExpression<?> sqlAstExpression) {
             if (astVisitorValueHolder.expects(EXPRESSION)
                     && !(sqlAstExpression.getFunctionRenderer() instanceof ExpressionFunction)) {
+                var accumulatorReference = tryRegisterAccumulator(sqlAstExpression);
+                if (accumulatorReference != null) {
+                    astVisitorValueHolder.yield(EXPRESSION, accumulatorReference);
+                    return;
+                }
                 // a function call as an operand within an aggregation expression is not yet supported
                 throw new FeatureNotSupportedException(
                         "TODO-HIBERNATE-196 https://jira.mongodb.org/browse/HIBERNATE-196");
@@ -1746,6 +1783,118 @@ public abstract class AbstractMqlTranslator<T extends JdbcOperation> implements 
         } else {
             throw new FeatureNotSupportedException("Only function expressions are supported");
         }
+    }
+
+    /** The prefix of a {@code $group} accumulator output field; {@code #} cannot occur in a mapped column name. */
+    private static final String ACCUMULATOR_FIELD_PREFIX = "#acc_";
+
+    /**
+     * Recognizes an aggregate function in SELECT, HAVING or ORDER BY under a GROUP BY, registers it as an accumulator
+     * on the GROUP BY context, and returns a reference to the {@code $group} output field holding its value — the form
+     * in which every later stage of the pipeline refers to it.
+     *
+     * <p>Registration is keyed by the accumulator's value number, so the same aggregate function written in two clauses
+     * shares one {@code $group} field. An aggregate appearing only in HAVING is thereby computed for the filter without
+     * ever being projected: {@code $project} lists only what SELECT asked for, and its inclusion semantics drop the
+     * rest.
+     *
+     * <p>Returns {@code null} when the expression is not an aggregate function this translator supports, or when the
+     * query has no GROUP BY clause for the accumulator to belong to, leaving the caller to raise its own
+     * unsupported-feature error.
+     */
+    private @Nullable AstFieldPathExpression tryRegisterAccumulator(SelfRenderingFunctionSqlAstExpression<?> function) {
+        var ctx = groupByContext;
+        if (ctx == null || !(function instanceof AggregateFunctionExpression aggregate)) {
+            return null;
+        }
+        // FILTER (WHERE ...) has no `$group` counterpart, and every accumulator below takes exactly one argument.
+        if (aggregate.getFilter() != null || function.getArguments().size() != 1) {
+            return null;
+        }
+        var argument = function.getArguments().get(0);
+        if (argument instanceof Distinct) {
+            throw new FeatureNotSupportedException("DISTINCT within an aggregate function is not supported");
+        }
+        // The result BSON type has to be the one Hibernate infers for the function and reads the column back as,
+        // which is not always what the accumulator would produce: `$sum` over `int` fields yields an int, while
+        // `sum()` over them is a `Long` in HQL. Casting the accumulator's argument pins the width, since MongoDB
+        // requires the accumulator itself to be the outermost operator.
+        var resultCast = resultTypeCast(function);
+        var accumulator =
+                switch (function.getFunctionName().toLowerCase(Locale.ROOT)) {
+                    case "count" ->
+                        new AstAccumulatorExpression(
+                                AstAccumulatorOperator.SUM, cast(countedValue(argument), resultCast));
+                    case "sum" ->
+                        new AstAccumulatorExpression(
+                                AstAccumulatorOperator.SUM, cast(acceptAndYieldArgument(argument), resultCast));
+                    case "avg" ->
+                        new AstAccumulatorExpression(
+                                AstAccumulatorOperator.AVG, cast(acceptAndYieldArgument(argument), resultCast));
+                    case "min" ->
+                        new AstAccumulatorExpression(
+                                AstAccumulatorOperator.MIN, cast(acceptAndYieldArgument(argument), resultCast));
+                    case "max" ->
+                        new AstAccumulatorExpression(
+                                AstAccumulatorOperator.MAX, cast(acceptAndYieldArgument(argument), resultCast));
+                    default -> null;
+                };
+        return accumulator == null ? null : new AstFieldPathExpression(registerAccumulator(ctx, accumulator));
+    }
+
+    private AstExpression acceptAndYieldArgument(SqlAstNode argument) {
+        return acceptAndYieldExpression(assertInstanceOf(argument, Expression.class));
+    }
+
+    /**
+     * The per-document contribution to a {@code COUNT}: {@code 1} for {@code COUNT(*)}, and for {@code COUNT(x)} the
+     * {@code 1} that SQL counts only when {@code x} is not null. A missing field compares equal to {@code null} in an
+     * aggregation expression, so one comparison covers both absent and explicitly null.
+     */
+    private AstExpression countedValue(SqlAstNode argument) {
+        var one = new AstValueExpression(new AstLiteral(new BsonInt32(1)));
+        if (argument instanceof Star) {
+            return one;
+        }
+        var isNull = new AstBinaryOperatorExpression(
+                AstComparisonExpressionOperator.EQ,
+                acceptAndYieldArgument(argument),
+                new AstValueExpression(new AstLiteral(BsonNull.VALUE)));
+        return new AstSwitchExpression(
+                List.of(new AstSwitchCase(isNull, new AstValueExpression(new AstLiteral(new BsonInt32(0))))), one);
+    }
+
+    private static AstExpression cast(
+            AstExpression expression, @Nullable AstConversionExpressionOperator conversionOperator) {
+        return conversionOperator == null ? expression : new AstUnaryOperatorExpression(conversionOperator, expression);
+    }
+
+    /** The conversion producing the BSON type of {@code expression}'s inferred result type, or {@code null}. */
+    private static @Nullable AstConversionExpressionOperator resultTypeCast(Expression expression) {
+        var expressionType = expression.getExpressionType();
+        if (expressionType == null || expressionType.getJdbcTypeCount() != 1) {
+            return null;
+        }
+        return switch (expressionType.getSingleJdbcMapping().getJdbcType().getDdlTypeCode()) {
+            case SqlTypes.TINYINT, SqlTypes.SMALLINT, SqlTypes.INTEGER -> AstConversionExpressionOperator.TO_INT;
+            case SqlTypes.BIGINT -> AstConversionExpressionOperator.TO_LONG;
+            case SqlTypes.REAL, SqlTypes.FLOAT, SqlTypes.DOUBLE -> AstConversionExpressionOperator.TO_DOUBLE;
+            case SqlTypes.DECIMAL, SqlTypes.NUMERIC -> AstConversionExpressionOperator.TO_DECIMAL;
+            default -> null;
+        };
+    }
+
+    /** Returns the {@code $group} output field name of {@code accumulator}, registering it if it is new. */
+    private static String registerAccumulator(GroupByContext ctx, AstAccumulatorExpression accumulator) {
+        var valueNumber = ctx.vnRegistry.valueNumber(accumulator);
+        var registered = ctx.registeredAccumulatorsByVN.get(valueNumber);
+        if (registered != null) {
+            return registered.key();
+        }
+        var fieldName = ACCUMULATOR_FIELD_PREFIX + ctx.registeredAccumulatorsByVN.size();
+        ctx.registeredAccumulatorsByVN.put(valueNumber, new AstGroupStageSpecification(fieldName, accumulator));
+        ctx.accumulatorFieldNames.add(fieldName);
+        return fieldName;
     }
 
     @Override

--- a/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/AstAccumulatorExpression.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/AstAccumulatorExpression.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2026-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.hibernate.internal.translate.mongoast;
+
+import java.util.List;
+import java.util.function.Consumer;
+import org.bson.BsonWriter;
+import org.hibernate.sql.exec.spi.JdbcParameterBinder;
+
+/**
+ * A MongoDB {@code $group}-stage accumulator applied to a single argument, e.g. {@code {$sum: <expr>}}. Rendered in
+ * value position so it can appear as the right-hand side of an
+ * {@link com.mongodb.hibernate.internal.translate.mongoast.command.aggregate.AstGroupStageSpecification} in the
+ * accumulator slot of an {@link com.mongodb.hibernate.internal.translate.mongoast.command.aggregate.AstGroupStage}.
+ *
+ * <p>An accumulator is only meaningful as the top-level operator of such a specification: MongoDB does not allow one to
+ * be nested inside an ordinary aggregation expression. The translator never builds one anywhere else.
+ *
+ * @param operator the accumulator to apply
+ * @param argument the single expression the accumulator is applied to
+ * @hidden
+ */
+@SuppressWarnings("MissingSummary")
+public record AstAccumulatorExpression(AstAccumulatorOperator operator, AstExpression argument)
+        implements AstExpression {
+
+    @Override
+    public StructuralKey structuralKey() {
+        return new StructuralKey("Accumulator", List.of(operator, argument));
+    }
+
+    @Override
+    public AstExpression mapChildren(AstNodeRewriter rewriter) {
+        return new AstAccumulatorExpression(operator, rewriter.rewrite(argument));
+    }
+
+    @Override
+    public void render(BsonWriter writer, Consumer<JdbcParameterBinder> binderConsumer) {
+        writer.writeStartDocument();
+        writer.writeName(operator.getOperatorName());
+        argument.render(writer, binderConsumer);
+        writer.writeEndDocument();
+    }
+}

--- a/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/AstAccumulatorExpression.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/AstAccumulatorExpression.java
@@ -22,13 +22,13 @@ import org.bson.BsonWriter;
 import org.hibernate.sql.exec.spi.JdbcParameterBinder;
 
 /**
- * A MongoDB {@code $group}-stage accumulator applied to a single argument, e.g. {@code {$sum: <expr>}}. Rendered in
- * value position so it can appear as the right-hand side of an
- * {@link com.mongodb.hibernate.internal.translate.mongoast.command.aggregate.AstGroupStageSpecification} in the
- * accumulator slot of an {@link com.mongodb.hibernate.internal.translate.mongoast.command.aggregate.AstGroupStage}.
+ * A MongoDB {@code $group}-stage accumulator applied to a single argument, e.g. {@code {$sum: <expr>}}.
  *
- * <p>An accumulator is only meaningful as the top-level operator of such a specification: MongoDB does not allow one to
- * be nested inside an ordinary aggregation expression. The translator never builds one anywhere else.
+ * <p>Only meaningful as the accumulator of an
+ * {@link com.mongodb.hibernate.internal.translate.mongoast.command.aggregate.AstGroupStageAccumulatorSpecification},
+ * which is the only place the translator builds one. MongoDB requires an accumulator to be the outermost operator of a
+ * {@code $group} field and rejects one nested inside an ordinary aggregation expression: {@code {"$toLong": {"$count":
+ * {}}}} fails with {@code unknown group operator '$toLong'}.
  *
  * @param operator the accumulator to apply
  * @param argument the single expression the accumulator is applied to

--- a/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/AstAccumulatorExpression.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/AstAccumulatorExpression.java
@@ -27,8 +27,7 @@ import org.hibernate.sql.exec.spi.JdbcParameterBinder;
  * <p>Only meaningful as the accumulator of an
  * {@link com.mongodb.hibernate.internal.translate.mongoast.command.aggregate.AstGroupStageAccumulatorSpecification},
  * which is the only place the translator builds one. MongoDB requires an accumulator to be the outermost operator of a
- * {@code $group} field and rejects one nested inside an ordinary aggregation expression: {@code {"$toLong": {"$count":
- * {}}}} fails with {@code unknown group operator '$toLong'}.
+ * {@code $group} field: {@code {"$toLong": {"$count": {}}}} fails with {@code unknown group operator '$toLong'}.
  *
  * @param operator the accumulator to apply
  * @param argument the single expression the accumulator is applied to

--- a/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/AstAccumulatorExpression.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/AstAccumulatorExpression.java
@@ -43,8 +43,9 @@ public record AstAccumulatorExpression(AstAccumulatorOperator operator, AstExpre
         return new StructuralKey("Accumulator", List.of(operator, argument));
     }
 
+    /** Narrowed so that a specification holding an accumulator can rebuild itself without casting. */
     @Override
-    public AstExpression mapChildren(AstNodeRewriter rewriter) {
+    public AstAccumulatorExpression mapChildren(AstNodeRewriter rewriter) {
         return new AstAccumulatorExpression(operator, rewriter.rewrite(argument));
     }
 

--- a/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/AstAccumulatorOperator.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/AstAccumulatorOperator.java
@@ -25,8 +25,17 @@ package com.mongodb.hibernate.internal.translate.mongoast;
 @SuppressWarnings("MissingSummary")
 public enum AstAccumulatorOperator {
     /**
-     * See <a href="https://www.mongodb.com/docs/manual/reference/operator/aggregation/sum/">{@code $sum}</a>. Sum will
-     * also be used for count aggregate(E.g {"$sum": {"$toLong": 1}}) as MQL doesn't have a build in COUNT aggregate
+     * See <a href="https://www.mongodb.com/docs/manual/reference/operator/aggregation/sum/">{@code $sum}</a>.
+     *
+     * <p>HQL {@code count()} is also expressed with this operator, as {@code {"$sum": {"$toLong": <0 or 1>}}}, rather
+     * than with MQL's own <a
+     * href="https://www.mongodb.com/docs/manual/reference/operator/aggregation/count-accumulator/">{@code $count}</a>
+     * accumulator, for two reasons. {@code $count} takes no argument, so it cannot express {@code COUNT(x)}, which
+     * counts only the documents where {@code x} is not null. And it returns an {@code int}, while HQL types
+     * {@code count()} as a {@code Long}, so the result needs a widening cast that cannot be applied here: an
+     * accumulator has to be the outermost operator of a {@code $group} specification, and the server rejects
+     * {@code {"$toLong": {"$count": {}}}} with {@code unknown group operator '$toLong'}. Casting the argument of
+     * {@code $sum} instead keeps one code path for every aggregate function.
      */
     SUM("$sum"),
     /** See <a href="https://www.mongodb.com/docs/manual/reference/operator/aggregation/avg/">{@code $avg}</a>. */

--- a/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/AstAccumulatorOperator.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/AstAccumulatorOperator.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2026-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.hibernate.internal.translate.mongoast;
+
+/**
+ * A {@code $group}-stage accumulator operator, i.e. one that reduces the documents of a group to a single value.
+ *
+ * @see AstAccumulatorExpression
+ * @hidden
+ */
+@SuppressWarnings("MissingSummary")
+public enum AstAccumulatorOperator {
+    /**
+     * See <a href="https://www.mongodb.com/docs/manual/reference/operator/aggregation/sum/">{@code $sum}</a>. Sum will
+     * also be used for count aggregate(E.g {"$sum": {"$toLong": 1}}) as MQL doesn't have a build in COUNT aggregate
+     */
+    SUM("$sum"),
+    /** See <a href="https://www.mongodb.com/docs/manual/reference/operator/aggregation/avg/">{@code $avg}</a>. */
+    AVG("$avg"),
+    /** See <a href="https://www.mongodb.com/docs/manual/reference/operator/aggregation/min/">{@code $min}</a>. */
+    MIN("$min"),
+    /** See <a href="https://www.mongodb.com/docs/manual/reference/operator/aggregation/max/">{@code $max}</a>. */
+    MAX("$max");
+
+    AstAccumulatorOperator(String operatorName) {
+        this.operatorName = operatorName;
+    }
+
+    String getOperatorName() {
+        return operatorName;
+    }
+
+    private final String operatorName;
+}

--- a/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/AstConversionExpressionOperator.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/AstConversionExpressionOperator.java
@@ -17,8 +17,10 @@
 package com.mongodb.hibernate.internal.translate.mongoast;
 
 /**
- * A single-operand type-conversion operator in aggregation-expression position, used to truncate a division quotient to
- * an integral result type.
+ * A single-operand type-conversion operator in aggregation-expression position, used where the BSON type MongoDB would
+ * produce differs from the one Hibernate infers for the result and reads the column back as: truncating a division
+ * quotient to an integral result type, or pinning an accumulator's result to the width of the aggregate function's
+ * return type.
  *
  * @see AstUnaryOperatorExpression
  * @hidden
@@ -28,7 +30,16 @@ public enum AstConversionExpressionOperator {
     /** See <a href="https://www.mongodb.com/docs/manual/reference/operator/aggregation/toInt/">{@code $toInt}</a>. */
     TO_INT("$toInt"),
     /** See <a href="https://www.mongodb.com/docs/manual/reference/operator/aggregation/toLong/">{@code $toLong}</a>. */
-    TO_LONG("$toLong");
+    TO_LONG("$toLong"),
+    /**
+     * See <a href="https://www.mongodb.com/docs/manual/reference/operator/aggregation/toDouble/">{@code $toDouble}</a>.
+     */
+    TO_DOUBLE("$toDouble"),
+    /**
+     * See <a
+     * href="https://www.mongodb.com/docs/manual/reference/operator/aggregation/toDecimal/">{@code $toDecimal}</a>.
+     */
+    TO_DECIMAL("$toDecimal");
 
     AstConversionExpressionOperator(String operatorName) {
         this.operatorName = operatorName;

--- a/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/AstNodeRewriter.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/AstNodeRewriter.java
@@ -18,6 +18,7 @@ package com.mongodb.hibernate.internal.translate.mongoast;
 
 import com.mongodb.hibernate.internal.translate.mongoast.command.AstUpdate;
 import com.mongodb.hibernate.internal.translate.mongoast.command.AstUpdateStatement;
+import com.mongodb.hibernate.internal.translate.mongoast.command.aggregate.AstGroupStageAccumulatorSpecification;
 import com.mongodb.hibernate.internal.translate.mongoast.command.aggregate.AstGroupStageSpecification;
 import com.mongodb.hibernate.internal.translate.mongoast.command.aggregate.AstLetVariable;
 import com.mongodb.hibernate.internal.translate.mongoast.command.aggregate.AstProjectStageSpecification;
@@ -48,6 +49,10 @@ public interface AstNodeRewriter {
     AstProjectStageSpecification rewrite(AstProjectStageSpecification node);
 
     AstGroupStageSpecification rewrite(AstGroupStageSpecification node);
+
+    AstGroupStageAccumulatorSpecification rewrite(AstGroupStageAccumulatorSpecification node);
+
+    AstAccumulatorExpression rewrite(AstAccumulatorExpression node);
 
     AstLetVariable rewrite(AstLetVariable node);
 

--- a/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/command/aggregate/AstGroupStage.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/command/aggregate/AstGroupStage.java
@@ -20,6 +20,7 @@ import static com.mongodb.hibernate.internal.MongoAssertions.assertFalse;
 
 import com.mongodb.hibernate.internal.translate.mongoast.AstNodeRewriter;
 import java.util.Collection;
+import java.util.List;
 import java.util.function.Consumer;
 import org.bson.BsonWriter;
 import org.hibernate.sql.exec.spi.JdbcParameterBinder;
@@ -27,7 +28,7 @@ import org.hibernate.sql.exec.spi.JdbcParameterBinder;
 /**
  * Represents MongoDB's {@code $group} aggregation stage.
  *
- * <p>HQL: SELECT country FROM Contact GROUP BY country
+ * <p>HQL: SELECT country, SUM(sales) FROM Contact GROUP BY country
  *
  * <p>MongoDB:
  *
@@ -36,22 +37,34 @@ import org.hibernate.sql.exec.spi.JdbcParameterBinder;
  *   "$group": {
  *     "_id": {
  *       "country": "$country"
- *     }
+ *     },
+ *     "#acc_0": {"$sum": "$sales"}
  *   }
  * }
  * </pre>
  *
+ * @param specifications the {@code _id} sub-key specifications, one per GROUP BY key; must be non-empty
+ * @param accumulatorSpecifications the accumulator specifications, rendered as siblings of {@code _id}; may be empty
  * @hidden
  */
-public record AstGroupStage(Collection<? extends AstGroupStageSpecification> specifications) implements AstStage {
+public record AstGroupStage(
+        Collection<? extends AstGroupStageSpecification> specifications,
+        Collection<? extends AstGroupStageSpecification> accumulatorSpecifications)
+        implements AstStage {
 
     public AstGroupStage {
         assertFalse(specifications.isEmpty());
     }
 
+    public AstGroupStage(Collection<? extends AstGroupStageSpecification> specifications) {
+        this(specifications, List.of());
+    }
+
     @Override
     public AstStage mapChildren(AstNodeRewriter rewriter) {
-        return new AstGroupStage(specifications.stream().map(rewriter::rewrite).toList());
+        return new AstGroupStage(
+                specifications.stream().map(rewriter::rewrite).toList(),
+                accumulatorSpecifications.stream().map(rewriter::rewrite).toList());
     }
 
     @Override
@@ -67,6 +80,7 @@ public record AstGroupStage(Collection<? extends AstGroupStageSpecification> spe
                     specifications.forEach(specification -> specification.render(writer, binderConsumer));
                 }
                 writer.writeEndDocument();
+                accumulatorSpecifications.forEach(specification -> specification.render(writer, binderConsumer));
             }
             writer.writeEndDocument();
         }

--- a/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/command/aggregate/AstGroupStage.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/command/aggregate/AstGroupStage.java
@@ -44,12 +44,14 @@ import org.hibernate.sql.exec.spi.JdbcParameterBinder;
  * </pre>
  *
  * @param specifications the {@code _id} sub-key specifications, one per GROUP BY key; must be non-empty
- * @param accumulatorSpecifications the accumulator specifications, rendered as siblings of {@code _id}; may be empty
+ * @param accumulatorSpecifications the accumulator specifications, rendered as siblings of {@code _id}; may be empty.
+ *     Typed separately from {@code specifications} so the two slots cannot be confused; see
+ *     {@link AstGroupStageAccumulatorSpecification}.
  * @hidden
  */
 public record AstGroupStage(
         Collection<? extends AstGroupStageSpecification> specifications,
-        Collection<? extends AstGroupStageSpecification> accumulatorSpecifications)
+        Collection<? extends AstGroupStageAccumulatorSpecification> accumulatorSpecifications)
         implements AstStage {
 
     public AstGroupStage {

--- a/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/command/aggregate/AstGroupStageAccumulatorSpecification.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/command/aggregate/AstGroupStageAccumulatorSpecification.java
@@ -28,13 +28,16 @@ import org.hibernate.sql.exec.spi.JdbcParameterBinder;
  * "$sales"}}.
  *
  * <p>Distinct from {@link AstGroupStageSpecification}, which holds an arbitrary
- * {@link com.mongodb.hibernate.internal.translate.mongoast.AstExpression} for an {@code _id} sub-key, because the two
- * slots of a {@code $group} stage accept opposite things and MongoDB does not reject both mistakes the same way. A
- * non-accumulator among the siblings of {@code _id} fails loudly ({@code Location40234: The field '...' must be an
- * accumulator object}), but an accumulator inside {@code _id} is silently accepted and means something else entirely
- * --- {@code $sum} there is the aggregation expression rather than the accumulator, so the query groups by a different
- * value and returns wrong results with no error. Requiring an {@link AstAccumulatorExpression} here makes both
- * unrepresentable.
+ * {@link com.mongodb.hibernate.internal.translate.mongoast.AstExpression} for an {@code _id} sub-key. Requiring an
+ * {@link AstAccumulatorExpression} here keeps the two collections of {@link AstGroupStage} from being interchangeable,
+ * and stops a non-accumulator reaching the accumulator slot, which MongoDB rejects with {@code Location40234: The field
+ * '...' must be an accumulator object}.
+ *
+ * <p>It does not prevent the opposite mistake: an {@link AstAccumulatorExpression} is an
+ * {@link com.mongodb.hibernate.internal.translate.mongoast.AstExpression}, so it remains assignable to an {@code _id}
+ * sub-key. That case is worth knowing about because MongoDB accepts it --- {@code $sum} inside {@code _id} is the
+ * aggregation expression rather than the accumulator, so the query groups by a different value and returns wrong
+ * results with no error. Nothing in the translator constructs it.
  *
  * @param key the {@code $group} output field name
  * @param accumulator the accumulator producing that field's value

--- a/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/command/aggregate/AstGroupStageAccumulatorSpecification.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/mongoast/command/aggregate/AstGroupStageAccumulatorSpecification.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2026-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.hibernate.internal.translate.mongoast.command.aggregate;
+
+import com.mongodb.hibernate.internal.translate.mongoast.AstAccumulatorExpression;
+import com.mongodb.hibernate.internal.translate.mongoast.AstNode;
+import com.mongodb.hibernate.internal.translate.mongoast.AstNodeRewriter;
+import java.util.function.Consumer;
+import org.bson.BsonWriter;
+import org.hibernate.sql.exec.spi.JdbcParameterBinder;
+
+/**
+ * One accumulator field of a {@code $group} stage, rendered as a sibling of {@code _id}, e.g. {@code "#acc_0": {"$sum":
+ * "$sales"}}.
+ *
+ * <p>Distinct from {@link AstGroupStageSpecification}, which holds an arbitrary
+ * {@link com.mongodb.hibernate.internal.translate.mongoast.AstExpression} for an {@code _id} sub-key, because the two
+ * slots of a {@code $group} stage accept opposite things and MongoDB does not reject both mistakes the same way. A
+ * non-accumulator among the siblings of {@code _id} fails loudly ({@code Location40234: The field '...' must be an
+ * accumulator object}), but an accumulator inside {@code _id} is silently accepted and means something else entirely
+ * --- {@code $sum} there is the aggregation expression rather than the accumulator, so the query groups by a different
+ * value and returns wrong results with no error. Requiring an {@link AstAccumulatorExpression} here makes both
+ * unrepresentable.
+ *
+ * @param key the {@code $group} output field name
+ * @param accumulator the accumulator producing that field's value
+ * @hidden
+ */
+@SuppressWarnings("MissingSummary")
+public record AstGroupStageAccumulatorSpecification(String key, AstAccumulatorExpression accumulator)
+        implements AstNode {
+
+    /** Returns a copy of this specification with {@code rewriter} applied to its accumulator. */
+    @Override
+    public AstGroupStageAccumulatorSpecification mapChildren(AstNodeRewriter rewriter) {
+        return new AstGroupStageAccumulatorSpecification(key, rewriter.rewrite(accumulator));
+    }
+
+    @Override
+    public void render(BsonWriter writer, Consumer<JdbcParameterBinder> binderConsumer) {
+        writer.writeName(key);
+        accumulator.render(writer, binderConsumer);
+    }
+}

--- a/src/main/java/com/mongodb/hibernate/internal/translate/rewrite/AccumulatorResultCastRule.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/rewrite/AccumulatorResultCastRule.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2026-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.hibernate.internal.translate.rewrite;
+
+import com.mongodb.hibernate.internal.translate.mongoast.AstConversionExpressionOperator;
+import com.mongodb.hibernate.internal.translate.mongoast.AstExpression;
+import com.mongodb.hibernate.internal.translate.mongoast.AstFieldPathExpression;
+import com.mongodb.hibernate.internal.translate.mongoast.AstUnaryOperatorExpression;
+import java.util.Map;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Pre-rule that wraps a reference to a {@code $group} accumulator in the conversion that makes it read back as the type
+ * Hibernate ORM inferred for the aggregate function, e.g. {@code "$#acc_0"} becomes {@code {"$toLong": "$#acc_0"}}.
+ *
+ * <p>Applied to the {@code $project} stage only, because that is the sole position where the BSON type matters:
+ * {@code MongoResultSet} reads a column through {@code ValueConversions}, which is strict --- {@code asInt64} on an
+ * {@code int32} throws. A {@code $match} for HAVING and a {@code $sort} compare numerically across BSON numeric types,
+ * so they need the raw accumulator and would be made worse by a cast: {@code $sort} requires a field path, and a cast
+ * would stop {@code $match} being compacted out of {@code $expr} form.
+ *
+ * <p>The cast cannot live inside {@code $group} instead. MongoDB requires the accumulator to be the outermost operator
+ * there, so it could only wrap the accumulator's argument --- and then it never runs when the accumulator has no input
+ * to convert: {@code $sum} over a group whose every value is null yields {@code int32 0} without evaluating the
+ * argument at all, and reading that as a {@code Long} throws.
+ */
+public final class AccumulatorResultCastRule implements RewriteRule {
+
+    private final Map<String, AstConversionExpressionOperator> castByAccumulatorField;
+
+    public AccumulatorResultCastRule(Map<String, AstConversionExpressionOperator> castByAccumulatorField) {
+        this.castByAccumulatorField = castByAccumulatorField;
+    }
+
+    @Override
+    public @Nullable AstExpression tryMatch(AstExpression node) {
+        if (node instanceof AstFieldPathExpression fieldPath) {
+            var cast = castByAccumulatorField.get(fieldPath.fieldPath());
+            if (cast != null) {
+                // A pre-rule match is not descended into, which is what keeps this from matching its own output.
+                return new AstUnaryOperatorExpression(cast, fieldPath);
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/mongodb/hibernate/internal/translate/rewrite/AstRewriter.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/rewrite/AstRewriter.java
@@ -16,6 +16,7 @@
 
 package com.mongodb.hibernate.internal.translate.rewrite;
 
+import com.mongodb.hibernate.internal.translate.mongoast.AstAccumulatorExpression;
 import com.mongodb.hibernate.internal.translate.mongoast.AstComputedFieldUpdate;
 import com.mongodb.hibernate.internal.translate.mongoast.AstDocument;
 import com.mongodb.hibernate.internal.translate.mongoast.AstElement;
@@ -27,6 +28,7 @@ import com.mongodb.hibernate.internal.translate.mongoast.AstSwitchCase;
 import com.mongodb.hibernate.internal.translate.mongoast.AstValue;
 import com.mongodb.hibernate.internal.translate.mongoast.command.AstUpdate;
 import com.mongodb.hibernate.internal.translate.mongoast.command.AstUpdateStatement;
+import com.mongodb.hibernate.internal.translate.mongoast.command.aggregate.AstGroupStageAccumulatorSpecification;
 import com.mongodb.hibernate.internal.translate.mongoast.command.aggregate.AstGroupStageSpecification;
 import com.mongodb.hibernate.internal.translate.mongoast.command.aggregate.AstLetVariable;
 import com.mongodb.hibernate.internal.translate.mongoast.command.aggregate.AstProjectStageSpecification;
@@ -88,6 +90,16 @@ public final class AstRewriter implements AstNodeRewriter {
 
     @Override
     public AstGroupStageSpecification rewrite(AstGroupStageSpecification node) {
+        return drive(node, rule -> rule::tryMatch, child -> child.mapChildren(this));
+    }
+
+    @Override
+    public AstGroupStageAccumulatorSpecification rewrite(AstGroupStageAccumulatorSpecification node) {
+        return drive(node, rule -> rule::tryMatch, child -> child.mapChildren(this));
+    }
+
+    @Override
+    public AstAccumulatorExpression rewrite(AstAccumulatorExpression node) {
         return drive(node, rule -> rule::tryMatch, child -> child.mapChildren(this));
     }
 

--- a/src/main/java/com/mongodb/hibernate/internal/translate/rewrite/GroupBySubstitutionRule.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/rewrite/GroupBySubstitutionRule.java
@@ -27,6 +27,7 @@ import com.mongodb.hibernate.internal.translate.mongoast.command.aggregate.AstSo
 import com.mongodb.hibernate.internal.translate.mongoast.filter.AstFieldOperationFilter;
 import com.mongodb.hibernate.internal.translate.mongoast.filter.AstFilter;
 import java.util.Map;
+import java.util.Set;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -37,16 +38,23 @@ import org.jspecify.annotations.Nullable;
  * <p>Any raw field-path leaf that survives without matching a GROUP BY key is a stray — a SELECT/HAVING/ORDER BY
  * reference to a column that is neither in GROUP BY nor inside an aggregate function. The rule throws
  * {@link FeatureNotSupportedException} in that case rather than emit a post-{@code $group} pipeline that references a
- * non-existent field. Extend the whitelist here when accumulator support lands.
+ * non-existent field.
+ *
+ * <p>The exception is a field path naming an accumulator the {@code $group} stage produced (see
+ * {@code AbstractMqlTranslator.registerAccumulator}). Such a path is a legitimate post-{@code $group} reference: it is
+ * neither a stray nor a GROUP BY key, so it is left alone in every position the rule would otherwise substitute.
  */
 public final class GroupBySubstitutionRule implements RewriteRule {
 
     private final Map<Integer, String> groupKeyVN;
     private final VNRegistry vnRegistry;
+    private final Set<String> accumulatorFields;
 
-    public GroupBySubstitutionRule(Map<Integer, String> groupKeyVN, VNRegistry vnRegistry) {
+    public GroupBySubstitutionRule(
+            Map<Integer, String> groupKeyVN, VNRegistry vnRegistry, Set<String> accumulatorFields) {
         this.groupKeyVN = groupKeyVN;
         this.vnRegistry = vnRegistry;
+        this.accumulatorFields = accumulatorFields;
     }
 
     @Override
@@ -56,6 +64,9 @@ public final class GroupBySubstitutionRule implements RewriteRule {
             return new AstFieldPathExpression("_id." + subKey);
         }
         if (node instanceof AstFieldPathExpression fp) {
+            if (accumulatorFields.contains(fp.fieldPath())) {
+                return null;
+            }
             throw strayColumn(fp.fieldPath());
         }
         return null;
@@ -64,13 +75,19 @@ public final class GroupBySubstitutionRule implements RewriteRule {
     @Override
     public @Nullable AstFilter tryMatch(AstFilter node) {
         if (node instanceof AstFieldOperationFilter fof) {
+            if (accumulatorFields.contains(fof.fieldPath())) {
+                return null;
+            }
             return new AstFieldOperationFilter(subKeyOrThrow(fof.fieldPath()), fof.filterOperation());
         }
         return null;
     }
 
     @Override
-    public AstSortField tryMatch(AstSortField node) {
+    public @Nullable AstSortField tryMatch(AstSortField node) {
+        if (accumulatorFields.contains(node.path())) {
+            return null;
+        }
         return new AstSortField(subKeyOrThrow(node.path()), node.order());
     }
 
@@ -85,7 +102,10 @@ public final class GroupBySubstitutionRule implements RewriteRule {
         return null;
     }
 
-    private AstProjectStageFieldPathSpecification idSpecification(String fieldPath) {
+    private @Nullable AstProjectStageFieldPathSpecification idSpecification(String fieldPath) {
+        if (accumulatorFields.contains(fieldPath)) {
+            return null;
+        }
         String subKey = lookupByFieldPath(fieldPath);
         if (subKey == null) {
             throw strayColumn(fieldPath);

--- a/src/main/java/com/mongodb/hibernate/internal/translate/rewrite/RewriteRule.java
+++ b/src/main/java/com/mongodb/hibernate/internal/translate/rewrite/RewriteRule.java
@@ -16,6 +16,7 @@
 
 package com.mongodb.hibernate.internal.translate.rewrite;
 
+import com.mongodb.hibernate.internal.translate.mongoast.AstAccumulatorExpression;
 import com.mongodb.hibernate.internal.translate.mongoast.AstComputedFieldUpdate;
 import com.mongodb.hibernate.internal.translate.mongoast.AstDocument;
 import com.mongodb.hibernate.internal.translate.mongoast.AstElement;
@@ -25,6 +26,7 @@ import com.mongodb.hibernate.internal.translate.mongoast.AstSwitchCase;
 import com.mongodb.hibernate.internal.translate.mongoast.AstValue;
 import com.mongodb.hibernate.internal.translate.mongoast.command.AstUpdate;
 import com.mongodb.hibernate.internal.translate.mongoast.command.AstUpdateStatement;
+import com.mongodb.hibernate.internal.translate.mongoast.command.aggregate.AstGroupStageAccumulatorSpecification;
 import com.mongodb.hibernate.internal.translate.mongoast.command.aggregate.AstGroupStageSpecification;
 import com.mongodb.hibernate.internal.translate.mongoast.command.aggregate.AstLetVariable;
 import com.mongodb.hibernate.internal.translate.mongoast.command.aggregate.AstProjectStageSpecification;
@@ -76,6 +78,14 @@ public interface RewriteRule {
     }
 
     default @Nullable AstGroupStageSpecification tryMatch(AstGroupStageSpecification node) {
+        return null;
+    }
+
+    default @Nullable AstGroupStageAccumulatorSpecification tryMatch(AstGroupStageAccumulatorSpecification node) {
+        return null;
+    }
+
+    default @Nullable AstAccumulatorExpression tryMatch(AstAccumulatorExpression node) {
         return null;
     }
 

--- a/src/test/java/com/mongodb/hibernate/internal/translate/mongoast/AstAccumulatorExpressionTests.java
+++ b/src/test/java/com/mongodb/hibernate/internal/translate/mongoast/AstAccumulatorExpressionTests.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2026-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.hibernate.internal.translate.mongoast;
+
+import static com.mongodb.hibernate.internal.translate.mongoast.AstMapChildrenAssertions.assertMapsChildren;
+import static com.mongodb.hibernate.internal.translate.mongoast.AstNodeAssertions.assertExpressionRendering;
+import static com.mongodb.hibernate.internal.translate.mongoast.AstStructuralKeyAssertions.assertStructuralKey;
+
+import java.util.List;
+import org.bson.BsonInt32;
+import org.junit.jupiter.api.Test;
+
+class AstAccumulatorExpressionTests {
+
+    @Test
+    void testRendering() {
+        assertExpressionRendering(
+                """
+                {"": {"$sum": "$x"}}\
+                """,
+                new AstAccumulatorExpression(AstAccumulatorOperator.SUM, new AstFieldPathExpression("x")));
+    }
+
+    @Test
+    void testRenderingWithConvertedArgument() {
+        // The translator casts the argument rather than the accumulator, because MongoDB requires the accumulator
+        // to be the outermost operator of a `$group` specification.
+        var toLong = new AstUnaryOperatorExpression(
+                AstConversionExpressionOperator.TO_LONG, new AstValueExpression(new AstLiteral(new BsonInt32(1))));
+        assertExpressionRendering(
+                """
+                {"": {"$sum": {"$toLong": {"$numberInt": "1"}}}}\
+                """,
+                new AstAccumulatorExpression(AstAccumulatorOperator.SUM, toLong));
+    }
+
+    @Test
+    void testMapChildren() {
+        assertMapsChildren(new AstAccumulatorExpression(AstAccumulatorOperator.AVG, new AstFieldPathExpression("f")));
+    }
+
+    @Test
+    void testStructuralKey() {
+        // The key is what makes the same aggregate written in two clauses share one `$group` accumulator, so both
+        // components have to reach it: a differing operator and a differing argument must both change the key.
+        assertStructuralKey(
+                new AstAccumulatorExpression(AstAccumulatorOperator.SUM, new AstFieldPathExpression("a")),
+                new StructuralKey("Accumulator", List.of(AstAccumulatorOperator.SUM, new AstFieldPathExpression("a"))),
+                new AstAccumulatorExpression(AstAccumulatorOperator.AVG, new AstFieldPathExpression("a")),
+                new AstAccumulatorExpression(AstAccumulatorOperator.MIN, new AstFieldPathExpression("a")),
+                new AstAccumulatorExpression(AstAccumulatorOperator.MAX, new AstFieldPathExpression("a")),
+                new AstAccumulatorExpression(AstAccumulatorOperator.SUM, new AstFieldPathExpression("b")));
+    }
+}

--- a/src/test/java/com/mongodb/hibernate/internal/translate/mongoast/AstMapChildrenAssertions.java
+++ b/src/test/java/com/mongodb/hibernate/internal/translate/mongoast/AstMapChildrenAssertions.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import com.mongodb.hibernate.internal.translate.mongoast.command.AstPipelineUpdate;
 import com.mongodb.hibernate.internal.translate.mongoast.command.AstUpdate;
 import com.mongodb.hibernate.internal.translate.mongoast.command.AstUpdateStatement;
+import com.mongodb.hibernate.internal.translate.mongoast.command.aggregate.AstGroupStageAccumulatorSpecification;
 import com.mongodb.hibernate.internal.translate.mongoast.command.aggregate.AstGroupStageSpecification;
 import com.mongodb.hibernate.internal.translate.mongoast.command.aggregate.AstLetVariable;
 import com.mongodb.hibernate.internal.translate.mongoast.command.aggregate.AstProjectStageIncludeSpecification;
@@ -189,6 +190,23 @@ public final class AstMapChildrenAssertions {
         @Override
         public AstProjectStageSpecification rewrite(AstProjectStageSpecification node) {
             return record(node, new AstProjectStageIncludeSpecification(name(node)));
+        }
+
+        @Override
+        public AstGroupStageAccumulatorSpecification rewrite(AstGroupStageAccumulatorSpecification node) {
+            return record(
+                    node,
+                    new AstGroupStageAccumulatorSpecification(
+                            name(node),
+                            new AstAccumulatorExpression(
+                                    AstAccumulatorOperator.SUM, new AstFieldPathExpression(name(node)))));
+        }
+
+        @Override
+        public AstAccumulatorExpression rewrite(AstAccumulatorExpression node) {
+            return record(
+                    node,
+                    new AstAccumulatorExpression(AstAccumulatorOperator.MAX, new AstFieldPathExpression(name(node))));
         }
 
         @Override

--- a/src/test/java/com/mongodb/hibernate/internal/translate/mongoast/StructuralKeyTagTests.java
+++ b/src/test/java/com/mongodb/hibernate/internal/translate/mongoast/StructuralKeyTagTests.java
@@ -44,6 +44,7 @@ class StructuralKeyTagTests {
     private static List<AstExpression> oneOfEachKind() {
         return List.of(
                 field(),
+                new AstAccumulatorExpression(AstAccumulatorOperator.SUM, field()),
                 new AstVariableExpression("v"),
                 new AstLiteralExpression(new AstLiteral(new BsonInt32(1))),
                 new AstValueExpression(new AstLiteral(new BsonInt32(1))),

--- a/src/test/java/com/mongodb/hibernate/internal/translate/mongoast/command/aggregate/AstGroupStageAccumulatorSpecificationTests.java
+++ b/src/test/java/com/mongodb/hibernate/internal/translate/mongoast/command/aggregate/AstGroupStageAccumulatorSpecificationTests.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2026-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.hibernate.internal.translate.mongoast.command.aggregate;
+
+import static com.mongodb.hibernate.internal.translate.mongoast.AstMapChildrenAssertions.assertMapsChildren;
+
+import com.mongodb.hibernate.internal.translate.mongoast.AstAccumulatorExpression;
+import com.mongodb.hibernate.internal.translate.mongoast.AstAccumulatorOperator;
+import com.mongodb.hibernate.internal.translate.mongoast.AstFieldPathExpression;
+import org.junit.jupiter.api.Test;
+
+class AstGroupStageAccumulatorSpecificationTests {
+
+    @Test
+    void testMapChildren() {
+        assertMapsChildren(new AstGroupStageAccumulatorSpecification(
+                "#acc_0", new AstAccumulatorExpression(AstAccumulatorOperator.SUM, new AstFieldPathExpression("f"))));
+    }
+}

--- a/src/test/java/com/mongodb/hibernate/internal/translate/mongoast/command/aggregate/AstGroupStageTests.java
+++ b/src/test/java/com/mongodb/hibernate/internal/translate/mongoast/command/aggregate/AstGroupStageTests.java
@@ -68,11 +68,11 @@ class AstGroupStageTests {
         var astGroupStage = new AstGroupStage(
                 List.of(new AstGroupStageSpecification("country", new AstFieldPathExpression("country"))),
                 List.of(
-                        new AstGroupStageSpecification(
+                        new AstGroupStageAccumulatorSpecification(
                                 "#acc_0",
                                 new AstAccumulatorExpression(
                                         AstAccumulatorOperator.SUM, new AstFieldPathExpression("sales"))),
-                        new AstGroupStageSpecification(
+                        new AstGroupStageAccumulatorSpecification(
                                 "#acc_1",
                                 new AstAccumulatorExpression(
                                         AstAccumulatorOperator.MAX, new AstFieldPathExpression("sales")))));
@@ -94,11 +94,11 @@ class AstGroupStageTests {
                         new AstGroupStageSpecification("k", new AstFieldPathExpression("a")),
                         new AstGroupStageSpecification("l", new AstFieldPathExpression("b"))),
                 List.of(
-                        new AstGroupStageSpecification(
+                        new AstGroupStageAccumulatorSpecification(
                                 "#acc_0",
                                 new AstAccumulatorExpression(
                                         AstAccumulatorOperator.SUM, new AstFieldPathExpression("c"))),
-                        new AstGroupStageSpecification(
+                        new AstGroupStageAccumulatorSpecification(
                                 "#acc_1",
                                 new AstAccumulatorExpression(
                                         AstAccumulatorOperator.AVG, new AstFieldPathExpression("d"))))));

--- a/src/test/java/com/mongodb/hibernate/internal/translate/mongoast/command/aggregate/AstGroupStageTests.java
+++ b/src/test/java/com/mongodb/hibernate/internal/translate/mongoast/command/aggregate/AstGroupStageTests.java
@@ -19,6 +19,8 @@ package com.mongodb.hibernate.internal.translate.mongoast.command.aggregate;
 import static com.mongodb.hibernate.internal.translate.mongoast.AstMapChildrenAssertions.assertMapsChildren;
 import static com.mongodb.hibernate.internal.translate.mongoast.AstNodeAssertions.assertRendering;
 
+import com.mongodb.hibernate.internal.translate.mongoast.AstAccumulatorExpression;
+import com.mongodb.hibernate.internal.translate.mongoast.AstAccumulatorOperator;
 import com.mongodb.hibernate.internal.translate.mongoast.AstFieldPathExpression;
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -62,7 +64,48 @@ class AstGroupStageTests {
     }
 
     @Test
+    void testRenderingWithAccumulators() {
+        var astGroupStage = new AstGroupStage(
+                List.of(new AstGroupStageSpecification("country", new AstFieldPathExpression("country"))),
+                List.of(
+                        new AstGroupStageSpecification(
+                                "#acc_0",
+                                new AstAccumulatorExpression(
+                                        AstAccumulatorOperator.SUM, new AstFieldPathExpression("sales"))),
+                        new AstGroupStageSpecification(
+                                "#acc_1",
+                                new AstAccumulatorExpression(
+                                        AstAccumulatorOperator.MAX, new AstFieldPathExpression("sales")))));
+
+        // The accumulators are siblings of `_id`, not members of it.
+        var expectedJson =
+                """
+                {"$group": {"_id": {"country": "$country"}, "#acc_0": {"$sum": "$sales"}, "#acc_1": {"$max": "$sales"}}}\
+                """;
+        assertRendering(expectedJson, astGroupStage);
+    }
+
+    @Test
     void testMapChildren() {
+        // Both collections need at least two differing children, so that a child put back in the wrong place, or in
+        // the wrong collection, is detectable.
+        assertMapsChildren(new AstGroupStage(
+                List.of(
+                        new AstGroupStageSpecification("k", new AstFieldPathExpression("a")),
+                        new AstGroupStageSpecification("l", new AstFieldPathExpression("b"))),
+                List.of(
+                        new AstGroupStageSpecification(
+                                "#acc_0",
+                                new AstAccumulatorExpression(
+                                        AstAccumulatorOperator.SUM, new AstFieldPathExpression("c"))),
+                        new AstGroupStageSpecification(
+                                "#acc_1",
+                                new AstAccumulatorExpression(
+                                        AstAccumulatorOperator.AVG, new AstFieldPathExpression("d"))))));
+    }
+
+    @Test
+    void testMapChildrenWithoutAccumulators() {
         assertMapsChildren(new AstGroupStage(List.of(
                 new AstGroupStageSpecification("k", new AstFieldPathExpression("a")),
                 new AstGroupStageSpecification("l", new AstFieldPathExpression("b")))));

--- a/src/test/java/com/mongodb/hibernate/internal/translate/rewrite/GroupBySubstitutionRuleTests.java
+++ b/src/test/java/com/mongodb/hibernate/internal/translate/rewrite/GroupBySubstitutionRuleTests.java
@@ -38,6 +38,7 @@ import com.mongodb.hibernate.internal.translate.mongoast.filter.AstLogicalFilter
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.bson.BsonInt32;
 import org.junit.jupiter.api.Test;
 
@@ -68,7 +69,7 @@ class GroupBySubstitutionRuleTests {
 
     private AstRewriter rewriterWithKeys(Map<AstExpression, String> keys) {
         keys.forEach((expression, subKey) -> groupKeyVN.put(vn.valueNumber(expression), subKey));
-        return new AstRewriter(new GroupBySubstitutionRule(groupKeyVN, vn), null);
+        return new AstRewriter(new GroupBySubstitutionRule(groupKeyVN, vn, Set.of()), null);
     }
 
     @Test

--- a/src/test/java/com/mongodb/hibernate/internal/translate/rewrite/GroupBySubstitutionRuleTests.java
+++ b/src/test/java/com/mongodb/hibernate/internal/translate/rewrite/GroupBySubstitutionRuleTests.java
@@ -31,8 +31,11 @@ import com.mongodb.hibernate.internal.translate.mongoast.command.aggregate.AstPr
 import com.mongodb.hibernate.internal.translate.mongoast.command.aggregate.AstProjectStageIncludeSpecification;
 import com.mongodb.hibernate.internal.translate.mongoast.command.aggregate.AstSortField;
 import com.mongodb.hibernate.internal.translate.mongoast.command.aggregate.AstSortOrder;
+import com.mongodb.hibernate.internal.translate.mongoast.filter.AstComparisonFilterOperation;
+import com.mongodb.hibernate.internal.translate.mongoast.filter.AstComparisonFilterOperator;
 import com.mongodb.hibernate.internal.translate.mongoast.filter.AstEmptyFilter;
 import com.mongodb.hibernate.internal.translate.mongoast.filter.AstExprFilter;
+import com.mongodb.hibernate.internal.translate.mongoast.filter.AstFieldOperationFilter;
 import com.mongodb.hibernate.internal.translate.mongoast.filter.AstLogicalFilter;
 import com.mongodb.hibernate.internal.translate.mongoast.filter.AstLogicalFilterOperator;
 import java.util.HashMap;
@@ -68,8 +71,12 @@ class GroupBySubstitutionRuleTests {
     }
 
     private AstRewriter rewriterWithKeys(Map<AstExpression, String> keys) {
+        return rewriterWithKeysAndAccumulators(keys, Set.of());
+    }
+
+    private AstRewriter rewriterWithKeysAndAccumulators(Map<AstExpression, String> keys, Set<String> accumulators) {
         keys.forEach((expression, subKey) -> groupKeyVN.put(vn.valueNumber(expression), subKey));
-        return new AstRewriter(new GroupBySubstitutionRule(groupKeyVN, vn, Set.of()), null);
+        return new AstRewriter(new GroupBySubstitutionRule(groupKeyVN, vn, accumulators), null);
     }
 
     @Test
@@ -152,5 +159,57 @@ class GroupBySubstitutionRuleTests {
         assertThatExceptionOfType(FeatureNotSupportedException.class)
                 .isThrownBy(() -> rewriter.rewrite(new AstSortField("x", AstSortOrder.ASC)))
                 .withMessageContaining("column 'x'");
+    }
+
+    /**
+     * A field naming an accumulator that {@code $group} produced is neither a GROUP BY key nor a stray: it is a
+     * legitimate post-{@code $group} reference and has to survive substitution untouched. One test per position the
+     * rule would otherwise rewrite or reject.
+     */
+    @Test
+    void accumulatorExpressionSurvives() {
+        var rewriter = rewriterWithKeysAndAccumulators(Map.of(x(), "x"), Set.of("#acc_0"));
+        var accumulatorReference = new AstFieldPathExpression("#acc_0");
+
+        assertThat(rewriter.rewrite(accumulatorReference)).isEqualTo(accumulatorReference);
+        assertThat(rewriter.rewrite(add(accumulatorReference, lit(1)))).isEqualTo(add(accumulatorReference, lit(1)));
+    }
+
+    @Test
+    void accumulatorFilterSurvives() {
+        var rewriter = rewriterWithKeysAndAccumulators(Map.of(x(), "x"), Set.of("#acc_0"));
+        var input = new AstFieldOperationFilter(
+                "#acc_0",
+                new AstComparisonFilterOperation(AstComparisonFilterOperator.GT, new AstLiteral(new BsonInt32(4))));
+
+        assertThat(rewriter.rewrite(input)).isEqualTo(input);
+    }
+
+    @Test
+    void accumulatorSortFieldSurvives() {
+        var rewriter = rewriterWithKeysAndAccumulators(Map.of(x(), "x"), Set.of("#acc_0"));
+
+        assertThat(rewriter.rewrite(new AstSortField("#acc_0", AstSortOrder.DESC)))
+                .isEqualTo(new AstSortField("#acc_0", AstSortOrder.DESC));
+    }
+
+    @Test
+    void accumulatorProjectSpecificationSurvives() {
+        var rewriter = rewriterWithKeysAndAccumulators(Map.of(x(), "x"), Set.of("#acc_0"));
+
+        assertThat(rewriter.rewrite(new AstProjectStageIncludeSpecification("#acc_0")))
+                .isEqualTo(new AstProjectStageIncludeSpecification("#acc_0"));
+        assertThat(rewriter.rewrite(new AstProjectStageFieldPathSpecification("#c_2", "#acc_0")))
+                .isEqualTo(new AstProjectStageFieldPathSpecification("#c_2", "#acc_0"));
+    }
+
+    /** The whitelist must admit only the registered names, not every field that looks generated. */
+    @Test
+    void anUnregisteredAccumulatorLikeNameIsStillAStray() {
+        var rewriter = rewriterWithKeysAndAccumulators(Map.of(x(), "x"), Set.of("#acc_0"));
+
+        assertThatExceptionOfType(FeatureNotSupportedException.class)
+                .isThrownBy(() -> rewriter.rewrite(new AstFieldPathExpression("#acc_1")))
+                .withMessageContaining("column '#acc_1'");
     }
 }


### PR DESCRIPTION
HIBERNATE-239, supporting

- count() (including count(*))
- avg()
- min()
- max()
- sum()

Statistical aggregates are not supported and tracked at HIBERNATE-257
